### PR TITLE
GMRES now supports preconditioning

### DIFF
--- a/src/IterativeSolvers.f90
+++ b/src/IterativeSolvers.f90
@@ -476,18 +476,20 @@ contains
     integer                , intent(out)   :: info
     !> Preconditioner.
     class(abstract_preconditioner), optional, intent(in) :: preconditioner
-    class(abstract_preconditioner), allocatable             :: precond
-    logical                                    :: has_precond
+    class(abstract_preconditioner), allocatable          :: precond
+    logical                                              :: has_precond
     !> Optional arguments.
     class(abstract_opts), optional, intent(in) :: options
-    type(gmres_opts)                       :: opts
-    logical, optional      , intent(in)    :: transpose
-    logical                                :: trans
+    type(gmres_opts)                           :: opts
+    logical             , optional, intent(in) :: transpose
+    logical                                    :: trans
+
     !> Internal variables.
     integer                                :: k_dim
     integer                                :: maxiter
     real(kind=wp)                          :: tol
     logical                                :: verbose
+
     !> Krylov subspace.
     class(abstract_vector), allocatable :: V(:)
     !> Upper Hessenberg matrix.
@@ -588,7 +590,7 @@ contains
        call V(1)%sub(b) ; call V(1)%scal(-1.0_wp)
 
        ! --> Initialize new starting Krylov vector if needed.
-       beta = V(1)%norm() ; call V(1)%scal(1.0D+00 / beta)
+       beta = V(1)%norm() ; call V(1)%scal(1.0_wp / beta)
 
        if (beta**2 .lt. tol) then
           exit gmres_iterations

--- a/src/IterativeSolvers.f90
+++ b/src/IterativeSolvers.f90
@@ -726,7 +726,7 @@ contains
     integer, intent(out)   :: info
     !> Preconditioner.
     class(abstract_preconditioner), optional, intent(in) :: preconditioner
-    class(abstract_preconditioner), allocatable                 :: precond
+    class(abstract_preconditioner), allocatable          :: precond
     logical                                              :: has_precond
     !> Optional arguments.
     class(abstract_opts), optional, intent(in) :: options
@@ -757,6 +757,11 @@ contains
        opts = cg_opts()
     endif
     tol = opts%atol + opts%rtol * b%norm() ; maxiter = opts%maxiter ; verbose = opts%verbose
+
+    if (present(preconditioner)) then
+       write(*, *) "INFO: CG does not support preconditioning yet. Precond is thus ignored."
+       write(*, *)
+    endif
     
     ! --> Initialize vectors.
     allocate (r, source=b)  ; call r%zero()
@@ -906,6 +911,11 @@ contains
     end if
     maxiter = opts%maxiter ; tol = opts%atol + opts%rtol * b%norm()
     verbose = opts%verbose ; trans = optval(transpose, .false.)
+
+    if (present(precond)) then
+       write(*, *) "INFO: BICGSTAB does not support preconditioning yet. Precond is thus ignored."
+       write(*, *)
+    endif
     
     ! Initialize vectors.
     allocate (r, source=b)

--- a/src/IterativeSolvers.f90
+++ b/src/IterativeSolvers.f90
@@ -912,7 +912,7 @@ contains
     maxiter = opts%maxiter ; tol = opts%atol + opts%rtol * b%norm()
     verbose = opts%verbose ; trans = optval(transpose, .false.)
 
-    if (present(precond)) then
+    if (present(preconditioner)) then
        write(*, *) "INFO: BICGSTAB does not support preconditioning yet. Precond is thus ignored."
        write(*, *)
     endif

--- a/src/LightKrylov.f90
+++ b/src/LightKrylov.f90
@@ -15,13 +15,23 @@ module LightKrylov
 
   private
 
-  public :: greetings, wp, atol, rtol,                                     &
-       abstract_vector, get_vec,                                           &
-       abstract_linop, abstract_spd_linop, identity_linop, scaled_linop, axpby_linop, &
-       arnoldi_factorization, lanczos_tridiagonalization, lanczos_bidiagonalization, &
-       nonsymmetric_lanczos_tridiagonalization, rational_arnoldi_factorization, &
-       eigs, eighs, gmres, save_eigenspectrum, svds, cg, bicgstab, &
-       abstract_opts, gmres_opts, bicgstab_opts, cg_opts
+  !> Global variables.
+  public :: greetings, wp, atol, rtol
+  !> Abstract vectors.
+  public :: abstract_vector, get_vec
+  !> Abstract linear operators.
+  public :: abstract_linop, abstract_spd_linop, identity_linop, scaled_linop, axpby_linop
+  !> Krylov factorization for general matrix.
+  public :: arnoldi_factorization, nonsymmetric_lanczos_tridiagonalization
+  public :: lanczos_bidiagonalization, rational_arnoldi_factorization
+  !> Krylov factorization for sym. pos. def. matrices.
+  public :: lanczos_tridiagonalization
+  !> Linear solvers.
+  public :: gmres, cg, bicgstab
+  public :: abstract_opts, gmres_opts, bicgstab_opts, cg_opts
+  public :: abstract_linear_solver, abstract_preconditioner
+  !> Matrix factorization.
+  public :: eigs, eighs, svds
 
 contains
 

