### PR TITLE
Krylov-Schur restarting procedure

### DIFF
--- a/src/IterativeSolvers.f90
+++ b/src/IterativeSolvers.f90
@@ -80,6 +80,15 @@ module lightkrylov_IterativeSolvers
       end subroutine abstract_linear_solver
    end interface
 
+   !-----
+   !-----
+   !-----
+
+   interface refined_ritz_vector
+      module procedure refined_real_ritz_vector
+      module procedure refined_cmplx_ritz_vector
+   end interface refined_ritz_vector
+   
 contains
 
    !=======================================================================================
@@ -522,7 +531,7 @@ contains
       !> Compute refined Ritz vectors.
       deallocate(eigvecs) ; allocate(eigvecs(conv, conv)) ; eigvecs = 0.0_wp
       do i = 1, conv
-         eigvecs(:, i) = refined_real_ritz_vector(T(1:conv+1, 1:conv), eigvals(i))
+         eigvecs(:, i) = refined_ritz_vector(T(1:conv+1, 1:conv), eigvals(i))
       enddo
 
       !> Compute and returns the eigenvectors constructed from the Krylov basis.

--- a/src/IterativeSolvers.f90
+++ b/src/IterativeSolvers.f90
@@ -519,8 +519,15 @@ contains
 
       end do lanczos
 
+      !> Compute refined Ritz vectors.
+      deallocate(eigvecs) ; allocate(eigvecs(conv, conv)) ; eigvecs = 0.0_wp
+      do i = 1, conv
+         eigvecs(:, i) = refined_real_ritz_vector(T(1:conv+1, 1:conv), eigvals(i))
+      enddo
+
       !> Compute and returns the eigenvectors constructed from the Krylov basis.
-      allocate(Xwrk, source=X) ; call mat_mult(X(1:kdim), Xwrk(1:kdim), eigvecs)
+      allocate(Xwrk, source=X(1:conv)) ; call initialize_krylov_subspace(X)
+      call mat_mult(X(1:conv), Xwrk(1:conv), eigvecs)
 
       return
    end subroutine eighs

--- a/src/IterativeSolvers.f90
+++ b/src/IterativeSolvers.f90
@@ -529,14 +529,14 @@ contains
       end do lanczos
 
       !> Compute refined Ritz vectors.
-      deallocate(eigvecs) ; allocate(eigvecs(conv, conv)) ; eigvecs = 0.0_wp
+      deallocate(eigvecs) ; allocate(eigvecs(k, conv)) ; eigvecs = 0.0_wp
       do i = 1, conv
-         eigvecs(:, i) = refined_ritz_vector(T(1:conv+1, 1:conv), eigvals(i))
+         eigvecs(:, i) = refined_ritz_vector(T(1:k+1, 1:k), eigvals(i))
       enddo
 
       !> Compute and returns the eigenvectors constructed from the Krylov basis.
-      allocate(Xwrk, source=X(1:conv)) ; call initialize_krylov_subspace(X)
-      call mat_mult(X(1:conv), Xwrk(1:conv), eigvecs)
+      allocate(Xwrk, source=X(1:k)) ; call initialize_krylov_subspace(X)
+      call mat_mult(X(1:conv), Xwrk(1:k), eigvecs)
 
       return
    end subroutine eighs

--- a/src/IterativeSolvers.f90
+++ b/src/IterativeSolvers.f90
@@ -173,6 +173,75 @@ contains
    end subroutine save_eigenspectrum
 
    !=======================================================================================
