### PR TITLE
Rational krylov

### DIFF
--- a/src/IterativeSolvers.f90
+++ b/src/IterativeSolvers.f90
@@ -742,13 +742,14 @@ contains
   !   SIAM Journal on Scientific and Statistical Computing, 13(2), 631–644.
   !
   !=======================================================================================
-  subroutine bicgstab(A, b, x, info, maxiter, tol, verbosity, transpose)
+  subroutine bicgstab(A, b, x, info, kdim, maxiter, tol, verbosity, transpose)
     !> Linear problem and initial guess.
     class(abstract_linop), intent(in) :: A
     class(abstract_vector), intent(in) :: b
     class(abstract_vector), intent(inout) :: x
     !> Output and optional input parameters.
     integer, intent(out) :: info
+    integer, optional, intent(in) :: kdim
     integer, optional, intent(in) :: maxiter
     real(kind=wp), optional, intent(in) :: tol
     logical, optional, intent(in) :: verbosity

--- a/src/IterativeSolvers.f90
+++ b/src/IterativeSolvers.f90
@@ -374,7 +374,7 @@ contains
   ! for solving nonsymmetric, non-Hermitian linear systems of equations, Ax = b.
   !
   ! Algorithmic Features:
-  ! ----------------------
+  ! ---------------------
   ! - Constructs a full Krylov subspace without restarts (i.e., not GMRES(m)).
   ! - Utilizes Arnoldi factorization to generate an orthonormal basis for the Krylov subspace.
   ! - Employs a least-squares solve to determine the optimal linear combination of the Krylov vectors.

--- a/src/KrylovDecomp.f90
+++ b/src/KrylovDecomp.f90
@@ -297,7 +297,7 @@ contains
     lanczos : do k = k_start, k_end
        ! --> Transpose matrix-vector product.
        call A%rmatvec(U(k), V(k))
-       ! /!\ Next lines not needed because already taken care of in the
+       ! /!\ NOTE : Next lines not needed because already taken care of in the
        !     full re-orthogonalization.
        ! if (k > 1) then
        !    call V(k)%axpby(1.0_wp, V(k-1), -beta)
@@ -323,7 +323,7 @@ contains
 
        ! --> Matrix-vector product.
        call A%matvec(V(k), U(k+1))
-       ! /!\ Not needed because taken care of in the full reortho. step.
+       ! /!\ NOTE : Not needed because taken care of in the full reortho. step.
        ! call U(k+1)%axpby(1.0_wp, U(k), -alpha)
 
        ! --> Full re-orthogonalization of the left Krylov subspace.

--- a/src/KrylovDecomp.f90
+++ b/src/KrylovDecomp.f90
@@ -10,7 +10,8 @@ module KrylovDecomp
   public :: arnoldi_factorization, &
        lanczos_tridiagonalization, &
        lanczos_bidiagonalization,  &
-       nonsymmetric_lanczos_tridiagonalization
+       nonsymmetric_lanczos_tridiagonalization, &
+       rational_arnoldi_factorization
 
 contains
 

--- a/src/KrylovDecomp.f90
+++ b/src/KrylovDecomp.f90
@@ -640,6 +640,4 @@ contains
     return
   end subroutine rational_arnoldi_factorization
 
-
-
 end module KrylovDecomp

--- a/src/KrylovDecomp.f90
+++ b/src/KrylovDecomp.f90
@@ -595,11 +595,11 @@ contains
           call A%matvec(X(k), wrk)
        endif
 
-       if (k < k_end) then
+       !if (k < k_end) then
           call solve(S, wrk, X(k+1), info, kdim, transpose=trans)
-       else !> Last pole is set to +infinity.
-          call Id%matvec(wrk, X(k+1))
-       endif
+       !else !> Last pole is set to +infinity.
+       !  call Id%matvec(wrk, X(k+1))
+       !endif
 
        ! --> Orthogonalize residual vector w.r.t. to previously computed Krylov vectors.
        do i = 1, k
@@ -618,11 +618,11 @@ contains
        beta = X(k+1)%norm() ; H(k+1, k) = beta
 
        ! --> Update the second Hessenberg matrix.
-       if (k < k_end) then
-          G(1:k, k) = H(1:k, k) / sigma + 1.0_wp ; G(k+1, k) = beta / sigma
-       else !> Last pole is set to +infinity.
-          G(1:k, k) = 1.0_wp ; G(k+1, k) = 0.0_wp
-       endif
+       !if (k < k_end) then
+          G(1:k, k) = H(1:k, k) / sigma ; G(k, k) = G(k, k) + 1.0_wp ; G(k+1, k) = beta / sigma
+       !else !> Last pole is set to +infinity.
+       !   G(1:k, k) = 1.0_wp ; G(k+1, k) = 0.0_wp
+       !endif
 
        ! --> Exit Arnoldi loop if needed.
        if (beta < tolerance) then

