### PR TITLE
Minor bug fixes

### DIFF
--- a/src/AbstractVector.f90
+++ b/src/AbstractVector.f90
@@ -270,8 +270,8 @@ contains
 
       ! Compute product column-wise
       C = 0.0_wp
-      do i = 1, size(A)
-         do j = 1, size(B)
+      do j = 1, size(B)
+         do i = 1, size(A)
             C(i, j) = A(i)%dot(B(j))
          end do
       end do
@@ -305,8 +305,8 @@ contains
          write (*, *) "INFO : Array sizes incompatible for summation. "
          stop 1
       end if
-      do i = 1, size(A, 1)
-         do j = 1, size(A, 2)
+      do j = 1, size(A, 2)
+         do i = 1, size(A, 1)
             A(i, j) = alpha*A(i, j) + beta*B(i, j)
          end do
       end do

--- a/src/AbstractVector.f90
+++ b/src/AbstractVector.f90
@@ -79,7 +79,7 @@ module lightkrylov_AbstractVector
       procedure(abstract_zero), deferred, public :: zero
       !! Sets an `abstract_vector` to zero.
       procedure(abstract_rand), deferred, public :: rand
-      !! Create a random `æbstract_vector.
+      !! Create a random `abstract_vector.
       procedure(abstract_scal), deferred, public :: scal
       !! Compute the scalar-vector product.
       procedure(axpby_interface), deferred, pass(self), public :: axpby

--- a/src/IterativeSolvers.f90
+++ b/src/IterativeSolvers.f90
@@ -320,7 +320,16 @@ contains
 
          ! Compute residuals.
          beta = H(k + 1, k) ! Get Krylov residual vector norm.
-         residuals(1:k) = compute_residual(beta, abs(eigvecs(k, 1:k)))
+         do i = 1, k
+            if (eigvals(i)%im > 0.0_wp) then
+               alpha = abs(cmplx(eigvecs(k, i), eigvecs(k, i+1), kind=wp))
+            else if (eigvals(i)%im < 0.0_wp) then
+               alpha = abs(cmplx(eigvecs(k, i-1), -eigvecs(k, i), kind=wp))
+            else
+               alpha = abs(eigvecs(k, i))
+            endif
+            residuals(i) = compute_residual(beta, alpha)
+         end do
 
          ! Check convergence.
          conv = count(residuals(1:k) < tol)


### PR DESCRIPTION
Fixed the residuals computations in `eigs`. When we made `deig` to follow LAPACK convetion for returning the real and imaginary parts of the eigenvectors, we did not change how the residuals were being computed in `eigs`. This now fixed.
I also fixed some inner/outer loop indices in the `mat_mult` subroutines to leverage the column-oriented array storay in Fortran.