+   ! Refined Ritz vectors.
+   !=======================================================================================
+   !
+   ! Purpose and formulation:
+   ! -----------------------
+   !
+   !
+   ! Algorithmic Features:
+   ! ----------------------
+   ! - ???
+   !
+   ! Input/Output Parameters:
+   ! ------------------------
+   ! - ???       [Input]
+   !
+   !=======================================================================================
+   function refined_real_ritz_vector(H, theta) result(x)
+     !> Input-output data.
+     real(kind=wp), intent(in) :: H(:, :)
+     real(kind=wp), intent(in) :: theta
+     real(kind=wp)             :: x(size(H, 2))
+     !> Miscellaneous.
+     real(kind=wp) :: A(size(H, 1), size(H, 2))
+     real(kind=wp) :: U(size(H, 1), size(H, 1)), V(size(H, 2), size(H, 2))
+     real(kind=wp) :: S(size(H, 2))
+     integer       :: i
+
+     !> Build H - theta*Id.
+     A = H
+     do i = 1, size(A, 2)
+        A(i, i) = A(i, i) - theta
+     enddo
+
+     !> USV.T = svd(A).
+     call svd(A, U, S, V)
+
+     !> Refined Ritz vector.
+     x = V(:, size(H, 2))
+
+     return
+   end function refined_real_ritz_vector
+
+   function refined_cmplx_ritz_vector(H, theta) result(x)
+     !> Input-Output data.
+     real(kind=wp)   , intent(in) :: H(:, :)
+     complex(kind=wp), intent(in) :: theta
+     complex(kind=wp)             :: x(size(H, 2))
+     !> Miscellaneous.
+     complex(kind=wp) :: A(size(H, 1), size(H, 2))
+     complex(kind=wp) :: U(size(H, 1), size(H, 1)), V(size(H, 2), size(H, 2))
+     real(kind=wp)    :: S(size(H, 2))
+     integer          :: i
+
+     !> Build H - theta*Id.
+     A = H
+     do i = 1, size(A, 2)
+        A(i, i) = A(i, i) - theta
+     enddo
+
+     !> USV.H = svd(A).
+     call svd(A, U, S, V)
+
+     !> Refined Ritz vector.
+     x = V(:, size(H, 2))
+
+     return
+   end function refined_cmplx_ritz_vector
+
+   !=======================================================================================
    ! Eigenvalue and Eigenvector Solver Subroutine (EIGS)
    !=======================================================================================
    !

--- a/src/LightKrylov.f90
+++ b/src/LightKrylov.f90
@@ -23,7 +23,7 @@ module LightKrylov
    public :: abstract_linop, abstract_spd_linop, identity_linop, scaled_linop, axpby_linop
    !> Krylov factorization for general matrix.
    public :: initialize_krylov_subspace
-   public :: arnoldi_factorization
+   public :: arnoldi_factorization, krylov_schur_restart
    public :: nonsymmetric_lanczos_tridiagonalization, two_sided_arnoldi_factorization
    public :: lanczos_bidiagonalization, rational_arnoldi_factorization
    !> Krylov factorization for sym. pos. def. matrices.

--- a/src/Utils.f90
+++ b/src/Utils.f90
@@ -245,8 +245,8 @@ contains
       lwork = max(1, 3*min(m, n), 5*min(m, n)); allocate (work(lwork))
 
       !> Shape assertions.
-      call assert_shape(U, [m, min(m, n)], "svd", "U")
-      call assert_shape(V, [n, min(m, n)], "svd", "V")
+      call assert_shape(U, [m, m], "svd", "U")
+      call assert_shape(V, [n, n], "svd", "V")
 
       !> SVD computation.
       a_tilde = a
@@ -292,8 +292,8 @@ contains
      lwork = max(1, 3*min(m, n), 5*min(m, n)); allocate (work(lwork)) ; allocate(rwork(5*min(m, n)))
 
      !> Shape assertion.
-     call assert_shape(U, [m, min(m, n)], "svd", "U")
-     call assert_shape(V, [n, min(m, n)], "svd", "V")
+     call assert_shape(U, [m, m], "svd", "U")
+     call assert_shape(V, [n, n], "svd", "V")
 
      !> SVD computation.
      a_tilde = a

--- a/src/Utils.f90
+++ b/src/Utils.f90
@@ -4,7 +4,7 @@ module lightkrylov_utils
 
    private
    !> General-purpose utilities.