--- a/src/KrylovDecomp.f90
+++ b/src/KrylovDecomp.f90
@@ -595,11 +595,11 @@ contains
           call A%matvec(X(k), wrk)
        endif
 
-       !if (k < k_end) then
+       if (k < k_end) then
           call solve(S, wrk, X(k+1), info, kdim, transpose=trans)
-       !else !> Last pole is set to +infinity.
-       !  call Id%matvec(wrk, X(k+1))
-       !endif
+       else !> Last pole is set to +infinity.
+         call Id%matvec(wrk, X(k+1))
+       endif
 
        ! --> Orthogonalize residual vector w.r.t. to previously computed Krylov vectors.
        do i = 1, k
@@ -618,11 +618,11 @@ contains
        beta = X(k+1)%norm() ; H(k+1, k) = beta
 
        ! --> Update the second Hessenberg matrix.
-       !if (k < k_end) then
+       if (k < k_end) then
           G(1:k, k) = H(1:k, k) / sigma ; G(k, k) = G(k, k) + 1.0_wp ; G(k+1, k) = beta / sigma
-       !else !> Last pole is set to +infinity.
-       !   G(1:k, k) = 1.0_wp ; G(k+1, k) = 0.0_wp
-       !endif
+       else !> Last pole is set to +infinity.
+          G(k, k) = 1.0_wp ; G(k+1, k) = 0.0_wp
+       endif
 
        ! --> Exit Arnoldi loop if needed.
        if (beta < tolerance) then

--- a/src/KrylovDecomp.f90
+++ b/src/KrylovDecomp.f90
@@ -563,6 +563,7 @@ contains
        if (beta < tolerance) then
           !> Logging information.
           !> Dimension of the computed invariant subspace.
+          info = k
           !> Exit the loop.
           exit arnoldi
        else
@@ -570,7 +571,7 @@ contains
        endif
 
     enddo arnoldi
-    
+
     return
   end subroutine rational_arnoldi_factorization
 

--- a/src/LightKrylov.f90
+++ b/src/LightKrylov.f90
@@ -14,7 +14,7 @@ module LightKrylov
 
   public :: greetings, wp, atol, rtol,                                     &
        abstract_vector, get_vec,                                           &
-       abstract_linop, abstract_spd_linop, identity_linop, scaled_linop,                                 &
+       abstract_linop, abstract_spd_linop, identity_linop, scaled_linop, axpby_linop, &
        arnoldi_factorization, lanczos_tridiagonalization, lanczos_bidiagonalization, &
        nonsymmetric_lanczos_tridiagonalization, &
        eigs, eighs, gmres, save_eigenspectrum, svds, cg, bicgstab

--- a/src/LightKrylov.f90
+++ b/src/LightKrylov.f90
@@ -16,7 +16,7 @@ module LightKrylov
        abstract_vector, get_vec,                                           &
        abstract_linop, abstract_spd_linop, identity_linop, scaled_linop, axpby_linop, &
        arnoldi_factorization, lanczos_tridiagonalization, lanczos_bidiagonalization, &
-       nonsymmetric_lanczos_tridiagonalization, &
+       nonsymmetric_lanczos_tridiagonalization, rational_arnoldi_factorization, &
        eigs, eighs, gmres, save_eigenspectrum, svds, cg, bicgstab
 
 contains

--- a/src/LightKrylov.f90
+++ b/src/LightKrylov.f90
@@ -14,7 +14,7 @@ module LightKrylov
 
   public :: greetings, wp, atol, rtol,                                     &
        abstract_vector, get_vec,                                           &
-       abstract_linop, abstract_spd_linop,                                 &
+       abstract_linop, abstract_spd_linop, identity_linop, scaled_linop,                                 &
        arnoldi_factorization, lanczos_tridiagonalization, lanczos_bidiagonalization, &
        nonsymmetric_lanczos_tridiagonalization, &
        eigs, eighs, gmres, save_eigenspectrum, svds, cg, bicgstab

--- a/src/LinearOperator.f90
+++ b/src/LinearOperator.f90
@@ -1,4 +1,5 @@
 module LinearOperator
+  use AbstractVector
   implicit none
 
   private
@@ -58,5 +59,35 @@ module LinearOperator
    contains
      private
   end type abstract_lowrank_linop