--- a/src/RationalKrylov.f90
+++ b/src/RationalKrylov.f90
@@ -67,7 +67,10 @@ contains
   ! - S. Guttel. "Rational Krylov Methods for Operator Functions", PhD Thesis, 2010.
   !
   !======================================================================================
-  subroutine rational_arnoldi_factorization(A, X, H, G, sigma, info, solve, linsolve_opts, kstart, kend, verbosity, tol, transpose)
+  subroutine rational_arnoldi_factorization( &
+       A, X, H, G, sigma, info, &
+       solve, linsolve_opts, preconditioner, &
+       kstart, kend, verbosity, tol, transpose)
     !> Linear operator to be factorized
     class(abstract_linop), intent(in) :: A
     !> Krylov basis.
@@ -81,6 +84,7 @@ contains
     !> Linear solver.
     procedure(abstract_linear_solver) :: solve
     class(abstract_opts), optional, intent(in) :: linsolve_opts
+    class(abstract_preconditioner), optional, intent(in) :: preconditioner
     !> Optional arguments.
     integer, optional, intent(in) :: kstart
     integer                       :: k_start
@@ -150,7 +154,7 @@ contains
        endif
 
        if (k < k_end) then
-          call solve(S, wrk, X(k+1), info, options=linsolve_opts, transpose=trans)
+          call solve(S, wrk, X(k+1), info, options=linsolve_opts, transpose=trans, preconditioner=preconditioner)
        else !> Last pole is set to +infinity.
          call Id%matvec(wrk, X(k+1))
        endif

--- a/test/TestIterativeSolvers.f90
+++ b/test/TestIterativeSolvers.f90
@@ -143,7 +143,7 @@ contains
     x = rvector() ; call x%zero()
     ! --> GMRES solver.
     opts = gmres_opts(kdim=3, verbose=.true.)
-    call gmres(A, b, x, info, opts)
+    call gmres(A, b, x, info, options=opts)
     ! --> Check convergence.
     call check(error, norm2(matmul(A%data, x%data) - b%data)**2 < rtol)
 
@@ -168,7 +168,7 @@ contains
     x = rvector()    ; call x%zero()
     ! --> GMRES solver.
     opts = gmres_opts(kdim=3, verbose=.true.)
-    call gmres(A, b, x, info, opts)
+    call gmres(A, b, x, info, options=opts)
     ! --> Check convergence.
     call check(error, norm2(matmul(A%data, x%data) - b%data)**2 < rtol)
 

--- a/test/TestIterativeSolvers.f90
+++ b/test/TestIterativeSolvers.f90
@@ -14,7 +14,55 @@ module TestIterativeSolvers
        collect_cg_testsuite,       &
        collect_bicgstab_testsuite
 
+  !-----------------------------------------------------------
+  !-----                                                 -----
+  !-----     JACOBI-BASED PRECONDITIONER FOR TESTING     -----
+  !-----                                                 -----
+  !-----------------------------------------------------------
+
+  type, extends(abstract_preconditioner), public :: jacobi_preconditioner
+     real(kind=wp), dimension(3) :: data
+   contains
+     private
+     procedure, pass(self), public :: apply
+     procedure, pass(self), public :: undo
+  end type jacobi_preconditioner
+
 contains
+
+  !--------------------------------------------------------------------
+  !-----                                                          -----
+  !-----     TYPE-BOUND PROCEDURES FOR JACOBI-PRECONDITIONING     -----
+  !-----                                                          -----
+  !--------------------------------------------------------------------
+
+  subroutine apply(self, vec_inout)
+    !> Preconditioner.
+    class(jacobi_preconditioner), intent(in)    :: self
+    !> Input/output vector.
+    class(abstract_vector)      , intent(inout) :: vec_inout
+
+    !> Diagonal scaling.
+    select type(vec_inout)
+    type is(rvector)
+       vec_inout%data = (1.0_wp / self%data) * vec_inout%data
+    end select
+    return
+  end subroutine apply
+
+  subroutine undo(self, vec_inout)
+    !> Preconditioner.
+    class(jacobi_preconditioner), intent(in)    :: self
+    !> Input/Output vector.
+    class(abstract_vector)      , intent(inout) :: vec_inout
+
+    !> Undo diagonal scaling.
+    select type(vec_inout)
+    type is(rvector)
+       vec_inout%data = self%data * vec_inout%data
+    end select
+    return
+  end subroutine undo
 
   !-------------------------------------------------------------
   !-----                                                   -----
@@ -119,8 +167,9 @@ contains
     type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
     testsuite = [&
-         new_unittest("GMRES full computation", test_gmres_full_computation),                                    &
-         new_unittest("GMRES full computation w. sym. pos. def. matrix", test_gmres_full_computation_spd_matrix) &
+         new_unittest("GMRES full computation", test_gmres_full_computation),                                     &
+         new_unittest("GMRES full computation w. sym. pos. def. matrix", test_gmres_full_computation_spd_matrix), &
+         new_unittest("GMRES + Jacobi precond.", test_precond_gmres_full_computation)                             &
          ]
     return
   end subroutine collect_gmres_testsuite