-   public :: assert_shape
+   public :: assert_shape, stop_error
    !> Linear Algebra Utilities.
    public :: inv, svd, eig, eigh, lstsq, schur, ordschur
 

--- a/src/Utils.f90
+++ b/src/Utils.f90
@@ -6,7 +6,7 @@ module lightkrylov_utils
    !> General-purpose utilities.
    public :: assert_shape
    !> Linear Algebra Utilities.
-   public :: inv, svd, eig, eigh, lstsq
+   public :: inv, svd, eig, eigh, lstsq, schur, ordschur
 
    !-------------------------------------------------------
    !-----                                             -----
@@ -480,6 +480,9 @@ contains
 
      !> Perform Schur decomposition.
      call dgees(jobvs, sort, dummy_select, n, A, lda, sdim, wr, wi, Z, ldvs, work, lwork, bwork, info)
+
+     !> Eigenvalues.
+     eigvals = cmplx(wr, wi, kind=wp)
 
      return
    end subroutine schur

--- a/src/Utils.f90
+++ b/src/Utils.f90
@@ -454,4 +454,62 @@ contains
       return
    end subroutine lstsq
 
+   !----------------------------------------------
+   !-----                                    -----
+   !-----     LAPACK SCHUR DECOMPOSITION     -----
+   !-----                                    -----
+   !----------------------------------------------
+
+   subroutine schur(A, Z, eigvals)
+     !> Matrix to be factorize.
+     real(kind=wp)   , intent(inout) :: A(:, :)
+     !> Schur basis.
+     real(kind=wp)   , intent(out)   :: Z(:, :)
+     !> Eigenvalues.
+     complex(kind=wp), intent(out)   :: eigvals(:)
+
+     !> LAPACK-related.
+     character :: jobvs="v", sort="n"
+     integer   :: n, lda, sdim, ldvs, lwork, info
+     real(kind=wp) :: wr(size(A, 1)), wi(size(A, 1))
+     real(kind=wp) :: work(3*size(A, 1))
+     logical       :: bwork(size(A, 1))
+
+     !> Setup lapack variables.
+     n = size(A, 1); lda = max(1, n); ldvs = max(1, n); lwork = max(1, 3*n)
+
+     !> Perform Schur decomposition.
+     call dgees(jobvs, sort, dummy_select, n, A, lda, sdim, wr, wi, Z, ldvs, work, lwork, bwork, info)
+
+     return
+   end subroutine schur
+
+   subroutine ordschur(T, Q, selected)
+     !> Schur matrix to be reordered.
+     real(kind=wp), intent(inout) :: T(:, :)
+     !> Schur basis to be reordered.
+     real(kind=wp), intent(inout) :: Q(:, :)
+     !> Array of selected eigenvalues.
+     logical      , intent(in)    :: selected(:)
+
+     !> LAPACK-related.
+     character :: job="n", compq="v"
+     integer   :: info, ldq, ldt, liwork, lwork, m, n, iwork(size(T, 1))
+     real(kind=wp) :: s, sep
+     real(kind=wp) :: work(size(T, 1)), wr(size(T, 1)), wi(size(T, 1))
+
+     !> Setup variables.
+     n = size(T, 2) ; ldt = n ; ldq = n ; lwork = max(1, n) ; liwork = 1
+
+     !> Re-order Schur.
+     call dtrsen(job, compq, selected, n, T, ldt, Q, ldq, wr, wi, m, s, sep, work, lwork, iwork, liwork, info)
+
+     return
+   end subroutine ordschur
+
+   logical function dummy_select(wr, wi) result(out)
+     real(kind=wp), intent(in) :: wr, wi
+     return
+   end function dummy_select
+
 end module lightkrylov_utils

--- a/src/Utils.f90
+++ b/src/Utils.f90
@@ -507,7 +507,7 @@ contains
      return
    end subroutine ordschur
 
-   logical function dummy_select(wr, wi) result(out)
+   pure logical function dummy_select(wr, wi) result(out)
      real(kind=wp), intent(in) :: wr, wi
      return
    end function dummy_select