+
+  !-------------------------------------
+  !-----                           -----
+  !-----     IDENTITY OPERATOR     -----
+  !-----                           -----
+  !-------------------------------------
+
+  type, extends(abstract_linop), public :: Identity_operator
+   contains
+     private
+     procedure, pass(self), public :: matvec  => identity_matvec
+     procedure, pass(self), public :: rmatvec => identity_matvec
+  end type Identity_operator
+
+contains
+
+  !-------------------------------------------------------------------
+  !-----                                                         -----
+  !-----     TYPE-BOUND PROCEDURES FOR THE IDENTITY OPERATOR     -----
+  !-----                                                         -----
+  !-------------------------------------------------------------------
+
+  subroutine identity_matvec(self, vec_in, vec_out)
+    class(identity_operator), intent(in)  :: self
+    class(abstract_vector)  , intent(in)  :: vec_in
+    class(abstract_vector)  , intent(out) :: vec_out
+    ! /!\ NOTE : This needs to be improved. It is a simple hack but I ain't happy with it.
+    call vec_out%zero() ; call vec_out%add(vec_in)
+    return
+  end subroutine identity_matvec
   
 end module LinearOperator

--- a/test/TestIterativeSolvers.f90
+++ b/test/TestIterativeSolvers.f90
@@ -238,7 +238,7 @@ contains
     ! --> Singular Value Decomposition.
     call svds(A, U, V, uvecs, vvecs, s, residuals, info)
     ! --> Check singular values.
-    call check(error, all_close(s, true_svdvals, rtol, atol), .true.)
+    call check(error, norm2(s-true_svdvals) < rtol, .true.)
 
     return
   end subroutine test_svd_singular_values

--- a/test/TestIterativeSolvers.f90
+++ b/test/TestIterativeSolvers.f90
@@ -142,7 +142,7 @@ contains
     ! --> GMRES solver.
     call gmres(A, b, x, info, kdim=3)
     ! --> Check convergence.
-    call check(error, norm2(matmul(A%data, x%data) - b%data)**2 < 1e-12)
+    call check(error, norm2(matmul(A%data, x%data) - b%data)**2 < rtol)
 
     return
   end subroutine test_gmres_full_computation
@@ -276,7 +276,7 @@ contains
     ! --> CG solver.
     call cg(A, b, x, info, verbosity=.true.)
     ! --> Check convergence.
-    call check(error, norm2(matmul(A%data, x%data) - b%data)**2 < 1e-12)
+    call check(error, norm2(matmul(A%data, x%data) - b%data)**2 < rtol)
     
     return
   end subroutine test_cg_full_computation_spd_matrix
@@ -314,7 +314,7 @@ contains
     ! --> BiCGSTAB solver.
     call bicgstab(A, b, x, info, verbosity=.true.)
     ! --> Check convergence.
-    call check(error, norm2(matmul(A%data, x%data) - b%data)**2 < 1e-12)
+    call check(error, norm2(matmul(A%data, x%data) - b%data)**2 < rtol)
     
     return
   end subroutine test_bicgstab_full_computation

--- a/test/TestKrylov.f90
+++ b/test/TestKrylov.f90
@@ -11,8 +11,8 @@ module TestKrylov
   public :: collect_arnoldi_testsuite,              &
        collect_lanczos_tridiag_testsuite,      &
        collect_lanczos_bidiag_testsuite,       &
-       collect_krylov_schur_testsuite, &
-       collect_nonsymmetric_lanczos_testsuite
+       collect_nonsymmetric_lanczos_testsuite, &
+       collect_rational_arnoldi_testsuite
 
 contains
 
@@ -433,16 +433,160 @@ contains
     return
   end subroutine test_nonsym_lanczos_full_factorization
 
-  !-----------------------------------------------------------------
-  !-----                                                       -----
-  !-----     TEST SUITE FOR THE KRYLOV-SCHUR FACTORIZATION     -----
-  !-----                                                       -----
-  !-----------------------------------------------------------------
+  !---------------------------------------------------------------------
+  !-----                                                           -----
+  !-----     TEST SUITE FOR THE RATIONAL ARNOLDI FACTORIZATION     -----
+  !-----                                                           -----
+  !---------------------------------------------------------------------
 
-  subroutine collect_krylov_schur_testsuite(testsuite)
+  subroutine collect_rational_arnoldi_testsuite(testsuite)
     !> Collection of tests.
     type(unittest_type), allocatable, intent(out) :: testsuite(:)
+
+    testsuite = [&
+         new_unittest("Rational Arnoldi full factorization", test_rational_arnoldi_full_factorization),            &
+         new_unittest("Rational Arnoldi basis orthogonality", test_rational_arnoldi_basis_orthogonality),          &
+         new_unittest("Rational Arnoldi invariant subspace computation", test_rational_arnoldi_invariant_subspace) &
+         ]
+
     return
