### PR TITLE
Dev

### DIFF
--- a/src/AbstractVector.f90
+++ b/src/AbstractVector.f90
@@ -4,6 +4,20 @@ module lightkrylov_AbstractVector
 
    private
    public :: get_vec
+   !> Krylov Basis utilities
+   public :: mat_mult, mat_axpby, mat_zero, mat_copy
+
+   interface mat_mult
+      !> Krylov Basis multiplication
+      module procedure mat_mult_direct
+      module procedure mat_mult_transpose
+   end interface mat_mult
+      
+   interface mat_axpby
+      !> Krylov Basis operations
+      module procedure mat_axpby_realmat
+      module procedure mat_axpby_avecmat
+   end interface mat_axpby
 
    !---------------------------------------------------
    !-----     ABSTRACT VECTOR TYPE DEFINITION     -----
@@ -93,6 +107,12 @@ contains
       alpha = sqrt(self%dot(self))
    end function norm
 
+   !------------------------------------------
+   !-----                                -----
+   !-----     MATRIX VECTOR PRODUCTS     -----
+   !-----                                -----
+   !------------------------------------------
+
    subroutine get_vec(y, X, v)
       !> Output vector.
       class(abstract_vector), allocatable, intent(out) :: y
@@ -121,5 +141,126 @@ contains
       if (allocated(wrk)) deallocate (wrk)
       return
    end subroutine get_vec
+
+   !------------------------------------------
+   !-----                                -----
+   !-----     MATRIX MATRIX PRODUCTS     -----
+   !-----                                -----
+   !------------------------------------------
+
+   subroutine mat_mult_direct(C,A,B)
+      ! Compute the matrix product C = A @ B with
+      !     C: abstract vector type Krylov basis :: size nxq
+      !     A: abstract vector type Krylov basis :: size nxr
+      !     B: real matrix                       :: size rxq
+      class(abstract_vector) , intent(out) :: C(:)   ! result
+      class(abstract_vector) , intent(in)  :: A(:)   ! krylov basis
+      real(kind=wp)          , intent(in)  :: B(:,:) ! coefficient matrix
+      !> Local variables
+      class(abstract_vector) , allocatable :: wrk
+      integer :: i
+    
+      !> Check sizes.
+      if (size(A) .ne. size(B,1)) then
+         write(*,*) "INFO : Abstract vector basis A and coefficient matrix B have incompatible sizes for the product A @ B."
+         return
+      endif
+      allocate(wrk, source=A(1))
+      !> Compute product column-wise
+      do i = 1, size(B,2)
+         call get_vec(wrk, A, B(:, i))
+         call C(i)%axpby(0.0_wp, wrk, 1.0_wp)
+      enddo
+      deallocate(wrk)
+      return
+    end subroutine mat_mult_direct
+
+    subroutine mat_mult_transpose(C,A,B)
+       ! Compute the matrix product C = A.T @ B with
+       !     C: real matrix                       :: size rxq
+       !     A: abstract vector type Krylov basis :: size nxr
+       !     B: abstract vector type Krylov basis :: size nxq
+       class(abstract_vector) , intent(in)  :: A(:)   ! krylov basis
+       class(abstract_vector) , intent(in)  :: B(:)   ! krylov basis
+       real(kind=wp)          , intent(out) :: C(size(A),size(B)) ! result
+       !> Local variables
+       integer :: i, j
+
+       !> Compute product column-wise
+       C = 0.0_wp
+       do i = 1, size(A)
+          do j = 1, size(B)
+             C(i,j) = A(i)%dot(B(j))
+          enddo
+       enddo
+       return
+    end subroutine mat_mult_transpose
+
+    !--------------------------------
+    !-----                      -----
+    !-----     MATRIX UTILS     -----
+    !-----                      -----
+    !--------------------------------
+ 
+    subroutine mat_axpby_realmat(A,alpha,B,beta)
+       ! Compute the scaled sum of two matrices in-place
+       !     alpha*A + beta*B
+       ! with
+       !     A,B: real matrices :: size nxr
+       real(kind=wp) , intent(inout)  :: A(:,:)
+       real(kind=wp) , intent(in)     :: B(:,:)
+       real(kind=wp) , intent(in)     :: alpha
+       real(kind=wp) , intent(in)     :: beta
+       !> local variables
+       integer :: i,j
+       !> Check size 
+       if (any(shape(A) .ne. shape(B))) then
+          write(*, *) "INFO : Array sizes incompatible for summation. "
+          stop 1
+       endif
+       do i = 1, size(A,1)
+          do j = 1, size(A,2)
+             A(i,j) = alpha*A(i,j) + beta*B(i,j)
+          enddo
+       enddo
+    end subroutine mat_axpby_realmat
+    
+    subroutine mat_axpby_avecmat(A,alpha,B,beta)
+       ! Compute the scaled sum of two matrices in-place
+       !     alpha*A + beta*B
+       ! with
+       !     A,B: abstract_vector type Krylov bases :: size nxr
+       class(abstract_vector) , intent(inout)  :: A(:)
+       class(abstract_vector) , intent(in)     :: B(:)
+       real(kind=wp)          , intent(in)     :: alpha
+       real(kind=wp)          , intent(in)     :: beta
+       !> local variables
+       integer :: i
+       !> Check size 
+       if (size(A) .ne. size(B)) then
+          write(*, *) "INFO : Array sizes incompatible for summation. "
+          stop 1
+       endif
+       do i = 1, size(A)
+          call A(i)%axpby(alpha, B(i), beta)
+       enddo
+    end subroutine mat_axpby_avecmat
+
+    subroutine mat_zero(A)
+       ! Initialise Krylov basis with zeros
+       class(abstract_vector) , intent(inout)  :: A(:)
+       !> local variables
+       integer :: i
+       do i = 1, size(A)
+          call A(i)%zero()
+       enddo
+    end subroutine mat_zero
+
+    subroutine mat_copy(A,B)
+       ! Copy data from B to A
+       class(abstract_vector) , intent(out)  :: A(:)
+       class(abstract_vector) , intent(in)   :: B(:)
+       call mat_axpby(A,0.0_wp,B,1.0_wp)
+    end subroutine mat_copy
 
 end module lightkrylov_AbstractVector

--- a/src/LightKrylov.f90
+++ b/src/LightKrylov.f90
@@ -18,7 +18,7 @@ module LightKrylov
    !> Global variables.
    public :: greetings, wp, atol, rtol
    !> Abstract vectors.
-   public :: abstract_vector, get_vec
+   public :: abstract_vector, get_vec, mat_mult, mat_axpby, mat_zero, mat_copy
    !> Abstract linear operators.
    public :: abstract_linop, abstract_spd_linop, identity_linop, scaled_linop, axpby_linop
    !> Krylov factorization for general matrix.

--- a/test/TestVector.f90
+++ b/test/TestVector.f90
@@ -1,7 +1,7 @@
 module TestVector
    use LightKrylov
    use testdrive, only: new_unittest, unittest_type, error_type, check
-   use stdlib_math, only: is_close
+   use stdlib_math, only: is_close, all_close
 
    implicit none
 


### PR DESCRIPTION
Krylov basis utilities added to `AbstractVector.f90`:

- `mat_mult`: Explicit interface for basis-basis multiplication and basis-real matrix multiplication
- `mat_axpby`: Explicit interface for scaled addition of bases and real matrices
- `mat_zero`: Essentially a copy of `initialize_krylov_subspace` for general usage without reference to Krylov subspaces
- `mat_copy`: Copy basis based on `mat_axpby`.

Test suites added.