### PR TITLE
Fast matmul

### DIFF
--- a/src/AbstractVector.f90
+++ b/src/AbstractVector.f90
@@ -196,8 +196,6 @@ contains
      !! Krylov basis.
       real(kind=wp), dimension(:), intent(in) :: v
      !! Coordinates of the output vector y in the Krylov basis X.
-      class(abstract_vector), allocatable :: wrk
-      ! Temporary working abstract vector.
       integer :: i
       ! Miscellaneous.
 
@@ -209,13 +207,9 @@ contains
       ! Initialize output vector.
       if (allocated(y) .eqv. .false.) allocate (y, source=X(1)); call y%zero()
       ! Compute output vector.
-      if (.not. allocated(wrk)) allocate (wrk, source=X(1))
       do i = 1, size(X)
-         wrk = X(i)
-         call wrk%scal(v(i))
-         call y%add(wrk)
+         call y%axpby(1.0_wp, X(i), v(i))
       end do
-      if (allocated(wrk)) deallocate (wrk)
       return
    end subroutine get_vec
 
@@ -236,8 +230,7 @@ contains
      !! Real-valued matrix to be left-multiplied by `A`.
 
       ! Local variables
-      class(abstract_vector), allocatable :: wrk
-      integer :: i
+      integer :: i, j
 
       ! Check sizes.
       if (size(A) .ne. size(B, 1)) then
@@ -250,13 +243,15 @@ contains
          write (*, *) "Coefficient matrix B does not have the same amout of colums as output basis C for the product C = A @ B."
          stop 1
       end if
-      allocate (wrk, source=A(1))
+      
       ! Compute product column-wise
-      do i = 1, size(B, 2)
-         call get_vec(wrk, A, B(:, i))
-         call C(i)%axpby(0.0_wp, wrk, 1.0_wp)
+      do j = 1, size(B, 2)
+         call C(j)%zero()
+         do i = 1, size(B, 1)
+            call C(j)%axpby(1.0_wp, A(i), B(i, j))
+         enddo
       end do
-      deallocate (wrk)
+
       return
    end subroutine mat_mult_direct
 

--- a/src/IterativeSolvers.f90
+++ b/src/IterativeSolvers.f90
@@ -335,7 +335,7 @@ contains
       end do arnoldi
 
       ! Reconstruct the eigenvectors from the Krylov basis.
-      allocate (Xwrk, source=X); call mat_mult(X(1:kdim), Xwrk(1:kdim), eigvecs)
+      allocate (Xwrk, source=X); call mat_mult(X(1:k), Xwrk(1:k), eigvecs(1:k, 1:k))
 
       return
    end subroutine eigs
@@ -581,9 +581,10 @@ contains
       info = k
 
       ! Compute and return the low-rank factors from the Krylov bases.
-      allocate (Uwrk, source=U); allocate (Vwrk, source=V)
-      call mat_mult(U(1:kdim), Uwrk(1:kdim), uvecs); call mat_mult(V(1:kdim), Vwrk(1:kdim), vvecs)
-
+      allocate (Uwrk, source=U(1:k)); allocate (Vwrk, source=V(1:k))
+      call mat_mult(U(1:k), Uwrk, uvecs(1:k, 1:k))
+      call mat_mult(V(1:k), Vwrk, vvecs(1:k, 1:k))
+      
       return
    end subroutine svds
 

--- a/src/IterativeSolvers.f90
+++ b/src/IterativeSolvers.f90
@@ -688,11 +688,13 @@ contains
       info = 0
 
       ! Initial Krylov vector.
-      if (trans) then
-         call A%rmatvec(x, V(1))
-      else
-         call A%matvec(x, V(1))
-      end if
+      if (x%norm() .ne. 0.0_wp) then
+         if (trans) then
+            call A%rmatvec(x, V(1))
+         else
+            call A%matvec(x, V(1))
+         end if
+      endif
       call V(1)%sub(b); call V(1)%scal(-1.0_wp)
       beta = V(1)%norm(); call V(1)%scal(1.0_wp/beta)
       gmres_iterations: do i = 1, maxiter


### PR DESCRIPTION
Included contributions :

- allocation-free `get_vec` and `mat_mult_direct`.
- Removed unnecessary matrix-product when reconstructing the singular/eigen vectors from the Krylov basis.