-  end subroutine collect_krylov_schur_testsuite
+  end subroutine collect_rational_arnoldi_testsuite
+
+  subroutine test_rational_arnoldi_full_factorization(error)
+    ! This function checks the correctness of the Arnoldi implementation by
+    ! verifying that the full factorization is correct, i.e. A @ X[1:k] = X[1:k+1] @ H.
+    ! A random 3x3 matrix is used for testing.
+
+    !> Error type to be returned.
+    type(error_type), allocatable, intent(out) :: error
+    !> Test matrix.
+    class(rmatrix), allocatable :: A
+    !> Krylov subspace.
+    class(rvector), dimension(:), allocatable :: X
+    !> Krylov subspace dimension.
+    integer, parameter :: kdim=3
+    !> Hessenberg matrix.
+    double precision, dimension(kdim+1, kdim) :: H
+    double precision, dimension(kdim+1, kdim) :: G
+    !> Shift.
+    double precision :: sigma
+    !> Information flag.
+    integer :: info
+    !> Misc.
+    integer :: k
+    double precision, dimension(3, kdim+1) :: Xdata
+    double precision :: alpha
+
+    ! --> Initialize matrix.
+    A = rmatrix() ; call random_number(A%data)
+    ! --> Initialize Krylov subspace.
+    allocate(X(1:kdim+1)) ; call random_number(X(1)%data)
+    alpha = X(1)%norm() ; call X(1)%scal(1.0D+00 / alpha)
+    do k = 2, size(X)
+       call X(k)%zero()
+    enddo
+    H = 0.0D+00 ; G = 0.0D+00 ; call random_number(sigma)
+    ! --> Arnoldi factorization.
+    call rational_arnoldi_factorization(A, X, H, G, sigma, info)
+    ! --> Check correctness of full factorization.
+    do k = 1, kdim+1
+       Xdata(:, k) = X(k)%data
+    enddo
+
+    call check(error, norm2( matmul(matmul(A%data, Xdata), G) - matmul(Xdata, H) ) < 1e-10 )
+
+    return
+  end subroutine test_rational_arnoldi_full_factorization
+
+  subroutine test_rational_arnoldi_invariant_subspace(error)
+    ! This function checks that the Arnoldi iteration stops whenever an invariant
+    ! has been computed. An arbitrary 3x3 matrix with a 2-dimensional invariant subspace
+    ! is being used for testing. The starting vector for Arnoldi has component only
+    ! within this 2-dimensional subspace.
+
+    !> Error type to be returned.
+    type(error_type), allocatable, intent(out) :: error
+    !> Test matrix.
+    class(rmatrix), allocatable :: A
+    !> Krylov subspace.
+    class(rvector), dimension(:), allocatable :: X
+    !> Krylov subspace dimension.
+    integer, parameter :: kdim = 3
+    !> Hessenberg matrix.
+    double precision, dimension(kdim+1, kdim) :: H
+    double precision, dimension(kdim+1, kdim) :: G
+    !> Shift
+    double precision :: sigma
+    !> Information flag.
+    integer :: info
+    !> Misc.
+    double precision, dimension(3, 3) :: Adata
+    double precision :: alpha
+    integer :: i, j, k
+
+    ! --> Initialize matrix with a 2-dimensional invariant subspace.
+    A = rmatrix() ; call random_number(A%data)
+    A%data(3, 1:2) = 0.0D+00 ; A%data(1:2, 3) = 0.0D+00
+    ! --> Initialize Krylov subspace.
+    allocate(X(1:kdim+1)) ; call random_number(X(1)%data)
+    X(1)%data(3) = 0.0D+00 ! Makes sure X(1) has component only within the invariant subspace.
+    alpha = X(1)%norm() ; call X(1)%scal(1.0D+00 / alpha)
+    do k = 2, size(X)
+       call X(k)%zero()
+    enddo
+    H = 0.0D+00 ; G = 0.0D+00 ; call random_number(sigma)
+    ! --> Arnoldi factorization.
+    call rational_arnoldi_factorization(A, X, H, G, sigma, info)
+    ! --> Check result.
+    call check(error, info == 2)
+
+    return
+  end subroutine test_rational_arnoldi_invariant_subspace
+
+  subroutine test_rational_arnoldi_basis_orthogonality(error)
+    !> Error type to be returned.
+    type(error_type), allocatable, intent(out) :: error
+    !> Test matrix.
+    class(rmatrix), allocatable :: A
+    !> Krylov subspace.
+    class(rvector), dimension(:), allocatable :: X
+    !> Krylov subspace dimension.
+    integer, parameter :: kdim = 2
+    !> Hessenberg matrix.
+    double precision, dimension(kdim+1, kdim) :: H
+    double precision, dimension(kdim+1, kdim) :: G
+    !> Shift.
+    double precision :: sigma
+    !> Information flag.
+    integer :: info
+    !> Misc.
+    double precision, dimension(3, 3) :: M, Id
+    double precision :: alpha
+    integer :: i, j, k
+
+    ! --> Initialize random matrix.
+    A = rmatrix() ; call random_number(A%data)
+    ! --> Initialize Krylov subspace.
+    allocate(X(1:kdim+1)) ; call random_number(X(1)%data)
+    alpha = X(1)%norm() ; call X(1)%scal(1.0D+00 / alpha)
+    do k = 2, size(X)
+       call X(k)%zero()
+    enddo
+    H = 0.0D+00 ; G = 0.0D+00 ; call random_number(sigma)
+    ! --> Arnoldi factorization.
+    call rational_arnoldi_factorization(A, X, H, G, sigma, info)
+    ! --> Compute Gram matrix associated to the Krylov basis.
+    do i = 1, kdim+1
+       do j = 1, kdim+1
+          M(i, j) = X(i)%dot(X(j))
+       enddo
+    enddo
+    ! --> Check result.
+    Id = reshape([1, 0, 0, 0, 1, 0, 0, 0, 1], shape=[3, 3]) !> Identity matrix.
+    call check(error, norm2(M - Id) < 1e-12)
+
+    return
+  end subroutine test_rational_arnoldi_basis_orthogonality
+
 
 end module TestKrylov