@@ -175,26 +224,47 @@ contains
     return
   end subroutine test_gmres_full_computation_spd_matrix
 
-  ! subroutine test_restarted_gmres_computation(error)
-  !   !> Eror type to be returned.
-  !   type(error_type), allocatable, intent(out) :: error
-  !   !> Linear Problem.
-  !   class(rmatrix), allocatable :: A ! Linear Operator.
-  !   class(rvector), allocatable :: b ! Right-hand side vector.
-  !   class(rvector), allocatable :: x ! Solution vector.
-  !   !> Information flag.
-  !   integer :: info
+  subroutine test_precond_gmres_full_computation(error)
+    !> Error type to be returned.
+    type(error_type), allocatable, intent(out) :: error
+    !> Linear Problem.
+    class(rmatrix), allocatable :: A ! Linear Operator.
+    class(rvector), allocatable :: b ! Right-hand side vector.
+    class(rvector), allocatable :: x ! Solution vector.
+    !> GMRES options.
+    type(gmres_opts) :: opts
+    !> Preconditioner.
+    type(jacobi_preconditioner), allocatable :: D
+    real(kind=wp) :: diag(3)
+    !> Information flag.
+    integer :: info
+    !> Miscellaneous.
+    integer :: i, j, k
 
-  !   ! --> Initialize linear problem.
-  !   A = rmatrix() ; call random_number(A%data)
-  !   b = rvector() ; call random_number(b%data)
-  !   x = rvector() ; call x%zero()
-  !   ! --> GMRES solver.
-  !   call gmres(A, b, x, info, kdim=2, verbosity=.true., maxiter=100)
-  !   ! --> Check convergence.
-  !   call check(error, norm2(matmul(A%data, x%data) - b%data)**2 < 1e-12)
-  !   return
-  ! end subroutine test_restarted_gmres_computation
+    ! --> Initialize linear problem.
+    A = rmatrix() ; call random_number(A%data)
+    b = rvector() ; call random_number(b%data)
+    x = rvector() ; call x%zero()
+    ! --> Preconditioner.
+    diag = 0.0_wp
+    do i = 1, 3
+       diag(i) = A%data(i, i)
+    enddo
+    D = jacobi_preconditioner(diag)
+    ! --> GMRES solver.
+    opts = gmres_opts(kdim=3, verbose=.true.)
+    write(*, *) "--> Running Unpreconditioned GMRES :"
+    call gmres(A, b, x, info, options=opts)
+    write(*, *)
+    write(*, *) "--> Running GMRES with Jacobi preconditioning."
+    call x%zero()
+    call gmres(A, b, x, info, options=opts, preconditioner=D)
+    ! --> Check convergence.
+    call check(error, norm2(matmul(A%data, x%data) - b%data)**2 < rtol)
+
+    return
+  end subroutine test_precond_gmres_full_computation
+
 
   !----------------------------------
   !-----                        -----

--- a/test/tests.f90
+++ b/test/tests.f90
@@ -29,7 +29,7 @@ program Tester
        new_testsuite("Real Matrix Test Suite", collect_real_matrix_testsuite),                    &
        new_testsuite("Operations on Abstract Lin. Op.", collect_abstract_linop_operations_testsuite), &
        new_testsuite("Arnoldi Test Suite", collect_arnoldi_testsuite),                            &
-       new_testsuite("Rational Arnoldi Test Suite", collect_rational_arnoldi_testsuite),          &
+       !new_testsuite("Rational Arnoldi Test Suite", collect_rational_arnoldi_testsuite),          &
        new_testsuite("Lanczos tridiagonalization Test Suite", collect_lanczos_tridiag_testsuite), &
        new_testsuite("Lanczos bidiagonalization Test Suite", collect_lanczos_bidiag_testsuite),   &
        new_testsuite("Eigenvalues Test Suite", collect_evp_testsuite),                            &

--- a/test/tests.f90
+++ b/test/tests.f90
@@ -29,7 +29,7 @@ program Tester
        new_testsuite("Real Matrix Test Suite", collect_real_matrix_testsuite),                    &
        new_testsuite("Operations on Abstract Lin. Op.", collect_abstract_linop_operations_testsuite), &
        new_testsuite("Arnoldi Test Suite", collect_arnoldi_testsuite),                            &
-       !new_testsuite("Rational Arnoldi Test Suite", collect_rational_arnoldi_testsuite),          &
+       new_testsuite("Rational Arnoldi Test Suite", collect_rational_arnoldi_testsuite),          &
        new_testsuite("Lanczos tridiagonalization Test Suite", collect_lanczos_tridiag_testsuite), &
        new_testsuite("Lanczos bidiagonalization Test Suite", collect_lanczos_bidiag_testsuite),   &
        new_testsuite("Eigenvalues Test Suite", collect_evp_testsuite),                            &


### PR DESCRIPTION
Added the possibility to pass a preconditioner to GMRES.
INFO messages are raised for CG and BiCGSTAB. Although they comply with the extend interface for linear solvers, preconditioning is not supported yet for these and any preconditioner passed to these will be ignored.