--- a/src/Utils.f90
+++ b/src/Utils.f90
@@ -72,6 +72,7 @@ module lightkrylov_utils
    !> Compute U, S, V = svd(A)
    interface svd
       module procedure dsvd
+      module procedure zsvd
    end interface svd
 
    !> Compute EVD(A).
@@ -267,6 +268,53 @@ contains
 
       return
    end subroutine dsvd
+
+   subroutine zsvd(A, U, S, V)
+     !> Matrix to be factorized
+     complex(kind=wp), intent(in)  :: A(:, :)
+     !> Left singular vectors.
+     complex(kind=wp), intent(out) :: U(:, :)
+     !> Singular values.
+     real(kind=wp), intent(out) :: S(:)
+     !> Right singular vectors.
+     complex(kind=wp), intent(out) :: V(:, :)
+
+     !> Lapack-related.
+     character :: jobu = "S", jobvt = "S"
+     integer   :: m, n, lda, ldu, ldvt, lwork, info
+     complex(kind=wp), allocatable :: work(:)
+     real(kind=wp), allocatable :: rwork(:)
+     complex(kind=wp) :: A_tilde(size(A, 1), size(A, 2)), vt(min(size(A, 1), size(A, 2)), size(A, 2))
+
+     !> Setup variables.
+     m = size(A, 1); n = size(A, 2)
+     lda = m; ldu = m; ldvt = n
+     lwork = max(1, 3*min(m, n), 5*min(m, n)); allocate (work(lwork)) ; allocate(rwork(5*min(m, n)))
+
+     !> Shape assertion.
+     call assert_shape(U, [m, min(m, n)], "svd", "U")
+     call assert_shape(V, [n, min(m, n)], "svd", "V")
+
+     !> SVD computation.
+     a_tilde = a
+     call zgesvd(jobu, jobvt, m, n, a_tilde, lda, s, u, ldu, vt, ldvt, work, lwork, rwork, info)
+     if (info /= 0) then
+        write (*, *) "ZGESVD returned info = ", info
+        if (info < 0) then
+           write (*, *) "The ", -info, "-th argument has an illegal value."
+        else
+           write (*, *) "ZBSQR did not converge. There are ", info, "superdiagonals"
+           write (*, *) "of an intermediate bidiagonal matrix form B which did not"
+           write (*, *) "converge to zero. See Lapack documentation for more details."
+        end if
+        call stop_error("svd: zgesvd error")
+     end if
+
+    !> Return the transpose of V.
+     v = transpose(vt) ; v = conjg(v)
+
+     return
+   end subroutine zsvd
 
    !-------------------------------------------
    !-----                                 -----

--- a/test/TestKrylov.f90
+++ b/test/TestKrylov.f90
@@ -4,7 +4,6 @@ module TestKrylov
    use TestMatrices
    use testdrive, only: new_unittest, unittest_type, error_type, check
    use stdlib_math, only: all_close, is_close
-   use stdlib_io_npy
    implicit none
 
    private
@@ -34,8 +33,7 @@ contains
            new_unittest("Arnoldi basis orthogonality", test_arnoldi_basis_orthogonality), &
            new_unittest("Block Arnoldi full factorization", test_block_arnoldi_full_factorization), &
            new_unittest("Block Arnoldi basis orthogonality", test_block_arnoldi_basis_orthogonality), &
-           new_unittest("Krylov-Schur restart", test_krylov_schur), &
-           new_unittest("Krylov-Schur basis orthogonality", test_krylov_schur_basis_orthogonality) &
+           new_unittest("Krylov-Schur restart", test_krylov_schur) &
                   ]
 
       return
@@ -216,111 +214,176 @@ contains
    end subroutine test_block_arnoldi_basis_orthogonality
 
    subroutine test_krylov_schur(error)