--- a/test/TestKrylov.f90
+++ b/test/TestKrylov.f90
@@ -73,7 +73,7 @@ contains
     do k = 1, kdim+1
        Xdata(:, k) = X(k)%data
     enddo
-    call check(error, norm2(matmul(Adata, Xdata(:, 1:kdim)) - matmul(Xdata, H)) < 1e-12 )
+    call check(error, norm2(matmul(Adata, Xdata(:, 1:kdim)) - matmul(Xdata, H)) < rtol )
 
     return
   end subroutine test_arnoldi_full_factorization
@@ -157,7 +157,7 @@ contains
     enddo
     ! --> Check result.
     Id = reshape([1, 0, 0, 0, 1, 0, 0, 0, 1], shape=[3, 3]) !> Identity matrix.
-    call check(error, norm2(G - Id) < 1e-12)
+    call check(error, norm2(G - Id) < rtol)
 
     return
   end subroutine test_arnoldi_basis_orthogonality
@@ -223,7 +223,7 @@ contains
        Xdata(:, k) = X(k)%data
     enddo
     alpha = norm2( matmul(Adata, Xdata(:, 1:kdim)) - matmul(Xdata, T) )
-    call check(error, alpha < 1e-12)
+    call check(error, alpha < rtol)
 
     return
   end subroutine test_lanczos_tridiag_full_factorization
@@ -304,7 +304,7 @@ contains
     enddo
     ! --> Check result.
     Id = reshape([1, 0, 0, 0, 1, 0, 0, 0, 1], shape=[3, 3])
-    call check(error, norm2(G - Id) < 1e-12)
+    call check(error, norm2(G - Id) < rtol)
     return
   end subroutine test_lanczos_tridiag_basis_orthogonality
 
@@ -362,7 +362,7 @@ contains
        Udata(:, k) = U(k)%data ; Vdata(:, k) = V(k)%data
     enddo
     alpha = norm2(matmul(A%data, Vdata(:, 1:kdim)) - matmul(Udata, B))
-    call check(error, alpha < 1e-12)
+    call check(error, alpha < rtol)
     return
   end subroutine test_lanczos_bidiag_full_factorization
 
@@ -421,14 +421,8 @@ contains
     do k = 1, size(V)
        Vdata(:, k) = V(k)%data ; Wdata(:, k) = W(k)%data
     enddo
-
     alpha = norm2(matmul(A%data, Vdata(:, 1:kdim)) - matmul(Vdata, T(1:kdim+1, 1:kdim)))
-    ! write(*, *) "ALPHA = ", alpha
-
-    ! alpha = norm2(matmul(transpose(A%data), Wdata(:, 1:kdim)) - matmul(Wdata, transpose(T(1:kdim, 1:kdim+1))))
-    ! write(*, *) "ALPHA =", alpha
-    ! write(*, *)
-    call check(error, alpha < 1e-12)
+    call check(error, alpha < rtol)
 
     return
   end subroutine test_nonsym_lanczos_full_factorization
