### PR TITLE
Tranpose flag

### DIFF
--- a/src/KrylovDecomp.f90
+++ b/src/KrylovDecomp.f90
@@ -298,15 +298,12 @@ contains
        ! --> Transpose matrix-vector product.
        call A%rmatvec(U(k), V(k))
        if (k > 1) then
-          wrk = V(k-1) ; call wrk%scal(beta)
-          call V(k)%sub(wrk)
+          call V(k)%axpby(1.0_wp, V(k-1), -beta)
        endif
 
        ! --> Full re-orthogonalization of the right Krylov subspace.
        do j = 1, k-1
-          wrk = V(j)
-          gamma = V(k)%dot(wrk)
-          call wrk%scal(gamma) ; call V(k)%sub(wrk)
+          gamma = V(k)%dot(V(j)) ; call V(k)%axpby(1.0_wp, V(j), -gamma)
        enddo
 
        ! --> Normalization step.
@@ -324,13 +321,11 @@ contains
 
        ! --> Matrix-vector product.
        call A%matvec(V(k), U(k+1))
-       wrk = U(k) ; call wrk%scal(alpha) ; call U(k+1)%sub(wrk)
+       call U(k+1)%axpby(1.0_wp, U(k), -alpha)
 
        ! --> Full re-orthogonalization of the left Krylov subspace.
        do j = 1, k
-          wrk = U(j)
-          gamma = U(k+1)%dot(wrk)
-          call wrk%scal(gamma) ; call U(k+1)%sub(wrk)
+          gamma = U(k+1)%dot(U(j)) ; call U(k+1)%axpby(1.0_wp, U(j), -gamma)
        enddo
 
        ! --> Normalization step.

--- a/src/KrylovDecomp.f90
+++ b/src/KrylovDecomp.f90
@@ -118,22 +118,16 @@ contains
 
     ! --> Orthogonalize residual w.r.t to previously computed Krylov vectors.
     do i = 1, k
-       ! --> Working array.
-       wrk = X(i)
+       alpha = X(k+1)%dot(X(i)) ; call X(k+1)%axpby(1.0_wp, X(i), -alpha)
        ! --> Update Hessenberg matrix.
-       alpha = X(k+1)%dot(wrk) ; H(i, k) = alpha
-       ! --> Orthogonalize residual vector.
-       call wrk%scal(alpha) ; call X(k+1)%sub(wrk)
+       H(i, k) = alpha
     enddo
 
     ! --> Perform full re-orthogonalization (see instability of MGS process)
     do i = 1, k
-       ! --> Working array.
-       wrk = X(i)
+       alpha = X(k+1)%dot(X(i)) ; call X(k+1)%axpby(1.0_wp, X(i), -alpha)
        ! --> Update Hessenberg matrix.
-       alpha = X(k+1)%dot(wrk) ; H(i, k) = H(i, k) + alpha
-       ! --> Orthogonalize residual vectors.
-       call wrk%scal(alpha) ; call X(k+1)%sub(wrk)
+       H(i, k) = H(i, k) + alpha
     enddo
 
     return

--- a/src/KrylovDecomp.f90
+++ b/src/KrylovDecomp.f90
@@ -229,18 +229,14 @@ contains
 
     ! --> Orthogonalize residual w.r.t to previously computed Krylov vectors.
     do i = max(1, k-1), k
-       ! --> Working array.
-       wrk = X(i)
+       alpha = X(k+1)%dot(X(i)) ; call X(k+1)%axpby(1.0_wp, X(i), -alpha)
        ! --> Update tridiag matrix.
-       alpha = X(k+1)%dot(wrk) ; T(i, k) = alpha
-       call wrk%scal(alpha) ; call X(k+1)%sub(wrk)
+       T(i, k) = alpha
     enddo
 
     ! --> Full re-orthogonalization.
     do i = 1, k
-       wrk = X(i)
-       alpha = X(k+1)%dot(wrk) ; call wrk%scal(alpha)
-       call X(k+1)%sub(wrk)
+       alpha = X(k+1)%dot(X(i)) ; call X(k+1)%axpby(1.0_wp, X(i), -alpha)
     enddo
 
     return

--- a/src/KrylovDecomp.f90
+++ b/src/KrylovDecomp.f90
@@ -19,15 +19,15 @@ contains
   !-----                                                           -----
   !---------------------------------------------------------------------
 
-  subroutine arnoldi_factorization(A, X, H, info, kstart, kend, verbosity, tol)
+  subroutine arnoldi_factorization(A, X, H, info, kstart, kend, verbosity, tol, transpose)
 
     ! --> Optional arguments (mainly for GMRES)
     integer, optional, intent(in) :: kstart, kend
-    logical, optional, intent(in) :: verbosity
+    logical, optional, intent(in) :: verbosity, transpose
     double precision, optional, intent(in) :: tol
 
     integer :: k_start, k_end
-    logical :: verbose
+    logical :: verbose, trans
     double precision :: tolerance
 
     ! --> Linear Operator to be factorized.
@@ -58,11 +58,16 @@ contains
     k_end     = optval(kend, kdim)
     verbose   = optval(verbosity, .false.)
     tolerance = optval(tol, 1.0D-12)
+    trans     = optval(transpose, .false.)
 
     ! --> Arnoldi factorization.
     arnoldi: do k = k_start, k_end
        ! --> Matrix-vector product.
-       call A%matvec(X(k), X(k+1))
+       if (trans) then
+          call A%rmatvec(X(k), X(k+1))
+       else
+          call A%matvec(X(k), X(k+1))
+       endif
        ! --> Update Hessenberg matrix.
        call update_hessenberg_matrix(H, X, k)
        beta = X(k+1)%norm() ; H(k+1, k) = beta


### PR DESCRIPTION
Added the possibility to use the transpose operator for:

- `arnoldi_factorization`
- `gmres`
- `bicgstab`

Also cleaned-up some of the reorthogonalization routines to use the axpby subroutine.