-      ! This function checks the correctness of the Arnoldi implementation by
-      ! verifying that the full factorization is correct, i.e. A @ X[1:k] = X[1:k+1] @ H.
-      ! A random 3x3 matrix is used for testing.
-
-      !> Error type to be returned.
-      type(error_type), allocatable, intent(out) :: error
-      !> Test matrix.
-      class(rmatrix), allocatable :: A
-      !> Krylov subspace.
-      class(rvector), dimension(:), allocatable :: X
-      !> Krylov subspace dimension.
-      integer, parameter :: kdim = 10
-      !> Hessenberg matrix.
-      real(kind=wp) :: H(kdim + 1, kdim)
-      !> Information flag.
-      integer :: info
-      !> Misc.
-      integer :: k, nblk
-      real(kind=wp) :: Xdata(test_size, kdim + 1)
-      real(kind=wp) :: alpha
-
-      ! --> Initialize matrix.
-      A = rmatrix(); call random_number(A%data)
-      ! --> Initialize Krylov subspace.
-      allocate (X(1:kdim + 1)) ; call initialize_krylov_subspace(X)
-      call random_number(X(1)%data); alpha = X(1)%norm() ; call X(1)%scal(1.0_wp / alpha)
-      H = 0.0_wp
-
-      ! --> Arnoldi factorization.
-      call arnoldi_factorization(A, X, H, info)
-
-      ! --> Krylov-Schur condensation.
-      call krylov_schur_restart(nblk, X, H, select_eigs)
-
-      ! --> Check correctness of full factorization.
-      do k = 1, kdim + 1
-         Xdata(:, k) = X(k)%data
-      end do
-
-      !> Infinity-norm of the error.
-      alpha = maxval(abs(matmul(A%data, Xdata(:, 1:nblk)) - matmul(Xdata(:, 1:nblk+1), H(1:nblk+1, 1:nblk))))
-
-      !> Check correctness.
-      call check(error, alpha < rtol)
-
-      return
-    contains
-      function select_eigs(eigvals) result(selected)
-        complex(kind=wp), intent(in) :: eigvals(:)
-        logical                      :: selected(size(eigvals))
-        selected = (eigvals%re > 0.5_wp)
-        return
-      end function select_eigs
-    end subroutine test_krylov_schur
-
+     ! This function checks the correctness of the Arnoldi implementation by
+     ! verifying that the full factorization is correct, i.e. A @ X[1:k] = X[1:k+1] @ H.
+     ! A random 3x3 matrix is used for testing.
+     
+     !> Error type to be returned.
+     type(error_type), allocatable, intent(out) :: error
+     !> Test matrix.
+     class(rmatrix), allocatable :: A
+     !> Krylov subspace.
+     class(rvector), dimension(:), allocatable :: X
+     !> Krylov subspace dimension.
+     integer, parameter :: kdim = 10
+     !> Hessenberg matrix.
+     real(kind=wp) :: H(kdim + 1, kdim)
+     !> Information flag.
+     integer :: info
+     !> Misc.
+     integer :: k, nblk
+     real(kind=wp) :: Xdata(test_size, kdim + 1)
+     real(kind=wp) :: alpha
+     
+     ! --> Initialize matrix.
+     A = rmatrix(); call random_number(A%data)
+     ! --> Initialize Krylov subspace.
+     allocate (X(1:kdim + 1)) ; call initialize_krylov_subspace(X)
+     call random_number(X(1)%data); alpha = X(1)%norm() ; call X(1)%scal(1.0_wp / alpha)
+     H = 0.0_wp
+     
+     ! --> Arnoldi factorization.
+     call arnoldi_factorization(A, X, H, info)
+     
+     ! --> Krylov-Schur condensation.
+     call krylov_schur_restart(nblk, X, H, select_eigs)
+     
+     ! --> Check correctness of full factorization.
+     do k = 1, kdim + 1
+        Xdata(:, k) = X(k)%data
+     end do
+     
+     !> Infinity-norm of the error.
+     alpha = maxval(abs(matmul(A%data, Xdata(:, 1:nblk)) - matmul(Xdata(:, 1:nblk+1), H(1:nblk+1, 1:nblk))))
+     
+     !> Check correctness.
+     call check(error, alpha < rtol)
+     
+     return
+   contains
+     function select_eigs(eigvals) result(selected)
+       complex(kind=wp), intent(in) :: eigvals(:)
+       logical                      :: selected(size(eigvals))
+       selected = (eigvals%re > 0.5_wp)
+       return
+     end function select_eigs
+   end subroutine test_krylov_schur
+   
+   subroutine test_block_krylov_schur(error)
+     ! This function checks the correctness of the Arnoldi implementation by
+     ! verifying that the full factorization is correct, i.e. A @ X[1:k] = X[1:k+1] @ H.
+     ! A random 3x3 matrix is used for testing.
+     
+     !> Error type to be returned.
+     type(error_type), allocatable, intent(out) :: error
+     !> Test matrix.
+     class(rmatrix), allocatable :: A
+     !> Krylov subspace.
+     class(rvector), dimension(:), allocatable :: X
+     !> Krylov subspace dimension.
+     integer, parameter :: p = 3
+     integer, parameter :: kdim = 7
+     !> Hessenberg matrix.
+     real(kind=wp) :: H(p*(kdim + 1), p*kdim)
+     !> Information flag.
+     integer :: info
+     !> Misc.
+     integer :: k, nblk
+     real(kind=wp) :: Xdata(test_size, p*(kdim + 1))
+     real(kind=wp) :: alpha, m(test_size)
+     class(rvector), allocatable :: X0(:)
+     
+     ! --> Initialize matrix.
+     A = rmatrix(); call random_number(A%data) ; m = sum(A%data, 2)/test_size
+     do k = 1, test_size
+        A%data(:, k) = A%data(:, k) - m
+     enddo
+     !A%data = 0.5 * (A%data + transpose(A%data))
+     ! --> Initialize Krylov subspace.
+     allocate (X(p*(kdim + 1))) ; allocate(X0(p))
+     do k = 1, p
+        call random_number(X0(k)%data)
+     enddo
+     call initialize_krylov_subspace(X, X0)
+     H = 0.0_wp
+     
+     ! --> Arnoldi factorization.
+     call arnoldi_factorization(A, X, H, info, block_size=p)
+     
+     ! --> Krylov-Schur condensation.
+     call krylov_schur_restart(nblk, X, H, select_eigs, p)
+     
+     ! --> Check correctness of full factorization.
+     do k = 1, p*(kdim + 1)
+        Xdata(:, k) = X(k)%data
+     end do
+     
+     !> Infinity-norm of the error.
+     alpha = maxval(abs(matmul(A%data, Xdata(:, 1:p*nblk)) - matmul(Xdata(:, 1:p*(nblk+1)), H(1:p*(nblk+1), 1:p*nblk))))
+     
+     !> Check correctness.
+     call check(error, alpha < rtol)
+     
+     return
+   contains
+     function select_eigs(eigvals) result(selected)
+       complex(kind=wp), intent(in) :: eigvals(:)
+       logical                      :: selected(size(eigvals))
+       selected = (abs(eigvals) > 2.0_wp)
+       return
+     end function select_eigs
+   end subroutine test_block_krylov_schur
+   
    subroutine test_krylov_schur_basis_orthogonality(error)