@@ -493,7 +487,7 @@ contains
        Xdata(:, k) = X(k)%data
     enddo
 
-    call check(error, norm2( matmul(matmul(A%data, Xdata), G) - matmul(Xdata, H) ) < 1e-10 )
+    call check(error, norm2( matmul(matmul(A%data, Xdata), G) - matmul(Xdata, H) ) < rtol )
 
     return
   end subroutine test_rational_arnoldi_full_factorization
@@ -518,7 +512,7 @@ contains
     !> Shift
     double precision :: sigma
     !> Information flag.
-    integer :: info
+    integer :: info = 0
     !> Misc.
     double precision, dimension(3, 3) :: Adata
     double precision :: alpha
@@ -587,6 +581,5 @@ contains
 
     return
   end subroutine test_rational_arnoldi_basis_orthogonality
-
-
+  
 end module TestKrylov

--- a/test/TestKrylov.f90
+++ b/test/TestKrylov.f90
@@ -467,8 +467,9 @@ contains
     !> Information flag.
     integer :: info
     !> Misc.
-    integer :: k
+    integer :: i, j, k
     double precision, dimension(3, kdim+1) :: Xdata
+    double precision, dimension(kdim, kdim) :: T
     double precision :: alpha
 
     ! --> Initialize matrix.
@@ -481,12 +482,8 @@ contains
     enddo
     H = 0.0D+00 ; G = 0.0D+00 ; call random_number(sigma)
     ! --> Arnoldi factorization.
-    call rational_arnoldi_factorization(A, X, H, G, sigma, info)
+    call rational_arnoldi_factorization(A, X, H, G, sigma, info, gmres)
     ! --> Check correctness of full factorization.
-    do k = 1, kdim+1
-       Xdata(:, k) = X(k)%data
-    enddo
-
     call check(error, norm2( matmul(matmul(A%data, Xdata), G) - matmul(Xdata, H) ) < rtol )
 
     return
@@ -530,7 +527,7 @@ contains
     enddo
     H = 0.0D+00 ; G = 0.0D+00 ; call random_number(sigma)
     ! --> Arnoldi factorization.
-    call rational_arnoldi_factorization(A, X, H, G, sigma, info)
+    call rational_arnoldi_factorization(A, X, H, G, sigma, info, gmres)
     ! --> Check result.
     call check(error, info == 2)
 
@@ -568,7 +565,7 @@ contains
     enddo
     H = 0.0D+00 ; G = 0.0D+00 ; call random_number(sigma)
     ! --> Arnoldi factorization.
-    call rational_arnoldi_factorization(A, X, H, G, sigma, info)
+    call rational_arnoldi_factorization(A, X, H, G, sigma, info, gmres)
     ! --> Compute Gram matrix associated to the Krylov basis.
     do i = 1, kdim+1
        do j = 1, kdim+1
@@ -581,5 +578,5 @@ contains
 
     return
   end subroutine test_rational_arnoldi_basis_orthogonality
-  
+
 end module TestKrylov

--- a/test/TestKrylov.f90
+++ b/test/TestKrylov.f90
@@ -565,7 +565,7 @@ contains
     enddo
     H = 0.0D+00 ; G = 0.0D+00 ; call random_number(sigma)
     ! --> Arnoldi factorization.
-    call rational_arnoldi_factorization(A, X, H, G, sigma, info, gmres)
+    call rational_arnoldi_factorization(A, X, H, G, sigma, info, bicgstab)
     ! --> Compute Gram matrix associated to the Krylov basis.
     do i = 1, kdim+1
        do j = 1, kdim+1

--- a/test/TestKrylov.f90
+++ b/test/TestKrylov.f90
@@ -484,8 +484,11 @@ contains
     ! --> Arnoldi factorization.
     call rational_arnoldi_factorization(A, X, H, G, sigma, info, gmres)
     ! --> Check correctness of full factorization.
+    do i = 1, kdim+1
+       Xdata(:, i) = X(i)%data
+    enddo
     call check(error, norm2( matmul(matmul(A%data, Xdata), G) - matmul(Xdata, H) ) < rtol )
-
+    
     return
   end subroutine test_rational_arnoldi_full_factorization
 

--- a/test/TestMatrices.f90
+++ b/test/TestMatrices.f90
@@ -7,7 +7,7 @@ module TestMatrices
 
   private
 
-  public :: collect_real_matrix_testsuite
+  public :: collect_real_matrix_testsuite, collect_abstract_linop_operations_testsuite
 
   !---------------------------------------
   !-----     GENERAL REAL MATRIX     -----
