### PR TITLE
Two sided eigs

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -18,7 +18,7 @@ library = false
 
 [fortran]
 implicit-typing = false
-implicit-external = false
+implicit-external = true
 source-form = "free"
 
 [dependencies]

--- a/src/IterativeSolvers.f90
+++ b/src/IterativeSolvers.f90
@@ -413,7 +413,7 @@ contains
     end do lanczos
 
     call sort_index(residuals, indices, reverse=.false.)
-    eigvals = eigvals(indices) ; rvecs = rvecs(:, indices) ; lvecs = lvecs(indices, :)
+    eigvals = eigvals(indices) ; rvecs = rvecs(:, indices) ; lvecs = lvecs(:, indices)
     return
   end subroutine two_sided_eigs
 

--- a/src/LightKrylov.f90
+++ b/src/LightKrylov.f90
@@ -31,7 +31,7 @@ module LightKrylov
   public :: abstract_opts, gmres_opts, cg_opts
   public :: abstract_linear_solver, abstract_preconditioner
   !> Matrix factorization.
-  public :: eigs, eighs, svds
+  public :: eigs, eighs, svds, two_sided_eigs
   public :: save_eigenspectrum
 
 contains

--- a/src/LightKrylov.f90
+++ b/src/LightKrylov.f90
@@ -22,6 +22,7 @@ module LightKrylov
   !> Abstract linear operators.
   public :: abstract_linop, abstract_spd_linop, identity_linop, scaled_linop, axpby_linop
   !> Krylov factorization for general matrix.
+  public :: initialize_krylov_subspace
   public :: arnoldi_factorization, nonsymmetric_lanczos_tridiagonalization
   public :: lanczos_bidiagonalization, rational_arnoldi_factorization
   !> Krylov factorization for sym. pos. def. matrices.


### PR DESCRIPTION
Added the possibility to simultaneously compute the left and right eigenvectors using the `nonsymmetric_lanczos_iteration`. Note that, for production cases it shouldn't probably be used as it may be very sensitive to floating point round off errors resulting from the necessity of maintaining the bi-orthogonality between the left and right Krylov basis. A better approach would be to implement the two-sided Arnoldi decomposition (see #33).