-      !> Error type to be returned.
-      type(error_type), allocatable, intent(out) :: error
-      !> Test matrix.
-      class(rmatrix), allocatable :: A
-      !> Krylov subspace.
-      class(rvector), dimension(:), allocatable :: X
-      class(rvector), dimension(:), allocatable :: X0
-      !> Krylov subspace dimension.
-      integer, parameter :: kdim = 10
-      !> Hessenberg matrix.
-      double precision, dimension(kdim + 1, kdim) :: H
-      !> Information flag.
-      integer :: info
-      !> Misc.
-      double precision, dimension(kdim, kdim) :: G, Id
-      double precision :: alpha
-      integer :: i, j, k, nblk
-
-      !! --> Initialize random matrix.
-      A = rmatrix(); call random_number(A%data)
-      !! --> Initialize Krylov subspace.
-      allocate(X(kdim + 1)) ; call initialize_krylov_subspace(X)
-      call random_number(X(1)%data) ; alpha = X(1)%norm() ; call X(1)%scal(1.0_wp / alpha)
-      H = 0.0_wp
-
-      ! --> Arnoldi factorization.
-      call arnoldi_factorization(A, X, H, info)
-
-      ! --> Krylov-Schur condensation.
-      call krylov_schur_restart(nblk, X, H, select_eigs)
-
-      ! --> Compute Gram matrix associated to the Krylov basis.
-      G = 0.0_wp
-      call mat_mult(G(1:nblk, 1:nblk),X(1:nblk),X(1:nblk))
-
-      ! --> Check result.
-      Id = 0.0_wp; forall (i=1:nblk) Id(i, i) = 1.0_wp
-      call check(error, norm2(G - Id) < rtol)
-
-      return
-    contains
-      function select_eigs(eigvals) result(selected)
-        complex(kind=wp), intent(in) :: eigvals(:)
-        logical                      :: selected(size(eigvals))
-        selected = (eigvals%re > 0.5_wp)
-        return
-      end function select_eigs
-    end subroutine test_krylov_schur_basis_orthogonality
-
+     !> Error type to be returned.
+     type(error_type), allocatable, intent(out) :: error
+     !> Test matrix.
+     class(rmatrix), allocatable :: A
+     !> Krylov subspace.
+     class(rvector), dimension(:), allocatable :: X
+     class(rvector), dimension(:), allocatable :: X0
+     !> Krylov subspace dimension.
+     integer, parameter :: kdim = 10
+     !> Hessenberg matrix.
+     double precision, dimension(kdim + 1, kdim) :: H
+     !> Information flag.
+     integer :: info
+     !> Misc.
+     double precision, dimension(kdim, kdim) :: G, Id
+     double precision :: alpha
+     integer :: i, j, k, nblk
+     
+     ! --> Initialize random matrix.
+     A = rmatrix(); call random_number(A%data)
+     ! --> Initialize Krylov subspace.
+     allocate(X(kdim + 1)) ; call initialize_krylov_subspace(X)
+     call random_number(X(1)%data) ; alpha = X(1)%norm() ; call X(1)%scal(1.0_wp / alpha)
+     H = 0.0_wp
+     
+     ! --> Arnoldi factorization.
+     call arnoldi_factorization(A, X, H, info)
+     
+     ! --> Krylov-Schur condensation.
+     call krylov_schur_restart(nblk, X, H, select_eigs)
+     
+     ! --> Compute Gram matrix associated to the Krylov basis.
+     G = 0.0_wp
+     call mat_mult(G(1:nblk, 1:nblk),X(1:nblk),X(1:nblk))
+     
+     ! --> Check result.
+     Id = 0.0_wp; forall (i=1:nblk) Id(i, i) = 1.0_wp
+     call check(error, norm2(G - Id) < rtol)
+     
+     return
+   contains
+     function select_eigs(eigvals) result(selected)
+       complex(kind=wp), intent(in) :: eigvals(:)
+       logical                      :: selected(size(eigvals))
+       selected = (abs(eigvals) > 0.5_wp)
+       return
+     end function select_eigs
+   end subroutine test_krylov_schur_basis_orthogonality
+   
    !-----------------------------------------------------------------
    !-----                                                       -----
    !-----     TEST SUITE FOR THE LANCZOS TRIDIAGONALIZATION     -----


### PR DESCRIPTION
This PR adds two main utilities to `LightKrylov` :
- `refined_ritz_vector` : simple postprocessing routine to obtain better approximate eigenvectors.
- `krylov_schur_restart` : Restarting an Arnoldi factorization using the Krylov-Schur algorithm.

Note that, although the code compiles and runs for restarting the block Arnoldi, it did not always passed the test. It seems to be related to how many eigenvalues have been selected relative to the blocksize. For the moment, if a block factorization is used, the routine will raise an automatic error.