@@ -171,28 +171,47 @@ contains
     return
   end subroutine collect_spd_matrix_testsuite
 
-  !-----------------------------------------------------------
-  !-----                                                 -----
-  !-----     TEST SUITE FOR GENERAL COMPLEX MATRICES     -----
-  !-----                                                 -----
-  !-----------------------------------------------------------
+  !----------------------------------------------------------------
+  !-----                                                      -----
+  !-----     TEST SUITE FOR OPERATIONS ON ABSTRACT LINOPS     -----
+  !-----                                                      -----
+  !----------------------------------------------------------------
 
-  subroutine collect_complex_matrix_testsuite(testsuite)
+  subroutine collect_abstract_linop_operations_testsuite(testsuite)
     !> Collection of tests.
     type(unittest_type), allocatable, intent(out) :: testsuite(:)
-    return
-  end subroutine collect_complex_matrix_testsuite
 
-  !------------------------------------------------------
-  !-----                                            -----
-  !-----      TEST SUITE FOR HERMITIAN MATRICES     -----
-  !-----                                            -----
-  !------------------------------------------------------
-
-  subroutine collect_hermitian_matrix_testsuite(testsuite)
-    !> Collection of tests.
-    type(unittest_type), allocatable, intent(out) :: testsuite(:)
+    testsuite = [ &
+         new_unittest("Scaled linear operator", test_scaled_linop) &
+    ]
     return
-  end subroutine collect_hermitian_matrix_testsuite
+  end subroutine collect_abstract_linop_operations_testsuite
+
+  subroutine test_scaled_linop(error)
+    !> Error type to be returned.
+    type(error_type), allocatable, intent(out) :: error
+    !> Test matrix.
+    class(rmatrix), allocatable :: A
+    !> Test vector.
+    class(rvector), allocatable :: x
+    class(rvector), allocatable :: y
+    !> Scaling factor.
+    double precision :: sigma
+    !> Scaled linear operator.
+    class(scaled_linop), allocatable :: B
+
+    ! --> Initialize test matrix and vector.
+    A = rmatrix() ; call random_number(A%data)
+    x = rvector() ; call random_number(x%data)
+    y = rvector() ; call y%zero()
+    ! --> Scaled operator.
+    sigma = 2.0D+00 ; B = scaled_linop(A, sigma)
+    ! --> Compute scaled matrix-vector product.
+    call B%A%matvec(x, y) ; call y%scal(sigma)
+    ! --> Check error.
+    call check(error, all_close(y%data, sigma*matmul(A%data, x%data)), .true.)
+
+    return
+  end subroutine test_scaled_linop
 
 end module TestMatrices

--- a/test/TestMatrices.f90
+++ b/test/TestMatrices.f90
@@ -182,7 +182,8 @@ contains
     type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
     testsuite = [ &
-         new_unittest("Scaled linear operator", test_scaled_linop) &
+         new_unittest("Scaled linear operator", test_scaled_linop), &
+         new_unittest("axpby linear operator", test_axpby_linop) &
     ]
     return
   end subroutine collect_abstract_linop_operations_testsuite
@@ -193,8 +194,7 @@ contains
     !> Test matrix.
     class(rmatrix), allocatable :: A
     !> Test vector.
-    class(rvector), allocatable :: x
-    class(rvector), allocatable :: y
+    class(rvector), allocatable :: x, y
     !> Scaling factor.
     real(kind=wp) :: sigma
     !> Scaled linear operator.
@@ -208,11 +208,38 @@ contains
     sigma = 2.0D+00 ; B = scaled_linop(A, sigma)
     ! --> Compute scaled matrix-vector product.
     call B%matvec(x, y)
-    write(*, *) y%data, sigma*matmul(A%data, x%data)
     ! --> Check error.
     call check(error, all_close(y%data, sigma*matmul(A%data, x%data)), .true.)
 
     return
   end subroutine test_scaled_linop
+
+  subroutine test_axpby_linop(error)
+    !> Error type to be returned.
+    type(error_type), allocatable, intent(out) :: error
+    !> Test matrices.
+    class(rmatrix), allocatable :: A, B
+    !> Test vector.
+    class(rvector), allocatable :: x, y
+    !> Scaling factors.
+    real(kind=wp) :: alpha, beta
+    !> axpby linear operator.
+    class(axpby_linop), allocatable :: C
+
+    ! --> Initialize test matrices and vector.
+    A = rmatrix() ; call random_number(A%data)
+    B = rmatrix() ; call random_number(B%data)
+    x = rvector() ; call random_number(x%data)
+    y = rvector() ; call y%zero()
+    call random_number(alpha) ; call random_number(beta)
+    ! --> axpby linear operator.
+    C = axpby_linop(A, B, alpha, beta, .false., .false.)
+    ! --> Compute the matrix-vector product.
+    call C%matvec(x, y)
+    ! --> Check error.
+    call check(error, all_close(matmul(alpha*A%data + beta*B%data, x%data), y%data), .true.)
+
+    return
+  end subroutine test_axpby_linop
 
 end module TestMatrices

--- a/test/TestMatrices.f90
+++ b/test/TestMatrices.f90
@@ -196,7 +196,7 @@ contains
     class(rvector), allocatable :: x
     class(rvector), allocatable :: y
     !> Scaling factor.
-    double precision :: sigma
+    real(kind=wp) :: sigma
     !> Scaled linear operator.
     class(scaled_linop), allocatable :: B
 

--- a/test/TestMatrices.f90
+++ b/test/TestMatrices.f90
@@ -207,7 +207,8 @@ contains
     ! --> Scaled operator.
     sigma = 2.0D+00 ; B = scaled_linop(A, sigma)
     ! --> Compute scaled matrix-vector product.
-    call B%A%matvec(x, y) ; call y%scal(sigma)
+    call B%matvec(x, y)
+    write(*, *) y%data, sigma*matmul(A%data, x%data)
     ! --> Check error.
     call check(error, all_close(y%data, sigma*matmul(A%data, x%data)), .true.)
 

--- a/test/tests.f90
+++ b/test/tests.f90
@@ -6,16 +6,10 @@ program Tester
   !> Abstract implementation of Krylov-based techniques.
   use LightKrylov
   !> Implementation of simple 3-dimensional vector types and associated matrices.
-  use TestVector                   , only : collect_real_vector_testsuite
-  use TestMatrices                 , only : collect_real_matrix_testsuite
-  use TestKrylov                   , only : collect_arnoldi_testsuite, &
-       collect_lanczos_tridiag_testsuite, collect_lanczos_bidiag_testsuite, &
-       collect_nonsymmetric_lanczos_testsuite
-  use TestIterativeSolvers         , only : collect_evp_testsuite, &
-       collect_gmres_testsuite, &
-       collect_svd_testsuite, &
-       collect_cg_testsuite, &
-       collect_bicgstab_testsuite
+  use TestVector
+  use TestMatrices
+  use TestKrylov
+  use TestIterativeSolvers
 
   implicit none
 
@@ -33,6 +27,7 @@ program Tester
   testsuites = [&
        new_testsuite("Real Vector Test Suite", collect_real_vector_testsuite),                    &
        new_testsuite("Real Matrix Test Suite", collect_real_matrix_testsuite),                    &
+       new_testsuite("Operations on Abstract Lin. Op.", collect_abstract_linop_operations_testsuite), &
        new_testsuite("Arnoldi Test Suite", collect_arnoldi_testsuite),                            &
        new_testsuite("Lanczos tridiagonalization Test Suite", collect_lanczos_tridiag_testsuite), &
        new_testsuite("Lanczos bidiagonalization Test Suite", collect_lanczos_bidiag_testsuite),   &

--- a/test/tests.f90
+++ b/test/tests.f90
@@ -29,6 +29,7 @@ program Tester
        new_testsuite("Real Matrix Test Suite", collect_real_matrix_testsuite),                    &
        new_testsuite("Operations on Abstract Lin. Op.", collect_abstract_linop_operations_testsuite), &
        new_testsuite("Arnoldi Test Suite", collect_arnoldi_testsuite),                            &
+       new_testsuite("Rational Arnoldi Test Suite", collect_rational_arnoldi_testsuite),          &
        new_testsuite("Lanczos tridiagonalization Test Suite", collect_lanczos_tridiag_testsuite), &
        new_testsuite("Lanczos bidiagonalization Test Suite", collect_lanczos_bidiag_testsuite),   &
        new_testsuite("Eigenvalues Test Suite", collect_evp_testsuite),                            &


### PR DESCRIPTION
Most of the commits in this pull request are related to the implementation of the rational Arnoldi method. The most important contributions include:

- Implementation of `rational_arnoldi_factorization`
- Definition of the classes `identity_linop` and `axpby_linop` ($\mathbf{C} = \alpha\mathbf{A} + \beta\mathbf{B}$).

Additional fixes:

- Changed all the tests to use `rtol` rather than `1.0D-12`. This seems to prevent the failure of the tests for `svds` and other Krylov-related techniques.
- Added a dummy argument `kdim` to `bicgstab` to comply with the `gmres` interface. It allows us to pass either solver to the rational Arnoldi if we wan to.