### PR TITLE
Major refactoring of the codebase.

### DIFF
--- a/example/ginzburg_landau/Ginzburg_Landau.f90
+++ b/example/ginzburg_landau/Ginzburg_Landau.f90
@@ -9,7 +9,8 @@ module Ginzburg_Landau
   use stdlib_optval, only : optval
   implicit none
 
-  private
+  character*128, parameter, private :: this_module = 'Ginzburg_Landau'
+
   public :: nx
   public :: initialize_parameters
 

--- a/example/ginzburg_landau/main.f90
+++ b/example/ginzburg_landau/main.f90
@@ -6,6 +6,8 @@ program demo
   use Ginzburg_Landau
   implicit none
 
+  character*128, parameter :: this_module = 'Example Ginzburg_Landau'
+
   !------------------------------------------------
   !-----     LINEAR OPERATOR INVESTIGATED     -----
   !------------------------------------------------
@@ -56,7 +58,7 @@ program demo
 
   !> Call to LightKrylov.
   call eigs(A, X, lambda, residuals, info)
-  call check_info(info, 'eigs', module='example Ginzburg-Landau', procedure='main')
+  call check_info(info, 'eigs', module=this_module, procedure='main')
 
   !> Transform eigenspectrum from unit-disk to standard complex plane.
   lambda = log(lambda) / tau

--- a/src/AbstractLinops.f90
+++ b/src/AbstractLinops.f90
@@ -3,7 +3,8 @@ module lightkrylov_AbstractLinops
     use lightkrylov_utils
     use lightkrylov_AbstractVectors
     implicit none
-    private
+
+    character*128, parameter, private :: this_module = 'Lightkrylov_AbstractLinops'
 
     type, abstract, public :: abstract_linop
     contains

--- a/src/AbstractLinops.fypp
+++ b/src/AbstractLinops.fypp
@@ -5,7 +5,8 @@ module lightkrylov_AbstractLinops
     use lightkrylov_utils
     use lightkrylov_AbstractVectors
     implicit none
-    private
+
+    character*128, parameter, private :: this_module = 'Lightkrylov_AbstractLinops'
 
     type, abstract, public :: abstract_linop
     contains

--- a/src/AbstractLinops.fypp
+++ b/src/AbstractLinops.fypp
@@ -19,46 +19,46 @@ module lightkrylov_AbstractLinops
 
 
 
-    #:for k1, t1 in RC_KINDS_TYPES
+    #:for kind, type in RC_KINDS_TYPES
     !------------------------------------------------------------------------------
-    !-----     Definition of an abstract ${t1}$ operator with kind=${k1}$     -----
+    !-----     Definition of an abstract ${type}$ operator with kind=${kind}$     -----
     !------------------------------------------------------------------------------
-    type, abstract, extends(abstract_linop), public :: abstract_linop_${t1[0]}$${k1}$
+    type, abstract, extends(abstract_linop), public :: abstract_linop_${type[0]}$${kind}$
         !! Base type to define an abstract linear operator. All other types defined in
         !! `LightKrylov` derive from this fundamental one.
     contains
         private
-        procedure(abstract_matvec_${t1[0]}$${k1}$), pass(self), deferred, public :: matvec
+        procedure(abstract_matvec_${type[0]}$${kind}$), pass(self), deferred, public :: matvec
         !! Procedure to compute the matrix-vector product \( \mathbf{y} = \mathbf{Ax} \).
-        procedure(abstract_matvec_${t1[0]}$${k1}$), pass(self), deferred, public :: rmatvec
+        procedure(abstract_matvec_${type[0]}$${kind}$), pass(self), deferred, public :: rmatvec
         !! Procedure to compute the reversed matrix-vector product \( \mathbf{y} = \mathbf{A}^H \mathbf{x} \).
     end type
 
     abstract interface
-        subroutine abstract_matvec_${t1[0]}$${k1}$(self, vec_in, vec_out)
+        subroutine abstract_matvec_${type[0]}$${kind}$(self, vec_in, vec_out)
             !! Interface for the matrix-vector product.
             use lightkrylov_AbstractVectors
-            import abstract_linop_${t1[0]}$${k1}$
-            class(abstract_linop_${t1[0]}$${k1}$) , intent(in)  :: self
+            import abstract_linop_${type[0]}$${kind}$
+            class(abstract_linop_${type[0]}$${kind}$) , intent(in)  :: self
             !! Linear operator \(\mathbf{A}\).
-            class(abstract_vector_${t1[0]}$${k1}$), intent(in)  :: vec_in
+            class(abstract_vector_${type[0]}$${kind}$), intent(in)  :: vec_in
             !! Vector to be multiplied by \(\mathbf{A}\).
-            class(abstract_vector_${t1[0]}$${k1}$), intent(out) :: vec_out
+            class(abstract_vector_${type[0]}$${kind}$), intent(out) :: vec_out
             !! Result of the matrix-vector product.
-        end subroutine abstract_matvec_${t1[0]}$${k1}$
+        end subroutine abstract_matvec_${type[0]}$${kind}$
     end interface
 
-    type, extends(abstract_linop_${t1[0]}$${k1}$), public :: adjoint_linop_${t1[0]}$${k1}$
+    type, extends(abstract_linop_${type[0]}$${kind}$), public :: adjoint_linop_${type[0]}$${kind}$
         !! Utility type to define an adjoint linear operator. The definition of `matvec` and `rmatvec`
         !! are directly inherited from those used to define `A`. Note that this utility does not
         !! compute the adjoint for you. It simply provides a utility to define a new operator
         !! with `matvec` and `rmatvec` being switched.
-        class(abstract_linop_${t1[0]}$${k1}$), allocatable :: A
+        class(abstract_linop_${type[0]}$${kind}$), allocatable :: A
         !! Linear operator whose adjoint needs to be defined.
     contains
         private
-        procedure, pass(self), public :: matvec => adjoint_matvec_${t1[0]}$${k1}$
-        procedure, pass(self), public :: rmatvec => adjoint_rmatvec_${t1[0]}$${k1}$
+        procedure, pass(self), public :: matvec => adjoint_matvec_${type[0]}$${kind}$
+        procedure, pass(self), public :: rmatvec => adjoint_rmatvec_${type[0]}$${kind}$
     end type
 
 

--- a/src/AbstractVectors.f90
+++ b/src/AbstractVectors.f90
@@ -4,16 +4,20 @@ module lightkrylov_AbstractVectors
     implicit none
     private
 
-    public :: innerprod_matrix
+    public :: innerprod
     public :: linear_combination
     public :: axpby_basis
     public :: zero_basis
     public :: copy_basis
 
-    interface innerprod_matrix
+    interface innerprod
+        module procedure innerprod_vector_rsp
         module procedure innerprod_matrix_rsp
+        module procedure innerprod_vector_rdp
         module procedure innerprod_matrix_rdp
+        module procedure innerprod_vector_csp
         module procedure innerprod_matrix_csp
+        module procedure innerprod_vector_cdp
         module procedure innerprod_matrix_cdp
     end interface
 
@@ -574,6 +578,25 @@ contains
         return
     end subroutine linear_combination_matrix_rsp
 
+    subroutine innerprod_vector_rsp(v, X, y)
+        !! Computes the inner product vector \( \mathbf{v} = \mathbf{X}^H \mathbf{v} \) between
+        !! a basis `X` of `abstract_vector` and `v`, a single `abstract_vector`.
+        class(abstract_vector_rsp), intent(in) :: X(:), y
+        !! Bases of `abstract_vector` whose inner products need to be computed.
+        real(sp), intent(out) :: v(size(X))
+        !! Resulting inner-product vector.
+
+        ! Local variables.
+        integer :: i
+
+        v = 0.0_sp
+        do i = 1, size(X)
+            v(i) = X(i)%dot(y)
+        enddo
+        
+        return
+    end subroutine innerprod_vector_rsp
+
     subroutine innerprod_matrix_rsp(M, X, Y)
         !! Computes the inner product matrix \( \mathbf{M} = \mathbf{X}^H \mathbf{Y} \) between
         !! two bases of `abstract_vector`.
@@ -717,6 +740,25 @@ contains
 
         return
     end subroutine linear_combination_matrix_rdp
+
+    subroutine innerprod_vector_rdp(v, X, y)
+        !! Computes the inner product vector \( \mathbf{v} = \mathbf{X}^H \mathbf{v} \) between
+        !! a basis `X` of `abstract_vector` and `v`, a single `abstract_vector`.
+        class(abstract_vector_rdp), intent(in) :: X(:), y
+        !! Bases of `abstract_vector` whose inner products need to be computed.
+        real(dp), intent(out) :: v(size(X))
+        !! Resulting inner-product vector.
+
+        ! Local variables.
+        integer :: i
+
+        v = 0.0_dp
+        do i = 1, size(X)
+            v(i) = X(i)%dot(y)
+        enddo
+        
+        return
+    end subroutine innerprod_vector_rdp
 
     subroutine innerprod_matrix_rdp(M, X, Y)
         !! Computes the inner product matrix \( \mathbf{M} = \mathbf{X}^H \mathbf{Y} \) between
@@ -862,6 +904,25 @@ contains
         return
     end subroutine linear_combination_matrix_csp
 
+    subroutine innerprod_vector_csp(v, X, y)
+        !! Computes the inner product vector \( \mathbf{v} = \mathbf{X}^H \mathbf{v} \) between
+        !! a basis `X` of `abstract_vector` and `v`, a single `abstract_vector`.
+        class(abstract_vector_csp), intent(in) :: X(:), y
+        !! Bases of `abstract_vector` whose inner products need to be computed.
+        complex(sp), intent(out) :: v(size(X))
+        !! Resulting inner-product vector.
+
+        ! Local variables.
+        integer :: i
+
+        v = 0.0_sp
+        do i = 1, size(X)
+            v(i) = X(i)%dot(y)
+        enddo
+        
+        return
+    end subroutine innerprod_vector_csp
+
     subroutine innerprod_matrix_csp(M, X, Y)
         !! Computes the inner product matrix \( \mathbf{M} = \mathbf{X}^H \mathbf{Y} \) between
         !! two bases of `abstract_vector`.
@@ -1005,6 +1066,25 @@ contains
 
         return
     end subroutine linear_combination_matrix_cdp
+
+    subroutine innerprod_vector_cdp(v, X, y)
+        !! Computes the inner product vector \( \mathbf{v} = \mathbf{X}^H \mathbf{v} \) between
+        !! a basis `X` of `abstract_vector` and `v`, a single `abstract_vector`.
+        class(abstract_vector_cdp), intent(in) :: X(:), y
+        !! Bases of `abstract_vector` whose inner products need to be computed.
+        complex(dp), intent(out) :: v(size(X))
+        !! Resulting inner-product vector.
+
+        ! Local variables.
+        integer :: i
+
+        v = 0.0_dp
+        do i = 1, size(X)
+            v(i) = X(i)%dot(y)
+        enddo
+        
+        return
+    end subroutine innerprod_vector_cdp
 
     subroutine innerprod_matrix_cdp(M, X, Y)
         !! Computes the inner product matrix \( \mathbf{M} = \mathbf{X}^H \mathbf{Y} \) between

--- a/src/AbstractVectors.f90
+++ b/src/AbstractVectors.f90
@@ -2,7 +2,8 @@ module lightkrylov_AbstractVectors
     use lightkrylov_constants
     use lightkrylov_utils
     implicit none
-    private
+
+    character*128, parameter, private :: this_module = 'Lightkrylov_AbstractVectors'
 
     public :: innerprod
     public :: linear_combination

--- a/src/AbstractVectors.fypp
+++ b/src/AbstractVectors.fypp
@@ -6,14 +6,15 @@ module lightkrylov_AbstractVectors
     implicit none
     private
 
-    public :: innerprod_matrix
+    public :: innerprod
     public :: linear_combination
     public :: axpby_basis
     public :: zero_basis
     public :: copy_basis
 
-    interface innerprod_matrix
+    interface innerprod
         #:for kind, type in RC_KINDS_TYPES
+        module procedure innerprod_vector_${type[0]}$${kind}$
         module procedure innerprod_matrix_${type[0]}$${kind}$
         #:endfor
     end interface
@@ -260,6 +261,25 @@ contains
 
         return
     end subroutine linear_combination_matrix_${type[0]}$${kind}$
+
+    subroutine innerprod_vector_${type[0]}$${kind}$(v, X, y)
+        !! Computes the inner product vector \( \mathbf{v} = \mathbf{X}^H \mathbf{v} \) between
+        !! a basis `X` of `abstract_vector` and `v`, a single `abstract_vector`.
+        class(abstract_vector_${type[0]}$${kind}$), intent(in) :: X(:), y
+        !! Bases of `abstract_vector` whose inner products need to be computed.
+        ${type}$, intent(out) :: v(size(X))
+        !! Resulting inner-product vector.
+
+        ! Local variables.
+        integer :: i
+
+        v = 0.0_${kind}$
+        do i = 1, size(X)
+            v(i) = X(i)%dot(y)
+        enddo
+        
+        return
+    end subroutine innerprod_vector_${type[0]}$${kind}$
 
     subroutine innerprod_matrix_${type[0]}$${kind}$(M, X, Y)
         !! Computes the inner product matrix \( \mathbf{M} = \mathbf{X}^H \mathbf{Y} \) between

--- a/src/AbstractVectors.fypp
+++ b/src/AbstractVectors.fypp
@@ -56,75 +56,75 @@ module lightkrylov_AbstractVectors
 
 
 
-    #:for k1, t1 in RC_KINDS_TYPES
+    #:for kind, type in RC_KINDS_TYPES
     !----------------------------------------------------------------------------
-    !-----     Definition of an abstract ${t1}$ vector with kind=${k1}$     -----
+    !-----     Definition of an abstract ${type}$ vector with kind=${kind}$     -----
     !----------------------------------------------------------------------------
 
-    type, abstract, extends(abstract_vector), public :: abstract_vector_${t1[0]}$${k1}$
+    type, abstract, extends(abstract_vector), public :: abstract_vector_${type[0]}$${kind}$
     contains
         private
-        procedure(abstract_zero_${t1[0]}$${k1}$), pass(self), deferred, public :: zero
-        !! Sets and `abstract_vector_${t1[0]}$${k1}$` to zero.
-        procedure(abstract_rand_${t1[0]}$${k1}$), pass(self), deferred, public :: rand
-        !! Creates a random `abstract_vector_${t1[0]}$${k1}$.
-        procedure(abstract_scal_${t1[0]}$${k1}$), pass(self), deferred, public :: scal
+        procedure(abstract_zero_${type[0]}$${kind}$), pass(self), deferred, public :: zero
+        !! Sets and `abstract_vector_${type[0]}$${kind}$` to zero.
+        procedure(abstract_rand_${type[0]}$${kind}$), pass(self), deferred, public :: rand
+        !! Creates a random `abstract_vector_${type[0]}$${kind}$.
+        procedure(abstract_scal_${type[0]}$${kind}$), pass(self), deferred, public :: scal
         !! Compute the scalar-vector product.
-        procedure(abstract_axpby_${t1[0]}$${k1}$), pass(self), deferred, public :: axpby
+        procedure(abstract_axpby_${type[0]}$${kind}$), pass(self), deferred, public :: axpby
         !! In-place computation of \( \mathbf{x} = \alpha \mathbf{x} + \beta \mathbf{y} \).
-        procedure(abstract_dot_${t1[0]}$${k1}$), pass(self), deferred, public :: dot
-        !! Computes the dot product between two `abstract_vector_${t1[0]}$${k1}$`.
-        procedure, pass(self), public :: norm => norm_${t1[0]}$${k1}$
+        procedure(abstract_dot_${type[0]}$${kind}$), pass(self), deferred, public :: dot
+        !! Computes the dot product between two `abstract_vector_${type[0]}$${kind}$`.
+        procedure, pass(self), public :: norm => norm_${type[0]}$${kind}$
         !! Computes the norm of the `abstract_vector`.
-        procedure, pass(self), public :: add => add_${t1[0]}$${k1}$
+        procedure, pass(self), public :: add => add_${type[0]}$${kind}$
         !! Adds two `abstract_vector`.
-        procedure, pass(self), public :: sub => sub_${t1[0]}$${k1}$
+        procedure, pass(self), public :: sub => sub_${type[0]}$${kind}$
         !! Subtracts two `abstract_vector`.
-        procedure, pass(self), public :: chsgn => chsgn_${t1[0]}$${k1}$
+        procedure, pass(self), public :: chsgn => chsgn_${type[0]}$${kind}$
     end type
 
     abstract interface
-        subroutine abstract_zero_${t1[0]}$${k1}$(self)
+        subroutine abstract_zero_${type[0]}$${kind}$(self)
             !! Abstract interface to zero-out a vector in-place.
-            import abstract_vector_${t1[0]}$${k1}$, ${k1}$
-            class(abstract_vector_${t1[0]}$${k1}$), intent(inout) :: self
+            import abstract_vector_${type[0]}$${kind}$, ${kind}$
+            class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: self
             !! Vector to be zeroed-out.
-        end subroutine abstract_zero_${t1[0]}$${k1}$
+        end subroutine abstract_zero_${type[0]}$${kind}$
 
-        subroutine abstract_rand_${t1[0]}$${k1}$(self, ifnorm)
+        subroutine abstract_rand_${type[0]}$${kind}$(self, ifnorm)
             !! Abstract interface to generate a random (normalized) vector.
-            import abstract_vector_${t1[0]}$${k1}$, ${k1}$
-            class(abstract_vector_${t1[0]}$${k1}$), intent(inout) :: self
+            import abstract_vector_${type[0]}$${kind}$, ${kind}$
+            class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: self
             logical, optional, intent(in) :: ifnorm
-        end subroutine abstract_rand_${t1[0]}$${k1}$
+        end subroutine abstract_rand_${type[0]}$${kind}$
 
-        subroutine abstract_scal_${t1[0]}$${k1}$(self, alpha)
+        subroutine abstract_scal_${type[0]}$${kind}$(self, alpha)
             !! Abstract interface to scale a vector.
-            import abstract_vector_${t1[0]}$${k1}$, ${k1}$
-            class(abstract_vector_${t1[0]}$${k1}$), intent(inout) :: self
+            import abstract_vector_${type[0]}$${kind}$, ${kind}$
+            class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: self
             !! Input/Output vector.
-            ${t1}$, intent(in) :: alpha
+            ${type}$, intent(in) :: alpha
             !! Scaling factor.
-        end subroutine abstract_scal_${t1[0]}$${k1}$
+        end subroutine abstract_scal_${type[0]}$${kind}$
 
-        subroutine abstract_axpby_${t1[0]}$${k1}$(self, alpha, vec, beta)
+        subroutine abstract_axpby_${type[0]}$${kind}$(self, alpha, vec, beta)
             !! Abstract interface to add/scale two vectors in-place.
-            import abstract_vector_${t1[0]}$${k1}$, ${k1}$
-            class(abstract_vector_${t1[0]}$${k1}$), intent(inout) :: self
+            import abstract_vector_${type[0]}$${kind}$, ${kind}$
+            class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: self
             !! Input/Output vector.
-            class(abstract_vector_${t1[0]}$${k1}$), intent(in) :: vec
+            class(abstract_vector_${type[0]}$${kind}$), intent(in) :: vec
             !! Vector to be added/subtracted.
-            ${t1}$, intent(in) :: alpha, beta
-        end subroutine abstract_axpby_${t1[0]}$${k1}$
+            ${type}$, intent(in) :: alpha, beta
+        end subroutine abstract_axpby_${type[0]}$${kind}$
 
-        function abstract_dot_${t1[0]}$${k1}$(self, vec) result(alpha)
+        function abstract_dot_${type[0]}$${kind}$(self, vec) result(alpha)
             !! Abstract interface to compute the dot product.
-            import abstract_vector_${t1[0]}$${k1}$, ${k1}$
-            class(abstract_vector_${t1[0]}$${k1}$), intent(in) :: self, vec
+            import abstract_vector_${type[0]}$${kind}$, ${kind}$
+            class(abstract_vector_${type[0]}$${kind}$), intent(in) :: self, vec
             !! Vectors whose dot product will be computed.
-            ${t1}$ :: alpha
+            ${type}$ :: alpha
             !! Result of the dot product.
-        end function abstract_dot_${t1[0]}$${k1}$
+        end function abstract_dot_${type[0]}$${kind}$
     end interface
 
 
@@ -142,52 +142,52 @@ contains
         return
     end subroutine copy_vec
 
-    #:for k1, t1 in RC_KINDS_TYPES
-    function norm_${t1[0]}$${k1}$(self) result(alpha)
+    #:for kind, type in RC_KINDS_TYPES
+    function norm_${type[0]}$${kind}$(self) result(alpha)
         !! Compute the norm of an `abstract_vector`.
-        class(abstract_vector_${t1[0]}$${k1}$), intent(in) :: self
+        class(abstract_vector_${type[0]}$${kind}$), intent(in) :: self
         !! Vector whose norm needs to be computed.
-        real(${k1}$) :: alpha
+        real(${kind}$) :: alpha
         !! Norm of the vector.
         alpha = abs(self%dot(self)) ; alpha = sqrt(alpha)
-    end function norm_${t1[0]}$${k1}$
+    end function norm_${type[0]}$${kind}$
 
-    subroutine sub_${t1[0]}$${k1}$(self, vec)
+    subroutine sub_${type[0]}$${kind}$(self, vec)
         !! Subtract two `abstract_vector` in-place.
-        class(abstract_vector_${t1[0]}$${k1}$), intent(inout) :: self
+        class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: self
         !! Input/Output vector.
-        class(abstract_vector_${t1[0]}$${k1}$), intent(in) :: vec
+        class(abstract_vector_${type[0]}$${kind}$), intent(in) :: vec
         !! Vector to be added.
-        #:if t1[0] == "c"
-        call self%axpby(cmplx(1.0_${k1}$, 0.0_${k1}$, kind=${k1}$), vec, cmplx(-1.0_${k1}$, 0.0_${k1}$, kind=${k1}$))
+        #:if type[0] == "c"
+        call self%axpby(cmplx(1.0_${kind}$, 0.0_${kind}$, kind=${kind}$), vec, cmplx(-1.0_${kind}$, 0.0_${kind}$, kind=${kind}$))
         #:else
-        call self%axpby(1.0_${k1}$, vec, -1.0_${k1}$)
+        call self%axpby(1.0_${kind}$, vec, -1.0_${kind}$)
         #:endif
-    end subroutine sub_${t1[0]}$${k1}$
+    end subroutine sub_${type[0]}$${kind}$
 
-    subroutine add_${t1[0]}$${k1}$(self, vec)
+    subroutine add_${type[0]}$${kind}$(self, vec)
         !! Add two `abstract_vector` in-place.
-        class(abstract_vector_${t1[0]}$${k1}$), intent(inout) :: self
+        class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: self
         !! Input/Output vector.
-        class(abstract_vector_${t1[0]}$${k1}$), intent(in) :: vec
+        class(abstract_vector_${type[0]}$${kind}$), intent(in) :: vec
         !! Vector to be added.
-        #:if t1[0] == "c"
-        call self%axpby(cmplx(1.0_${k1}$, 0.0_${k1}$, kind=${k1}$), vec, cmplx(1.0_${k1}$, 0.0_${k1}$, kind=${k1}$))
+        #:if type[0] == "c"
+        call self%axpby(cmplx(1.0_${kind}$, 0.0_${kind}$, kind=${kind}$), vec, cmplx(1.0_${kind}$, 0.0_${kind}$, kind=${kind}$))
         #:else
-        call self%axpby(1.0_${k1}$, vec, 1.0_${k1}$)
+        call self%axpby(1.0_${kind}$, vec, 1.0_${kind}$)
         #:endif
-    end subroutine add_${t1[0]}$${k1}$
+    end subroutine add_${type[0]}$${kind}$
 
-    subroutine chsgn_${t1[0]}$${k1}$(self)
+    subroutine chsgn_${type[0]}$${kind}$(self)
         !! Changes the sign of the `abstract_vector`.
-        class(abstract_vector_${t1[0]}$${k1}$), intent(inout) :: self
+        class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: self
         !! Vector whose entries need to change sign.
-        #:if t1[0] == "c"
-        call self%scal(cmplx(-1.0_${k1}$, 0.0_${k1}$, kind=${k1}$))
+        #:if type[0] == "c"
+        call self%scal(cmplx(-1.0_${kind}$, 0.0_${kind}$, kind=${kind}$))
         #:else
-        call self%scal(-1.0_${k1}$)
+        call self%scal(-1.0_${kind}$)
         #:endif
-    end subroutine chsgn_${t1[0]}$${k1}$
+    end subroutine chsgn_${type[0]}$${kind}$
 
     #:endfor
     

--- a/src/AbstractVectors.fypp
+++ b/src/AbstractVectors.fypp
@@ -4,7 +4,8 @@ module lightkrylov_AbstractVectors
     use lightkrylov_constants
     use lightkrylov_utils
     implicit none
-    private
+
+    character*128, parameter, private :: this_module = 'Lightkrylov_AbstractVectors'
 
     public :: innerprod
     public :: linear_combination

--- a/src/BaseKrylov.f90
+++ b/src/BaseKrylov.f90
@@ -8,7 +8,7 @@ module lightkrylov_BaseKrylov
     use lightkrylov_AbstractLinops
     implicit none
     
-    private
+    character*128, parameter, private :: this_module = 'LightKrylov_BaseKrylov'
 
     public :: qr
     public :: apply_permutation_matrix
@@ -1799,7 +1799,7 @@ contains
 
             ! Orthogonalize current blk vectors.
             call qr(X(kp+1:kpp), H(kp+1:kpp, kpm+1:kp), info)
-            call check_info(info, 'qr', module='LightKrylov_BaseKrylov', procedure='arnoldi_rsp')
+            call check_info(info, 'qr', module=this_module, procedure='arnoldi_rsp')
 
             ! Extract residual norm (smallest diagonal element of H matrix).
             res = 0.0_sp
@@ -1924,7 +1924,7 @@ contains
 
             ! Orthogonalize current blk vectors.
             call qr(X(kp+1:kpp), H(kp+1:kpp, kpm+1:kp), info)
-            call check_info(info, 'qr', module='LightKrylov_BaseKrylov', procedure='arnoldi_rdp')
+            call check_info(info, 'qr', module=this_module, procedure='arnoldi_rdp')
 
             ! Extract residual norm (smallest diagonal element of H matrix).
             res = 0.0_dp
@@ -2049,7 +2049,7 @@ contains
 
             ! Orthogonalize current blk vectors.
             call qr(X(kp+1:kpp), H(kp+1:kpp, kpm+1:kp), info)
-            call check_info(info, 'qr', module='LightKrylov_BaseKrylov', procedure='arnoldi_csp')
+            call check_info(info, 'qr', module=this_module, procedure='arnoldi_csp')
 
             ! Extract residual norm (smallest diagonal element of H matrix).
             res = 0.0_sp
@@ -2174,7 +2174,7 @@ contains
 
             ! Orthogonalize current blk vectors.
             call qr(X(kp+1:kpp), H(kp+1:kpp, kpm+1:kp), info)
-            call check_info(info, 'qr', module='LightKrylov_BaseKrylov', procedure='arnoldi_cdp')
+            call check_info(info, 'qr', module=this_module, procedure='arnoldi_cdp')
 
             ! Extract residual norm (smallest diagonal element of H matrix).
             res = 0.0_dp

--- a/src/BaseKrylov.f90
+++ b/src/BaseKrylov.f90
@@ -139,7 +139,7 @@ contains
             enddo
     
             ! Orthonormalize.
-            allocate(R(1:p, 1:p)) ; R = 0.0_sp
+            allocate(R(1:p, 1:p)) ; R = zero_rsp
             allocate(perm(1:p)) ; perm = 0
             call qr(Q, R, perm, info)
             do i = 1, p
@@ -163,7 +163,7 @@ contains
       real(sp) :: alpha
 
       ! check for zero vector
-      if (y%norm() < atol_dp) then
+      if (y%norm() < atol_sp) then
          write(msg, *) 'The input vector is (numerically) zero.'
          call logger%log_error(trim(msg), module=this_module, procedure='orthonormalize_vector_against_basis_rsp', &
                               & stat=-1, errmsg='Cannot orthonormalize.')
@@ -181,11 +181,11 @@ contains
       alpha = y%norm()
       call y%scal(one_rsp / alpha)
 
-      if (alpha < atol_dp) then ! error
+      if (alpha < atol_sp) then ! error
          write(msg, *) 'The input vector is in the span of X.'
          call logger%log_error(trim(msg), module=this_module, procedure='orthonormalize_vector_against_basis_rsp', & 
                               & stat=-2, errmsg='Cannot orthonormalize.')
-      else if (alpha < rtol_dp) then ! repeat to avoid floating point errors
+      else if (alpha < rtol_sp) then ! repeat to avoid floating point errors
          write(msg, *) 'The norm of the component of y in the orthogonal complement of X is ||y||_orth = ', &
                         & alpha, ': The input vector is nearly in the span of X. ', &
                         & 'Repeating orthonormalisation.'
@@ -219,7 +219,7 @@ contains
 
       ! check for zero vector
       do i = 1, size(Y)
-         if ( Y(i)%norm() < atol_dp) then
+         if ( Y(i)%norm() < atol_sp) then
             write(msg, *) 'Zero vector detected in input basis, column ', i
             call logger%log_error(trim(msg), module=this_module, &
                                  & procedure='orthonormalize_basis_against_basis_rsp', & 
@@ -228,7 +228,7 @@ contains
       end do
 
       ! check for colinear vectors
-      R = 0.0_sp
+      R = zero_rsp
       call qr(Y, R, info)
       call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_against_basis_rsp')
       if (info > 0) then ! colinear vectors!
@@ -247,7 +247,7 @@ contains
       end block
 
       do i = 1, size(Y)
-         if ( Y(i)%norm() < atol_dp) then ! error
+         if ( Y(i)%norm() < atol_sp) then ! error
             write(msg, *) 'The input vector', i, 'is in the span of X.'
             call logger%log_error(trim(msg), module=this_module, &
                                  & procedure='orthonormalize_basis_against_basis_rsp', & 
@@ -256,7 +256,7 @@ contains
       end do
          
       ! normalize
-      R = 0.0_sp
+      R = zero_rsp
       call qr(Y, R, info)
       call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_against_basis_rsp')
       
@@ -290,7 +290,7 @@ contains
             enddo
     
             ! Orthonormalize.
-            allocate(R(1:p, 1:p)) ; R = 0.0_dp
+            allocate(R(1:p, 1:p)) ; R = zero_rdp
             allocate(perm(1:p)) ; perm = 0
             call qr(Q, R, perm, info)
             do i = 1, p
@@ -379,7 +379,7 @@ contains
       end do
 
       ! check for colinear vectors
-      R = 0.0_dp
+      R = zero_rdp
       call qr(Y, R, info)
       call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_against_basis_rdp')
       if (info > 0) then ! colinear vectors!
@@ -407,7 +407,7 @@ contains
       end do
          
       ! normalize
-      R = 0.0_dp
+      R = zero_rdp
       call qr(Y, R, info)
       call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_against_basis_rdp')
       
@@ -441,7 +441,7 @@ contains
             enddo
     
             ! Orthonormalize.
-            allocate(R(1:p, 1:p)) ; R = 0.0_sp
+            allocate(R(1:p, 1:p)) ; R = zero_rsp
             allocate(perm(1:p)) ; perm = 0
             call qr(Q, R, perm, info)
             do i = 1, p
@@ -465,7 +465,7 @@ contains
       real(sp) :: alpha
 
       ! check for zero vector
-      if (y%norm() < atol_dp) then
+      if (y%norm() < atol_sp) then
          write(msg, *) 'The input vector is (numerically) zero.'
          call logger%log_error(trim(msg), module=this_module, procedure='orthonormalize_vector_against_basis_csp', &
                               & stat=-1, errmsg='Cannot orthonormalize.')
@@ -483,11 +483,11 @@ contains
       alpha = y%norm()
       call y%scal(one_csp / alpha)
 
-      if (alpha < atol_dp) then ! error
+      if (alpha < atol_sp) then ! error
          write(msg, *) 'The input vector is in the span of X.'
          call logger%log_error(trim(msg), module=this_module, procedure='orthonormalize_vector_against_basis_csp', & 
                               & stat=-2, errmsg='Cannot orthonormalize.')
-      else if (alpha < rtol_dp) then ! repeat to avoid floating point errors
+      else if (alpha < rtol_sp) then ! repeat to avoid floating point errors
          write(msg, *) 'The norm of the component of y in the orthogonal complement of X is ||y||_orth = ', &
                         & alpha, ': The input vector is nearly in the span of X. ', &
                         & 'Repeating orthonormalisation.'
@@ -521,7 +521,7 @@ contains
 
       ! check for zero vector
       do i = 1, size(Y)
-         if ( Y(i)%norm() < atol_dp) then
+         if ( Y(i)%norm() < atol_sp) then
             write(msg, *) 'Zero vector detected in input basis, column ', i
             call logger%log_error(trim(msg), module=this_module, &
                                  & procedure='orthonormalize_basis_against_basis_csp', & 
@@ -530,7 +530,7 @@ contains
       end do
 
       ! check for colinear vectors
-      R = 0.0_sp
+      R = zero_rsp
       call qr(Y, R, info)
       call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_against_basis_csp')
       if (info > 0) then ! colinear vectors!
@@ -549,7 +549,7 @@ contains
       end block
 
       do i = 1, size(Y)
-         if ( Y(i)%norm() < atol_dp) then ! error
+         if ( Y(i)%norm() < atol_sp) then ! error
             write(msg, *) 'The input vector', i, 'is in the span of X.'
             call logger%log_error(trim(msg), module=this_module, &
                                  & procedure='orthonormalize_basis_against_basis_csp', & 
@@ -558,7 +558,7 @@ contains
       end do
          
       ! normalize
-      R = 0.0_sp
+      R = zero_rsp
       call qr(Y, R, info)
       call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_against_basis_csp')
       
@@ -592,7 +592,7 @@ contains
             enddo
     
             ! Orthonormalize.
-            allocate(R(1:p, 1:p)) ; R = 0.0_dp
+            allocate(R(1:p, 1:p)) ; R = zero_rdp
             allocate(perm(1:p)) ; perm = 0
             call qr(Q, R, perm, info)
             do i = 1, p
@@ -681,7 +681,7 @@ contains
       end do
 
       ! check for colinear vectors
-      R = 0.0_dp
+      R = zero_rdp
       call qr(Y, R, info)
       call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_against_basis_cdp')
       if (info > 0) then ! colinear vectors!
@@ -709,7 +709,7 @@ contains
       end do
          
       ! normalize
-      R = 0.0_dp
+      R = zero_rdp
       call qr(Y, R, info)
       call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_against_basis_cdp')
       
@@ -743,19 +743,19 @@ contains
         verbose   = optval(verbosity, .false.)
         tolerance = optval(tol, rtol_sp)
 
-        info = 0 ; R = 0.0_sp
+        info = 0 ; R = zero_rsp
         do j = 1, size(Q)
             ! First pass
             do i = 1, j-1
                 beta = Q(i)%dot(Q(j))
-                call Q(j)%axpby(1.0_sp, Q(i), -beta)
+                call Q(j)%axpby(one_rsp, Q(i), -beta)
                 R(i, j) = beta
             enddo
 
             ! Second pass
             do i = 1, j-1
                 beta = Q(i)%dot(Q(j))
-                call Q(j)%axpby(1.0_sp, Q(i), -beta)
+                call Q(j)%axpby(one_rsp, Q(i), -beta)
                 R(i, j) = R(i, j) + beta
             enddo
 
@@ -769,9 +769,9 @@ contains
                     write(output_unit, *) "      (j, beta) = (", j, ", ", beta, ")"
                 endif
                 info = j
-                R(i, j) = 0.0_sp ; call Q(j)%zero()
+                R(i, j) = zero_rsp ; call Q(j)%zero()
             else
-                call Q(j)%scal(1.0_sp / beta) ; R(j, j) = beta
+                call Q(j)%scal(one_rsp / beta) ; R(j, j) = beta
             endif
         enddo
 
@@ -802,7 +802,7 @@ contains
         real(sp)  :: Rii(size(Q))
 
         info = 0 ; kdim = size(Q)
-        R = 0.0_sp ; Rii = 0.0_sp
+        R = zero_rsp ; Rii = zero_rsp
         
         ! Deals with the optional arguments.
         verbose = optval(verbosity, .false.)
@@ -822,9 +822,9 @@ contains
                     ! Orthogonalize against existing columns
                     do k = 1, i-1
                         beta = Q(i)%dot(Q(k))
-                        call Q(i)%axpby(1.0_sp, Q(k), -beta)
+                        call Q(i)%axpby(one_rsp, Q(k), -beta)
                     enddo
-                    beta = Q(i)%norm() ; call Q(i)%scal(1.0_sp / beta)
+                    beta = Q(i)%norm() ; call Q(i)%scal(one_rsp / beta)
                 enddo
                 info = j
                 exit qr_step
@@ -837,20 +837,20 @@ contains
 
             if (abs(beta) < tolerance) then
                info = j
-                R(j, j) = 0.0_sp ; call Q(j)%zero()
+                R(j, j) = zero_rsp ; call Q(j)%zero()
             else
-                R(j, j) = beta ; call Q(j)%scal(1.0_sp / beta)
+                R(j, j) = beta ; call Q(j)%scal(one_rsp / beta)
             endif
 
             ! Orthonormalize all columns against new vector (MGS)
             do i = j+1, kdim
                 beta = Q(j)%dot(Q(i))
-                call Q(i)%axpby(1.0_sp, Q(j), -beta)
+                call Q(i)%axpby(one_rsp, Q(j), -beta)
                 R(j, i) = beta
             enddo
 
             ! Update Rii
-            Rii(j) = 0.0_sp
+            Rii(j) = zero_rsp
             do i = j+1, kdim
                 Rii(i) = Rii(i) - R(j, i)**2
             enddo
@@ -882,12 +882,12 @@ contains
 
         ! Allocations.
         allocate(Qwrk, source=Q(1)) ; call Qwrk%zero()
-        allocate(Rwrk(1:max(1, n))) ; Rwrk = 0.0_sp
+        allocate(Rwrk(1:max(1, n))) ; Rwrk = zero_rsp
 
         ! Swap columns.
-        call Qwrk%axpby(0.0_sp, Q(j), 1.0_sp)
-        call Q(j)%axpby(0.0_sp, Q(i), 1.0_sp)
-        call Q(i)%axpby(0.0_sp, Qwrk, 1.0_sp)
+        call Qwrk%axpby(zero_rsp, Q(j), one_rsp)
+        call Q(j)%axpby(zero_rsp, Q(i), one_rsp)
+        call Q(i)%axpby(zero_rsp, Qwrk, one_rsp)
         
         Rwrk(1) = Rii(j); Rii(j) = Rii(i); Rii(i) = Rwrk(1)
         iwrk = perm(j); perm(j) = perm(i) ; perm(i) = iwrk
@@ -1010,19 +1010,19 @@ contains
         verbose   = optval(verbosity, .false.)
         tolerance = optval(tol, rtol_dp)
 
-        info = 0 ; R = 0.0_dp
+        info = 0 ; R = zero_rdp
         do j = 1, size(Q)
             ! First pass
             do i = 1, j-1
                 beta = Q(i)%dot(Q(j))
-                call Q(j)%axpby(1.0_dp, Q(i), -beta)
+                call Q(j)%axpby(one_rdp, Q(i), -beta)
                 R(i, j) = beta
             enddo
 
             ! Second pass
             do i = 1, j-1
                 beta = Q(i)%dot(Q(j))
-                call Q(j)%axpby(1.0_dp, Q(i), -beta)
+                call Q(j)%axpby(one_rdp, Q(i), -beta)
                 R(i, j) = R(i, j) + beta
             enddo
 
@@ -1036,9 +1036,9 @@ contains
                     write(output_unit, *) "      (j, beta) = (", j, ", ", beta, ")"
                 endif
                 info = j
-                R(i, j) = 0.0_dp ; call Q(j)%zero()
+                R(i, j) = zero_rdp ; call Q(j)%zero()
             else
-                call Q(j)%scal(1.0_dp / beta) ; R(j, j) = beta
+                call Q(j)%scal(one_rdp / beta) ; R(j, j) = beta
             endif
         enddo
 
@@ -1069,7 +1069,7 @@ contains
         real(dp)  :: Rii(size(Q))
 
         info = 0 ; kdim = size(Q)
-        R = 0.0_dp ; Rii = 0.0_dp
+        R = zero_rdp ; Rii = zero_rdp
         
         ! Deals with the optional arguments.
         verbose = optval(verbosity, .false.)
@@ -1089,9 +1089,9 @@ contains
                     ! Orthogonalize against existing columns
                     do k = 1, i-1
                         beta = Q(i)%dot(Q(k))
-                        call Q(i)%axpby(1.0_dp, Q(k), -beta)
+                        call Q(i)%axpby(one_rdp, Q(k), -beta)
                     enddo
-                    beta = Q(i)%norm() ; call Q(i)%scal(1.0_dp / beta)
+                    beta = Q(i)%norm() ; call Q(i)%scal(one_rdp / beta)
                 enddo
                 info = j
                 exit qr_step
@@ -1104,20 +1104,20 @@ contains
 
             if (abs(beta) < tolerance) then
                info = j
-                R(j, j) = 0.0_dp ; call Q(j)%zero()
+                R(j, j) = zero_rdp ; call Q(j)%zero()
             else
-                R(j, j) = beta ; call Q(j)%scal(1.0_dp / beta)
+                R(j, j) = beta ; call Q(j)%scal(one_rdp / beta)
             endif
 
             ! Orthonormalize all columns against new vector (MGS)
             do i = j+1, kdim
                 beta = Q(j)%dot(Q(i))
-                call Q(i)%axpby(1.0_dp, Q(j), -beta)
+                call Q(i)%axpby(one_rdp, Q(j), -beta)
                 R(j, i) = beta
             enddo
 
             ! Update Rii
-            Rii(j) = 0.0_dp
+            Rii(j) = zero_rdp
             do i = j+1, kdim
                 Rii(i) = Rii(i) - R(j, i)**2
             enddo
@@ -1149,12 +1149,12 @@ contains
 
         ! Allocations.
         allocate(Qwrk, source=Q(1)) ; call Qwrk%zero()
-        allocate(Rwrk(1:max(1, n))) ; Rwrk = 0.0_dp
+        allocate(Rwrk(1:max(1, n))) ; Rwrk = zero_rdp
 
         ! Swap columns.
-        call Qwrk%axpby(0.0_dp, Q(j), 1.0_dp)
-        call Q(j)%axpby(0.0_dp, Q(i), 1.0_dp)
-        call Q(i)%axpby(0.0_dp, Qwrk, 1.0_dp)
+        call Qwrk%axpby(zero_rdp, Q(j), one_rdp)
+        call Q(j)%axpby(zero_rdp, Q(i), one_rdp)
+        call Q(i)%axpby(zero_rdp, Qwrk, one_rdp)
         
         Rwrk(1) = Rii(j); Rii(j) = Rii(i); Rii(i) = Rwrk(1)
         iwrk = perm(j); perm(j) = perm(i) ; perm(i) = iwrk
@@ -1277,19 +1277,19 @@ contains
         verbose   = optval(verbosity, .false.)
         tolerance = optval(tol, rtol_sp)
 
-        info = 0 ; R = 0.0_sp
+        info = 0 ; R = zero_rsp
         do j = 1, size(Q)
             ! First pass
             do i = 1, j-1
                 beta = Q(i)%dot(Q(j))
-                call Q(j)%axpby(cmplx(1.0_sp, 0.0_sp, kind=sp), Q(i), -beta)
+                call Q(j)%axpby(one_csp, Q(i), -beta)
                 R(i, j) = beta
             enddo
 
             ! Second pass
             do i = 1, j-1
                 beta = Q(i)%dot(Q(j))
-                call Q(j)%axpby(cmplx(1.0_sp, 0.0_sp, kind=sp), Q(i), -beta)
+                call Q(j)%axpby(one_csp, Q(i), -beta)
                 R(i, j) = R(i, j) + beta
             enddo
 
@@ -1303,9 +1303,9 @@ contains
                     write(output_unit, *) "      (j, beta) = (", j, ", ", beta, ")"
                 endif
                 info = j
-                R(i, j) = 0.0_sp ; call Q(j)%zero()
+                R(i, j) = zero_rsp ; call Q(j)%zero()
             else
-                call Q(j)%scal(1.0_sp / beta) ; R(j, j) = beta
+                call Q(j)%scal(one_rsp / beta) ; R(j, j) = beta
             endif
         enddo
 
@@ -1336,7 +1336,7 @@ contains
         complex(sp)  :: Rii(size(Q))
 
         info = 0 ; kdim = size(Q)
-        R = 0.0_sp ; Rii = 0.0_sp
+        R = zero_rsp ; Rii = zero_rsp
         
         ! Deals with the optional arguments.
         verbose = optval(verbosity, .false.)
@@ -1356,9 +1356,9 @@ contains
                     ! Orthogonalize against existing columns
                     do k = 1, i-1
                         beta = Q(i)%dot(Q(k))
-                        call Q(i)%axpby(cmplx(1.0_sp, 0.0_sp, kind=sp), Q(k), -beta)
+                        call Q(i)%axpby(one_csp, Q(k), -beta)
                     enddo
-                    beta = Q(i)%norm() ; call Q(i)%scal(1.0_sp / beta)
+                    beta = Q(i)%norm() ; call Q(i)%scal(one_rsp / beta)
                 enddo
                 info = j
                 exit qr_step
@@ -1371,20 +1371,20 @@ contains
 
             if (abs(beta) < tolerance) then
                info = j
-                R(j, j) = 0.0_sp ; call Q(j)%zero()
+                R(j, j) = zero_rsp ; call Q(j)%zero()
             else
-                R(j, j) = beta ; call Q(j)%scal(1.0_sp / beta)
+                R(j, j) = beta ; call Q(j)%scal(one_rsp / beta)
             endif
 
             ! Orthonormalize all columns against new vector (MGS)
             do i = j+1, kdim
                 beta = Q(j)%dot(Q(i))
-                call Q(i)%axpby(cmplx(1.0_sp, 0.0_sp, kind=sp), Q(j), -beta)
+                call Q(i)%axpby(one_csp, Q(j), -beta)
                 R(j, i) = beta
             enddo
 
             ! Update Rii
-            Rii(j) = 0.0_sp
+            Rii(j) = zero_rsp
             do i = j+1, kdim
                 Rii(i) = Rii(i) - R(j, i)**2
             enddo
@@ -1416,12 +1416,12 @@ contains
 
         ! Allocations.
         allocate(Qwrk, source=Q(1)) ; call Qwrk%zero()
-        allocate(Rwrk(1:max(1, n))) ; Rwrk = 0.0_sp
+        allocate(Rwrk(1:max(1, n))) ; Rwrk = zero_rsp
 
         ! Swap columns.
-        call Qwrk%axpby(cmplx(0.0_sp, 0.0_sp, kind=sp), Q(j), cmplx(1.0_sp, 0.0_sp, kind=sp))
-        call Q(j)%axpby(cmplx(0.0_sp, 0.0_sp, kind=sp), Q(i), cmplx(1.0_sp, 0.0_sp, kind=sp))
-        call Q(i)%axpby(cmplx(0.0_sp, 0.0_sp, kind=sp), Qwrk, cmplx(1.0_sp, 0.0_sp, kind=sp))
+        call Qwrk%axpby(zero_csp, Q(j), one_csp)
+        call Q(j)%axpby(zero_csp, Q(i), one_csp)
+        call Q(i)%axpby(zero_csp, Qwrk, one_csp)
         
         Rwrk(1) = Rii(j); Rii(j) = Rii(i); Rii(i) = Rwrk(1)
         iwrk = perm(j); perm(j) = perm(i) ; perm(i) = iwrk
@@ -1544,19 +1544,19 @@ contains
         verbose   = optval(verbosity, .false.)
         tolerance = optval(tol, rtol_dp)
 
-        info = 0 ; R = 0.0_dp
+        info = 0 ; R = zero_rdp
         do j = 1, size(Q)
             ! First pass
             do i = 1, j-1
                 beta = Q(i)%dot(Q(j))
-                call Q(j)%axpby(cmplx(1.0_dp, 0.0_dp, kind=dp), Q(i), -beta)
+                call Q(j)%axpby(one_cdp, Q(i), -beta)
                 R(i, j) = beta
             enddo
 
             ! Second pass
             do i = 1, j-1
                 beta = Q(i)%dot(Q(j))
-                call Q(j)%axpby(cmplx(1.0_dp, 0.0_dp, kind=dp), Q(i), -beta)
+                call Q(j)%axpby(one_cdp, Q(i), -beta)
                 R(i, j) = R(i, j) + beta
             enddo
 
@@ -1570,9 +1570,9 @@ contains
                     write(output_unit, *) "      (j, beta) = (", j, ", ", beta, ")"
                 endif
                 info = j
-                R(i, j) = 0.0_dp ; call Q(j)%zero()
+                R(i, j) = zero_rdp ; call Q(j)%zero()
             else
-                call Q(j)%scal(1.0_dp / beta) ; R(j, j) = beta
+                call Q(j)%scal(one_rdp / beta) ; R(j, j) = beta
             endif
         enddo
 
@@ -1603,7 +1603,7 @@ contains
         complex(dp)  :: Rii(size(Q))
 
         info = 0 ; kdim = size(Q)
-        R = 0.0_dp ; Rii = 0.0_dp
+        R = zero_rdp ; Rii = zero_rdp
         
         ! Deals with the optional arguments.
         verbose = optval(verbosity, .false.)
@@ -1623,9 +1623,9 @@ contains
                     ! Orthogonalize against existing columns
                     do k = 1, i-1
                         beta = Q(i)%dot(Q(k))
-                        call Q(i)%axpby(cmplx(1.0_dp, 0.0_dp, kind=dp), Q(k), -beta)
+                        call Q(i)%axpby(one_cdp, Q(k), -beta)
                     enddo
-                    beta = Q(i)%norm() ; call Q(i)%scal(1.0_dp / beta)
+                    beta = Q(i)%norm() ; call Q(i)%scal(one_rdp / beta)
                 enddo
                 info = j
                 exit qr_step
@@ -1638,20 +1638,20 @@ contains
 
             if (abs(beta) < tolerance) then
                info = j
-                R(j, j) = 0.0_dp ; call Q(j)%zero()
+                R(j, j) = zero_rdp ; call Q(j)%zero()
             else
-                R(j, j) = beta ; call Q(j)%scal(1.0_dp / beta)
+                R(j, j) = beta ; call Q(j)%scal(one_rdp / beta)
             endif
 
             ! Orthonormalize all columns against new vector (MGS)
             do i = j+1, kdim
                 beta = Q(j)%dot(Q(i))
-                call Q(i)%axpby(cmplx(1.0_dp, 0.0_dp, kind=dp), Q(j), -beta)
+                call Q(i)%axpby(one_cdp, Q(j), -beta)
                 R(j, i) = beta
             enddo
 
             ! Update Rii
-            Rii(j) = 0.0_dp
+            Rii(j) = zero_rdp
             do i = j+1, kdim
                 Rii(i) = Rii(i) - R(j, i)**2
             enddo
@@ -1683,12 +1683,12 @@ contains
 
         ! Allocations.
         allocate(Qwrk, source=Q(1)) ; call Qwrk%zero()
-        allocate(Rwrk(1:max(1, n))) ; Rwrk = 0.0_dp
+        allocate(Rwrk(1:max(1, n))) ; Rwrk = zero_rdp
 
         ! Swap columns.
-        call Qwrk%axpby(cmplx(0.0_dp, 0.0_dp, kind=dp), Q(j), cmplx(1.0_dp, 0.0_dp, kind=dp))
-        call Q(j)%axpby(cmplx(0.0_dp, 0.0_dp, kind=dp), Q(i), cmplx(1.0_dp, 0.0_dp, kind=dp))
-        call Q(i)%axpby(cmplx(0.0_dp, 0.0_dp, kind=dp), Qwrk, cmplx(1.0_dp, 0.0_dp, kind=dp))
+        call Qwrk%axpby(zero_cdp, Q(j), one_cdp)
+        call Q(j)%axpby(zero_cdp, Q(i), one_cdp)
+        call Q(i)%axpby(zero_cdp, Qwrk, one_cdp)
         
         Rwrk(1) = Rii(j); Rii(j) = Rii(i); Rii(i) = Rwrk(1)
         iwrk = perm(j); perm(j) = perm(i) ; perm(i) = iwrk
@@ -1826,7 +1826,7 @@ contains
         integer :: k, i, kdim, kpm, kp, kpp
 
         ! Deals with optional non-unity blksize and allocations.
-        p = optval(blksize, 1) ; allocate(res(1:p)) ; res = 0.0_sp
+        p = optval(blksize, 1) ; allocate(res(1:p)) ; res = zero_rsp
         allocate(perm(1:size(H, 2))) ; perm = 0 ; info = 0
 
         ! Check dimensions.
@@ -1862,7 +1862,7 @@ contains
             call check_info(info, 'qr', module=this_module, procedure='arnoldi_rsp')
 
             ! Extract residual norm (smallest diagonal element of H matrix).
-            res = 0.0_sp
+            res = zero_rsp
             do i = 1, p
                 res(i) = H(kp+i, kpm+i)
             enddo
@@ -1896,7 +1896,7 @@ contains
 
         ! Counters and allocations.
         kpm = (k - 1) * p ; kp = kpm + p ; kpp = kp + p
-        allocate(wrk(1:kp, 1:p)) ; wrk = 0.0_sp
+        allocate(wrk(1:kp, 1:p)) ; wrk = zero_rsp
 
         ! Orthogonalize residual vector w.r.t. to previous computed Krylov vectors.
         call innerprod(H(1:kp, kpm+1:kp), X(1:kp), X(kp+1:kpp))
@@ -1951,7 +1951,7 @@ contains
         integer :: k, i, kdim, kpm, kp, kpp
 
         ! Deals with optional non-unity blksize and allocations.
-        p = optval(blksize, 1) ; allocate(res(1:p)) ; res = 0.0_dp
+        p = optval(blksize, 1) ; allocate(res(1:p)) ; res = zero_rdp
         allocate(perm(1:size(H, 2))) ; perm = 0 ; info = 0
 
         ! Check dimensions.
@@ -1987,7 +1987,7 @@ contains
             call check_info(info, 'qr', module=this_module, procedure='arnoldi_rdp')
 
             ! Extract residual norm (smallest diagonal element of H matrix).
-            res = 0.0_dp
+            res = zero_rdp
             do i = 1, p
                 res(i) = H(kp+i, kpm+i)
             enddo
@@ -2021,7 +2021,7 @@ contains
 
         ! Counters and allocations.
         kpm = (k - 1) * p ; kp = kpm + p ; kpp = kp + p
-        allocate(wrk(1:kp, 1:p)) ; wrk = 0.0_dp
+        allocate(wrk(1:kp, 1:p)) ; wrk = zero_rdp
 
         ! Orthogonalize residual vector w.r.t. to previous computed Krylov vectors.
         call innerprod(H(1:kp, kpm+1:kp), X(1:kp), X(kp+1:kpp))
@@ -2076,7 +2076,7 @@ contains
         integer :: k, i, kdim, kpm, kp, kpp
 
         ! Deals with optional non-unity blksize and allocations.
-        p = optval(blksize, 1) ; allocate(res(1:p)) ; res = 0.0_sp
+        p = optval(blksize, 1) ; allocate(res(1:p)) ; res = zero_rsp
         allocate(perm(1:size(H, 2))) ; perm = 0 ; info = 0
 
         ! Check dimensions.
@@ -2112,7 +2112,7 @@ contains
             call check_info(info, 'qr', module=this_module, procedure='arnoldi_csp')
 
             ! Extract residual norm (smallest diagonal element of H matrix).
-            res = 0.0_sp
+            res = zero_rsp
             do i = 1, p
                 res(i) = H(kp+i, kpm+i)
             enddo
@@ -2146,7 +2146,7 @@ contains
 
         ! Counters and allocations.
         kpm = (k - 1) * p ; kp = kpm + p ; kpp = kp + p
-        allocate(wrk(1:kp, 1:p)) ; wrk = 0.0_sp
+        allocate(wrk(1:kp, 1:p)) ; wrk = zero_rsp
 
         ! Orthogonalize residual vector w.r.t. to previous computed Krylov vectors.
         call innerprod(H(1:kp, kpm+1:kp), X(1:kp), X(kp+1:kpp))
@@ -2201,7 +2201,7 @@ contains
         integer :: k, i, kdim, kpm, kp, kpp
 
         ! Deals with optional non-unity blksize and allocations.
-        p = optval(blksize, 1) ; allocate(res(1:p)) ; res = 0.0_dp
+        p = optval(blksize, 1) ; allocate(res(1:p)) ; res = zero_rdp
         allocate(perm(1:size(H, 2))) ; perm = 0 ; info = 0
 
         ! Check dimensions.
@@ -2237,7 +2237,7 @@ contains
             call check_info(info, 'qr', module=this_module, procedure='arnoldi_cdp')
 
             ! Extract residual norm (smallest diagonal element of H matrix).
-            res = 0.0_dp
+            res = zero_rdp
             do i = 1, p
                 res(i) = H(kp+i, kpm+i)
             enddo
@@ -2271,7 +2271,7 @@ contains
 
         ! Counters and allocations.
         kpm = (k - 1) * p ; kp = kpm + p ; kpp = kp + p
-        allocate(wrk(1:kp, 1:p)) ; wrk = 0.0_dp
+        allocate(wrk(1:kp, 1:p)) ; wrk = zero_rdp
 
         ! Orthogonalize residual vector w.r.t. to previous computed Krylov vectors.
         call innerprod(H(1:kp, kpm+1:kp), X(1:kp), X(kp+1:kpp))

--- a/src/BaseKrylov.fypp
+++ b/src/BaseKrylov.fypp
@@ -10,7 +10,7 @@ module lightkrylov_BaseKrylov
     use lightkrylov_AbstractLinops
     implicit none
     
-    private
+    character*128, parameter, private :: this_module = 'LightKrylov_BaseKrylov'
 
     public :: qr
     public :: apply_permutation_matrix
@@ -597,7 +597,7 @@ contains
 
             ! Orthogonalize current blk vectors.
             call qr(X(kp+1:kpp), H(kp+1:kpp, kpm+1:kp), info)
-            call check_info(info, 'qr', module='LightKrylov_BaseKrylov', procedure='arnoldi_${type[0]}$${kind}$')
+            call check_info(info, 'qr', module=this_module, procedure='arnoldi_${type[0]}$${kind}$')
 
             ! Extract residual norm (smallest diagonal element of H matrix).
             res = 0.0_${kind}$

--- a/src/BaseKrylov.fypp
+++ b/src/BaseKrylov.fypp
@@ -23,29 +23,29 @@ module lightkrylov_BaseKrylov
     public :: krylov_schur
 
     interface qr
-        #:for k1, t1 in RC_KINDS_TYPES
-        module procedure qr_no_pivoting_${t1[0]}$${k1}$
-        module procedure qr_with_pivoting_${t1[0]}$${k1}$
+        #:for kind, type in RC_KINDS_TYPES
+        module procedure qr_no_pivoting_${type[0]}$${kind}$
+        module procedure qr_with_pivoting_${type[0]}$${kind}$
         #:endfor
     end interface
 
     interface swap_columns
-        #: for k1, t1 in RC_KINDS_TYPES
-        module procedure swap_columns_${t1[0]}$${k1}$
+        #: for kind, type in RC_KINDS_TYPES
+        module procedure swap_columns_${type[0]}$${kind}$
         #:endfor
     end interface
 
     interface apply_permutation_matrix
-        #: for k1, t1 in RC_KINDS_TYPES
-        module procedure apply_permutation_matrix_${t1[0]}$${k1}$
-        module procedure apply_permutation_matrix_array_${t1[0]}$${k1}$
+        #: for kind, type in RC_KINDS_TYPES
+        module procedure apply_permutation_matrix_${type[0]}$${kind}$
+        module procedure apply_permutation_matrix_array_${type[0]}$${kind}$
         #:endfor
     end interface
 
     interface apply_inverse_permutation_matrix
-        #:for k1, t1 in RC_KINDS_TYPES
-        module procedure apply_inverse_permutation_matrix_${t1[0]}$${k1}$
-        module procedure apply_inverse_permutation_matrix_array_${t1[0]}$${k1}$
+        #:for kind, type in RC_KINDS_TYPES
+        module procedure apply_inverse_permutation_matrix_${type[0]}$${kind}$
+        module procedure apply_inverse_permutation_matrix_array_${type[0]}$${kind}$
         #:endfor
     end interface
 
@@ -92,14 +92,14 @@ contains
     !-----     UTILITY FUNCTIONS     -----
     !-------------------------------------
 
-    #:for k1, t1 in RC_KINDS_TYPES
-    subroutine initialize_krylov_subspace_${t1[0]}$${k1}$(X, X0)
-        class(abstract_vector_${t1[0]}$${k1}$), intent(inout) :: X(:)
-        class(abstract_vector_${t1[0]}$${k1}$), optional, intent(in) :: X0(:)
+    #:for kind, type in RC_KINDS_TYPES
+    subroutine initialize_krylov_subspace_${type[0]}$${kind}$(X, X0)
+        class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: X(:)
+        class(abstract_vector_${type[0]}$${kind}$), optional, intent(in) :: X0(:)
 
         ! Internal variables.
-        class(abstract_vector_${t1[0]}$${k1}$), allocatable :: Q(:)
-        ${t1}$, allocatable :: R(:, :)
+        class(abstract_vector_${type[0]}$${kind}$), allocatable :: Q(:)
+        ${type}$, allocatable :: R(:, :)
         integer, allocatable :: perm(:)
         integer :: i, p, info
 
@@ -120,7 +120,7 @@ contains
             enddo
     
             ! Orthonormalize.
-            allocate(R(1:p, 1:p)) ; R = 0.0_${k1}$
+            allocate(R(1:p, 1:p)) ; R = zero_r${kind}$
             allocate(perm(1:p)) ; perm = 0
             call qr(Q, R, perm, info)
             do i = 1, p
@@ -129,72 +129,72 @@ contains
         endif
 
         return
-    end subroutine initialize_krylov_subspace_${t1[0]}$${k1}$
+    end subroutine initialize_krylov_subspace_${type[0]}$${kind}$
 
-    subroutine orthonormalize_vector_against_basis_${t1[0]}$${k1}$(y, X)
+    subroutine orthonormalize_vector_against_basis_${type[0]}$${kind}$(y, X)
       !! Orthonormalizes the `abstract_vector` `y` against a basis `X` of `abstract_vector`.
-      class(abstract_vector_${t1[0]}$${k1}$), intent(inout) :: y
+      class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: y
       !! Input `abstract_vector` to orthonormalize
-      class(abstract_vector_${t1[0]}$${k1}$), intent(in)    :: X(:)
+      class(abstract_vector_${type[0]}$${kind}$), intent(in)    :: X(:)
       !! Input `abstract_vector` basis to orthonormalize against
 
       ! internals
       character*128 :: msg
-      ${t1}$ :: coef(size(X))
-      real(${k1}$) :: alpha
+      ${type}$ :: coef(size(X))
+      real(${kind}$) :: alpha
 
       ! check for zero vector
       if (y%norm() < atol_${kind}$) then
          write(msg, *) 'The input vector is (numerically) zero.'
-         call logger%log_error(trim(msg), module=this_module, procedure='orthonormalize_vector_against_basis_${t1[0]}$${k1}$', &
+         call logger%log_error(trim(msg), module=this_module, procedure='orthonormalize_vector_against_basis_${type[0]}$${kind}$', &
                               & stat=-1, errmsg='Cannot orthonormalize.')
       end if
 
       ! orthogonalize
       call innerprod(coef, X, y)
       block
-         class(abstract_vector_${t1[0]}$${k1}$), allocatable :: proj
+         class(abstract_vector_${type[0]}$${kind}$), allocatable :: proj
          call linear_combination(proj, X, coef)
          call y%sub(proj)
       end block
 
       ! normalize
       alpha = y%norm()
-      call y%scal(one_${t1[0]}$${k1}$ / alpha)
+      call y%scal(one_${type[0]}$${kind}$ / alpha)
 
       if (alpha < atol_${kind}$) then ! error
          write(msg, *) 'The input vector is in the span of X.'
-         call logger%log_error(trim(msg), module=this_module, procedure='orthonormalize_vector_against_basis_${t1[0]}$${k1}$', & 
+         call logger%log_error(trim(msg), module=this_module, procedure='orthonormalize_vector_against_basis_${type[0]}$${kind}$', & 
                               & stat=-2, errmsg='Cannot orthonormalize.')
       else if (alpha < rtol_${kind}$) then ! repeat to avoid floating point errors
          write(msg, *) 'The norm of the component of y in the orthogonal complement of X is ||y||_orth = ', &
                         & alpha, ': The input vector is nearly in the span of X. ', &
                         & 'Repeating orthonormalisation.'
-         call logger%log_warning(trim(msg), module=this_module, procedure='orthonormalize_vector_against_basis_${t1[0]}$${k1}$')
+         call logger%log_warning(trim(msg), module=this_module, procedure='orthonormalize_vector_against_basis_${type[0]}$${kind}$')
          call innerprod(coef, X, y)
          block
-            class(abstract_vector_${t1[0]}$${k1}$), allocatable :: proj
+            class(abstract_vector_${type[0]}$${kind}$), allocatable :: proj
             call linear_combination(proj, X, coef)
             call y%sub(proj)
          end block
          alpha = y%norm()
-         call y%scal(one_${t1[0]}$${k1}$ / alpha)
+         call y%scal(one_${type[0]}$${kind}$ / alpha)
       end if
       
       return
-    end subroutine orthonormalize_vector_against_basis_${t1[0]}$${k1}$
+    end subroutine orthonormalize_vector_against_basis_${type[0]}$${kind}$
 
-    subroutine orthonormalize_basis_against_basis_${t1[0]}$${k1}$(Y, X)
+    subroutine orthonormalize_basis_against_basis_${type[0]}$${kind}$(Y, X)
       !! Orthonormalizes the `abstract_vector` basis `Y` against a basis `X` of `abstract_vector`.
-      class(abstract_vector_${t1[0]}$${k1}$), intent(inout) :: Y(:)
+      class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: Y(:)
       !! Input `abstract_vector` basis to orthonormalize
-      class(abstract_vector_${t1[0]}$${k1}$), intent(in)    :: X(:)
+      class(abstract_vector_${type[0]}$${kind}$), intent(in)    :: X(:)
       !! Input `abstract_vector` basis to orthonormalize against
 
       ! internals
       character*128 :: msg
-      ${t1}$ :: coef(size(X), size(Y))
-      ${t1}$ :: R(size(Y), size(Y))
+      ${type}$ :: coef(size(X), size(Y))
+      ${type}$ :: R(size(Y), size(Y))
       integer :: i, info
       logical :: repeat
 
@@ -203,46 +203,46 @@ contains
          if ( Y(i)%norm() < atol_${kind}$) then
             write(msg, *) 'Zero vector detected in input basis, column ', i
             call logger%log_error(trim(msg), module=this_module, &
-                                 & procedure='orthonormalize_basis_against_basis_${t1[0]}$${k1}$', & 
+                                 & procedure='orthonormalize_basis_against_basis_${type[0]}$${kind}$', & 
                                  & stat=-1, errmsg='Cannot orthonormalize.')
          end if
       end do
 
       ! check for colinear vectors
-      R = 0.0_${k1}$
+      R = zero_r${kind}$
       call qr(Y, R, info)
-      call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_against_basis_${t1[0]}$${k1}$')
+      call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_against_basis_${type[0]}$${kind}$')
       if (info > 0) then ! colinear vectors!
          write(msg, *) 'Colinear vectors detected in input basis'
          call logger%log_error(trim(msg), module=this_module, &
-                                 & procedure='orthonormalize_basis_against_basis_${t1[0]}$${k1}$', & 
+                                 & procedure='orthonormalize_basis_against_basis_${type[0]}$${kind}$', & 
                                  & stat=-2, errmsg='Cannot orthonormalize.')
       end if
 
       ! orthogonalize
       call innerprod(coef, X, Y)
       block
-         class(abstract_vector_${t1[0]}$${k1}$), allocatable :: proj(:)
+         class(abstract_vector_${type[0]}$${kind}$), allocatable :: proj(:)
          call linear_combination(proj, X, coef)
-         call axpby_basis(Y, one_${t1[0]}$${k1}$, proj, -one_${t1[0]}$${k1}$)
+         call axpby_basis(Y, one_${type[0]}$${kind}$, proj, -one_${type[0]}$${kind}$)
       end block
 
       do i = 1, size(Y)
          if ( Y(i)%norm() < atol_${kind}$) then ! error
             write(msg, *) 'The input vector', i, 'is in the span of X.'
             call logger%log_error(trim(msg), module=this_module, &
-                                 & procedure='orthonormalize_basis_against_basis_${t1[0]}$${k1}$', & 
+                                 & procedure='orthonormalize_basis_against_basis_${type[0]}$${kind}$', & 
                                  & stat=-3, errmsg='Cannot orthonormalize.')
          end if
       end do
          
       ! normalize
-      R = 0.0_${k1}$
+      R = zero_r${kind}$
       call qr(Y, R, info)
-      call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_against_basis_${t1[0]}$${k1}$')
+      call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_against_basis_${type[0]}$${kind}$')
       
       return
-    end subroutine orthonormalize_basis_against_basis_${t1[0]}$${k1}$
+    end subroutine orthonormalize_basis_against_basis_${type[0]}$${kind}$
 
     #:endfor
 
@@ -250,50 +250,42 @@ contains
     !-----     QR FACTORIZATION     -----
     !------------------------------------
 
-    #:for k1, t1 in RC_KINDS_TYPES
-    subroutine qr_no_pivoting_${t1[0]}$${k1}$(Q, R, info, verbosity, tol)
-        class(abstract_vector_${t1[0]}$${k1}$), intent(inout) :: Q(:)
+    #:for kind, type in RC_KINDS_TYPES
+    subroutine qr_no_pivoting_${type[0]}$${kind}$(Q, R, info, verbosity, tol)
+        class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: Q(:)
         !! Array of `abstract_vector` to be orthonormalized.
-        ${t1}$, intent(out) :: R(:, :)
+        ${type}$, intent(out) :: R(:, :)
         !! Upper triangular matrix \(\mathbf{R}\) resulting from the QR factorization.
         integer, intent(out) :: info
         !! Information flag.
         logical, optional, intent(in) :: verbosity
         !! Verbosity control.
         logical                       :: verbose
-        real(${k1}$), optional, intent(in) :: tol
+        real(${kind}$), optional, intent(in) :: tol
         !! Tolerance to determine colinearity.
-        real(${k1}$)                       :: tolerance
+        real(${kind}$)                       :: tolerance
 
         ! Internal variables.
-        ${t1}$ :: beta
+        ${type}$ :: beta
         integer :: idx, i, j, k, kdim, iwrk
 
         ! Deals with the optional args.
         verbose   = optval(verbosity, .false.)
-        tolerance = optval(tol, rtol_${k1}$)
+        tolerance = optval(tol, rtol_${kind}$)
 
-        info = 0 ; R = 0.0_${k1}$
+        info = 0 ; R = zero_r${kind}$
         do j = 1, size(Q)
             ! First pass
             do i = 1, j-1
                 beta = Q(i)%dot(Q(j))
-                #:if t1[0] == "c"
-                call Q(j)%axpby(cmplx(1.0_${k1}$, 0.0_${k1}$, kind=${k1}$), Q(i), -beta)
-                #:else
-                call Q(j)%axpby(1.0_${k1}$, Q(i), -beta)
-                #:endif
+                call Q(j)%axpby(one_${type[0]}$${kind}$, Q(i), -beta)
                 R(i, j) = beta
             enddo
 
             ! Second pass
             do i = 1, j-1
                 beta = Q(i)%dot(Q(j))
-                #:if t1[0] == "c"
-                call Q(j)%axpby(cmplx(1.0_${k1}$, 0.0_${k1}$, kind=${k1}$), Q(i), -beta)
-                #:else
-                call Q(j)%axpby(1.0_${k1}$, Q(i), -beta)
-                #:endif
+                call Q(j)%axpby(one_${type[0]}$${kind}$, Q(i), -beta)
                 R(i, j) = R(i, j) + beta
             enddo
 
@@ -307,19 +299,19 @@ contains
                     write(output_unit, *) "      (j, beta) = (", j, ", ", beta, ")"
                 endif
                 info = j
-                R(i, j) = 0.0_${k1}$ ; call Q(j)%zero()
+                R(i, j) = zero_r${kind}$ ; call Q(j)%zero()
             else
-                call Q(j)%scal(1.0_${k1}$ / beta) ; R(j, j) = beta
+                call Q(j)%scal(one_r${kind}$ / beta) ; R(j, j) = beta
             endif
         enddo
 
         return
-    end subroutine qr_no_pivoting_${t1[0]}$${k1}$
+    end subroutine qr_no_pivoting_${type[0]}$${kind}$
 
-    subroutine qr_with_pivoting_${t1[0]}$${k1}$(Q, R, perm, info, verbosity, tol)
-        class(abstract_vector_${t1[0]}$${k1}$), intent(inout) :: Q(:)
+    subroutine qr_with_pivoting_${type[0]}$${kind}$(Q, R, perm, info, verbosity, tol)
+        class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: Q(:)
         !! Array of `abstract_vector` to be orthonormalized.
-        ${t1}$, intent(out) :: R(:, :)
+        ${type}$, intent(out) :: R(:, :)
         !! Upper triangular matrix resulting from the QR factorization.
         integer, intent(out) :: perm(size(Q))
         !! Permutation matrix.
@@ -328,23 +320,23 @@ contains
         logical, optional, intent(in) :: verbosity
         !! Verbosity control.
         logical :: verbose
-        real(${k1}$), optional, intent(in) :: tol
+        real(${kind}$), optional, intent(in) :: tol
 
         !! Tolerance to detect colinearity.
-        real(${k1}$) :: tolerance
+        real(${kind}$) :: tolerance
 
         ! Internal variables
-        ${t1}$ :: beta
+        ${type}$ :: beta
         integer :: idx, i, j, k, kdim, iwrk
         integer :: idxv(1)
-        ${t1}$  :: Rii(size(Q))
+        ${type}$  :: Rii(size(Q))
 
         info = 0 ; kdim = size(Q)
-        R = 0.0_${k1}$ ; Rii = 0.0_${k1}$
+        R = zero_r${kind}$ ; Rii = zero_r${kind}$
         
         ! Deals with the optional arguments.
         verbose = optval(verbosity, .false.)
-        tolerance = optval(tol, rtol_${k1}$)
+        tolerance = optval(tol, rtol_${kind}$)
 
         ! Initialize diagonal entries.
         do i = 1, kdim
@@ -360,13 +352,9 @@ contains
                     ! Orthogonalize against existing columns
                     do k = 1, i-1
                         beta = Q(i)%dot(Q(k))
-                        #:if t1[0] == "c"
-                        call Q(i)%axpby(cmplx(1.0_${k1}$, 0.0_${k1}$, kind=${k1}$), Q(k), -beta)
-                        #:else
-                        call Q(i)%axpby(1.0_${k1}$, Q(k), -beta)
-                        #:endif
+                        call Q(i)%axpby(one_${type[0]}$${kind}$, Q(k), -beta)
                     enddo
-                    beta = Q(i)%norm() ; call Q(i)%scal(1.0_${k1}$ / beta)
+                    beta = Q(i)%norm() ; call Q(i)%scal(one_r${kind}$ / beta)
                 enddo
                 info = j
                 exit qr_step
@@ -379,24 +367,20 @@ contains
 
             if (abs(beta) < tolerance) then
                info = j
-                R(j, j) = 0.0_${k1}$ ; call Q(j)%zero()
+                R(j, j) = zero_r${kind}$ ; call Q(j)%zero()
             else
-                R(j, j) = beta ; call Q(j)%scal(1.0_${k1}$ / beta)
+                R(j, j) = beta ; call Q(j)%scal(one_r${kind}$ / beta)
             endif
 
             ! Orthonormalize all columns against new vector (MGS)
             do i = j+1, kdim
                 beta = Q(j)%dot(Q(i))
-                #:if t1[0] == "c"
-                call Q(i)%axpby(cmplx(1.0_${k1}$, 0.0_${k1}$, kind=${k1}$), Q(j), -beta)
-                #:else
-                call Q(i)%axpby(1.0_${k1}$, Q(j), -beta)
-                #:endif
+                call Q(i)%axpby(one_${type[0]}$${kind}$, Q(j), -beta)
                 R(j, i) = beta
             enddo
 
             ! Update Rii
-            Rii(j) = 0.0_${k1}$
+            Rii(j) = zero_r${kind}$
             do i = j+1, kdim
                 Rii(i) = Rii(i) - R(j, i)**2
             enddo
@@ -404,14 +388,14 @@ contains
         enddo qr_step
 
         return
-    end subroutine qr_with_pivoting_${t1[0]}$${k1}$
+    end subroutine qr_with_pivoting_${type[0]}$${kind}$
 
-    subroutine swap_columns_${t1[0]}$${k1}$(Q, R, Rii, perm, i, j)
-        class(abstract_vector_${t1[0]}$${k1}$), intent(inout) :: Q(:)
+    subroutine swap_columns_${type[0]}$${kind}$(Q, R, Rii, perm, i, j)
+        class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: Q(:)
         !! Vector basis whose i-th and j-th columns need swapping.
-        ${t1}$, intent(inout) :: R(:, :)
+        ${type}$, intent(inout) :: R(:, :)
         !! Upper triangular matrix resulting from QR.
-        ${t1}$, intent(inout) :: Rii(:)
+        ${type}$, intent(inout) :: Rii(:)
         !! Diagonal entries of R.
         integer, intent(inout) :: perm(:)
         !! Column ordering.
@@ -419,8 +403,8 @@ contains
         !! Index of the columns to be swapped.
 
         ! Internal variables.
-        class(abstract_vector_${t1[0]}$${k1}$), allocatable :: Qwrk
-        ${t1}$, allocatable :: Rwrk(:)
+        class(abstract_vector_${type[0]}$${kind}$), allocatable :: Qwrk
+        ${type}$, allocatable :: Rwrk(:)
         integer :: iwrk, m, n
 
         ! Sanity checks.
@@ -428,18 +412,12 @@ contains
 
         ! Allocations.
         allocate(Qwrk, source=Q(1)) ; call Qwrk%zero()
-        allocate(Rwrk(1:max(1, n))) ; Rwrk = 0.0_${k1}$
+        allocate(Rwrk(1:max(1, n))) ; Rwrk = zero_r${kind}$
 
         ! Swap columns.
-        #:if t1[0] == "c"
-        call Qwrk%axpby(cmplx(0.0_${k1}$, 0.0_${k1}$, kind=${k1}$), Q(j), cmplx(1.0_${k1}$, 0.0_${k1}$, kind=${k1}$))
-        call Q(j)%axpby(cmplx(0.0_${k1}$, 0.0_${k1}$, kind=${k1}$), Q(i), cmplx(1.0_${k1}$, 0.0_${k1}$, kind=${k1}$))
-        call Q(i)%axpby(cmplx(0.0_${k1}$, 0.0_${k1}$, kind=${k1}$), Qwrk, cmplx(1.0_${k1}$, 0.0_${k1}$, kind=${k1}$))
-        #:else
-        call Qwrk%axpby(0.0_${k1}$, Q(j), 1.0_${k1}$)
-        call Q(j)%axpby(0.0_${k1}$, Q(i), 1.0_${k1}$)
-        call Q(i)%axpby(0.0_${k1}$, Qwrk, 1.0_${k1}$)
-        #:endif
+        call Qwrk%axpby(zero_${type[0]}$${kind}$, Q(j), one_${type[0]}$${kind}$)
+        call Q(j)%axpby(zero_${type[0]}$${kind}$, Q(i), one_${type[0]}$${kind}$)
+        call Q(i)%axpby(zero_${type[0]}$${kind}$, Qwrk, one_${type[0]}$${kind}$)
         
         Rwrk(1) = Rii(j); Rii(j) = Rii(i); Rii(i) = Rwrk(1)
         iwrk = perm(j); perm(j) = perm(i) ; perm(i) = iwrk
@@ -449,28 +427,28 @@ contains
         endif
 
         return
-    end subroutine swap_columns_${t1[0]}$${k1}$
+    end subroutine swap_columns_${type[0]}$${kind}$
 
-    subroutine apply_permutation_matrix_${t1[0]}$${k1}$(Q, perm)
-        class(abstract_vector_${t1[0]}$${k1}$), intent(inout) :: Q(:)
+    subroutine apply_permutation_matrix_${type[0]}$${kind}$(Q, perm)
+        class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: Q(:)
         !! Basis vectors to be permuted.
         integer, intent(in) :: perm(:)
         !! Permutation matrix (vector representation).
 
         ! Internal variables.
         integer :: i
-        class(abstract_vector_${t1[0]}$${k1}$), allocatable :: Qwrk(:)
+        class(abstract_vector_${type[0]}$${kind}$), allocatable :: Qwrk(:)
 
         allocate(Qwrk, source=Q)
         do i = 1, size(perm)
-            call Q(i)%axpby(zero_${t1[0]}$${k1}$, Qwrk(perm(i)), one_${t1[0]}$${k1}$)
+            call Q(i)%axpby(zero_${type[0]}$${kind}$, Qwrk(perm(i)), one_${type[0]}$${kind}$)
         enddo
 
         return
-    end subroutine apply_permutation_matrix_${t1[0]}$${k1}$
+    end subroutine apply_permutation_matrix_${type[0]}$${kind}$
 
-    subroutine apply_inverse_permutation_matrix_${t1[0]}$${k1}$(Q, perm)
-        class(abstract_vector_${t1[0]}$${k1}$), intent(inout) :: Q(:)
+    subroutine apply_inverse_permutation_matrix_${type[0]}$${kind}$(Q, perm)
+        class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: Q(:)
         !! Basis vectors to be (un-) permuted.
         integer, intent(in) :: perm(:)
         !! Permutation matrix (vector representation).
@@ -478,7 +456,7 @@ contains
         ! Internal variables.
         integer :: i
         integer :: inv_perm(size(perm))
-        class(abstract_vector_${t1[0]}$${k1}$), allocatable :: Qwrk(:)
+        class(abstract_vector_${type[0]}$${kind}$), allocatable :: Qwrk(:)
 
         allocate(Qwrk, source=Q) ; inv_perm = 0
 
@@ -489,21 +467,21 @@ contains
 
         ! Undo permutation.
         do i = 1, size(perm)
-            call Q(i)%axpby(zero_${t1[0]}$${k1}$, Qwrk(inv_perm(i)), one_${t1[0]}$${k1}$)
+            call Q(i)%axpby(zero_${type[0]}$${kind}$, Qwrk(inv_perm(i)), one_${type[0]}$${kind}$)
         enddo
 
         return
-    end subroutine apply_inverse_permutation_matrix_${t1[0]}$${k1}$
+    end subroutine apply_inverse_permutation_matrix_${type[0]}$${kind}$
 
-    subroutine apply_permutation_matrix_array_${t1[0]}$${k1}$(Q, perm)
-        ${t1}$, intent(inout) :: Q(:, :)
+    subroutine apply_permutation_matrix_array_${type[0]}$${kind}$(Q, perm)
+        ${type}$, intent(inout) :: Q(:, :)
         !! Basis vectors to be permuted.
         integer, intent(in) :: perm(:)
         !! Permutation matrix (vector representation).
 
         ! Internal variables.
         integer :: i
-        ${t1}$, allocatable :: Qwrk(:, :)
+        ${type}$, allocatable :: Qwrk(:, :)
 
         Qwrk = Q
         do i = 1, size(perm)
@@ -511,10 +489,10 @@ contains
         enddo
 
         return
-    end subroutine apply_permutation_matrix_array_${t1[0]}$${k1}$
+    end subroutine apply_permutation_matrix_array_${type[0]}$${kind}$
 
-    subroutine apply_inverse_permutation_matrix_array_${t1[0]}$${k1}$(Q, perm)
-        ${t1}$, intent(inout) :: Q(:, :)
+    subroutine apply_inverse_permutation_matrix_array_${type[0]}$${kind}$(Q, perm)
+        ${type}$, intent(inout) :: Q(:, :)
         !! Basis vectors to be (un-) permuted.
         integer, intent(in) :: perm(:)
         !! Permutation matrix (vector representation).
@@ -522,7 +500,7 @@ contains
         ! Internal variables.
         integer :: i
         integer :: inv_perm(size(perm))
-        ${t1}$, allocatable :: Qwrk(:, :)
+        ${type}$, allocatable :: Qwrk(:, :)
 
         Qwrk = Q ; inv_perm = 0
 
@@ -537,7 +515,7 @@ contains
         enddo
 
         return
-    end subroutine apply_inverse_permutation_matrix_array_${t1[0]}$${k1}$
+    end subroutine apply_inverse_permutation_matrix_array_${type[0]}$${kind}$
 
 
     #:endfor
@@ -579,7 +557,7 @@ contains
         integer :: k, i, kdim, kpm, kp, kpp
 
         ! Deals with optional non-unity blksize and allocations.
-        p = optval(blksize, 1) ; allocate(res(1:p)) ; res = 0.0_${kind}$
+        p = optval(blksize, 1) ; allocate(res(1:p)) ; res = zero_r${kind}$
         allocate(perm(1:size(H, 2))) ; perm = 0 ; info = 0
 
         ! Check dimensions.
@@ -615,7 +593,7 @@ contains
             call check_info(info, 'qr', module=this_module, procedure='arnoldi_${type[0]}$${kind}$')
 
             ! Extract residual norm (smallest diagonal element of H matrix).
-            res = 0.0_${kind}$
+            res = zero_r${kind}$
             do i = 1, p
                 res(i) = H(kp+i, kpm+i)
             enddo
@@ -649,7 +627,7 @@ contains
 
         ! Counters and allocations.
         kpm = (k - 1) * p ; kp = kpm + p ; kpp = kp + p
-        allocate(wrk(1:kp, 1:p)) ; wrk = 0.0_${kind}$
+        allocate(wrk(1:kp, 1:p)) ; wrk = zero_r${kind}$
 
         ! Orthogonalize residual vector w.r.t. to previous computed Krylov vectors.
         call innerprod(H(1:kp, kpm+1:kp), X(1:kp), X(kp+1:kpp))

--- a/src/BaseKrylov.fypp
+++ b/src/BaseKrylov.fypp
@@ -3,6 +3,7 @@
 module lightkrylov_BaseKrylov
     use iso_fortran_env
     use stdlib_optval, only: optval
+    use stdlib_linalg, only: eye
     use LightKrylov_constants
     use LightKrylov_Logger
     use LightKrylov_Utils
@@ -65,6 +66,13 @@ module lightkrylov_BaseKrylov
         #:for kind, type in RC_KINDS_TYPES
         module procedure orthogonalize_vector_against_basis_${type[0]}$${kind}$
         module procedure orthogonalize_basis_against_basis_${type[0]}$${kind}$
+        #:endfor
+    end interface
+
+    interface double_gram_schmidt_step
+        #:for kind, type in RC_KINDS_TYPES
+        module procedure DGS_vector_against_basis_${type[0]}$${kind}$
+        module procedure DGS_basis_against_basis_${type[0]}$${kind}$
         #:endfor
     end interface
 
@@ -131,7 +139,7 @@ contains
         return
     end subroutine initialize_krylov_subspace_${type[0]}$${kind}$
 
-    subroutine orthogonalize_vector_against_basis_${type[0]}$${kind}$(y, X, info, beta)
+    subroutine orthogonalize_vector_against_basis_${type[0]}$${kind}$(y, X, info, if_chk_orthonormal, beta)
       !! Orthonormalizes the `abstract_vector` `y` against a basis `X` of `abstract_vector`.
       class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: y
       !! Input `abstract_vector` to orthogonalize
@@ -139,6 +147,9 @@ contains
       !! Input `abstract_vector` basis to orthogonalize against
       integer, intent(out) :: info
       !! Information flag.
+      logical,                          optional, intent(in)    :: if_chk_orthonormal
+      logical                                                   :: chk_X_orthonormality
+      !! Check that input Krylov vectors `X` form an orthonormal basis (expensive!)
       ${type}$,                         optional, intent(out)   :: beta(:)
       !! Projection coefficients if requested
 
@@ -147,8 +158,26 @@ contains
 
       info = 0
 
+      ! optional input argument
+      chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
+
       ! check for zero vector
       if (y%norm() < atol_${kind}$) info = 1
+
+      if (chk_X_orthonormality) then
+         block 
+            ${type}$, dimension(size(X), size(X)) :: G
+            call innerprod(G, X, X)
+            if (abs(G(size(X),size(X))) < rtol_${kind}$) then
+               ! The last vector in X is zero, it does not impact orthogonalisation
+               info = -2
+            else if (norm2(abs(G - eye(size(X)))) > rtol_${kind}$) then
+               ! The basis is not orthonormal. Cannot orthonormalize.
+               info = -1
+               return
+            end if
+         end block
+      end if
 
       ! orthogonalize
       call innerprod(proj_coefficients, X, y)
@@ -160,14 +189,14 @@ contains
 
       if (present(beta)) then
          ! check size
-         call assert_shape(beta, [ size(X) ], 'orthogonalize_vector_against_basis_${type[0]}$${kind}$', 'beta')
+         call assert_shape(beta, shape(proj_coefficients), 'orthogonalize_vector_against_basis_${type[0]}$${kind}$', 'beta')
          beta = proj_coefficients
       end if
       
       return
     end subroutine orthogonalize_vector_against_basis_${type[0]}$${kind}$
 
-    subroutine orthogonalize_basis_against_basis_${type[0]}$${kind}$(Y, X, info, beta)
+    subroutine orthogonalize_basis_against_basis_${type[0]}$${kind}$(Y, X, info, if_chk_orthonormal, beta)
       !! Orthonormalizes the `abstract_vector` basis `Y` against a basis `X` of `abstract_vector`.
       class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: Y(:)
       !! Input `abstract_vector` basis to orthogonalize
@@ -175,20 +204,40 @@ contains
       !! Input `abstract_vector` basis to orthogonalize against
       integer, intent(out) :: info
       !! Information flag.
+      logical,                          optional, intent(in)    :: if_chk_orthonormal
+      logical                                                   :: chk_X_orthonormality
+      !! Check that input Krylov vectors `X` form an orthonormal basis (expensive!)
       ${type}$,                         optional, intent(out)   :: beta(:,:)
       !! Projection coefficients if requested
 
       ! internals
       ${type}$ :: proj_coefficients(size(X), size(Y))
-      ${type}$ :: R(size(Y), size(Y))
       integer :: i
 
       info = 0
+
+      ! optional input argument
+      chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
       ! check for zero vector
       do i = 1, size(Y)
          if ( Y(i)%norm() < atol_${kind}$) info = i
       end do
+
+      if (chk_X_orthonormality) then
+         block 
+            ${type}$, dimension(size(X), size(X)) :: G
+            call innerprod(G, X, X)
+            if (abs(G(size(X),size(X))) < rtol_${kind}$) then
+               ! The last vector in X is zero, it does not impact orthogonalisation
+               info = -2
+            else if (norm2(abs(G - eye(size(X)))) > rtol_${kind}$) then
+               ! The basis is not orthonormal. Cannot orthonormalize.
+               info = -1
+               return
+            end if
+         end block
+      end if
       
       ! orthogonalize
       call innerprod(proj_coefficients, X, Y)
@@ -200,12 +249,98 @@ contains
 
       if (present(beta)) then
          ! check size
-         call assert_shape(beta, [ size(X), size(Y) ], 'orthogonalize_basis_against_basis_${type[0]}$${kind}$', 'beta')
+         call assert_shape(beta, shape(proj_coefficients), 'orthogonalize_basis_against_basis_${type[0]}$${kind}$', 'beta')
          beta = proj_coefficients
       end if
       
       return
     end subroutine orthogonalize_basis_against_basis_${type[0]}$${kind}$
+
+    subroutine DGS_vector_against_basis_${type[0]}$${kind}$(y, X, info, if_chk_orthonormal, beta)
+      !! Computes one step of the double Gram-Schmidt orthogonalization process of the
+      !! `abstract_vector` `y` against the `abstract_vector` basis `X`
+      class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: y
+      !! Input `abstract_vector` to orthogonalize
+      class(abstract_vector_${type[0]}$${kind}$), intent(in)    :: X(:)
+      !! Input `abstract_vector` basis to orthogonalize against
+      integer, intent(out) :: info
+      !! Information flag.
+      logical,                          optional, intent(in)    :: if_chk_orthonormal
+      logical                                                   :: chk_X_orthonormality
+      !! Check that input Krylov vectors `X` form an orthonormal basis (expensive!)
+      ${type}$,                         optional, intent(out)   :: beta(:)
+      !! Projection coefficients if requested
+
+      ! internals
+      ${type}$, dimension(size(X)) :: proj_coefficients, wrk
+
+      ! optional input argument
+      chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
+
+      info = 0
+
+      proj_coefficients = zero_${type[0]}$${kind}$; wrk = zero_${type[0]}$${kind}$
+
+      ! Orthogonalize vector y w.r.t. to Krylov basis X in two passes of GS.
+      ! first pass
+      call orthogonalize_against_basis(y, X, info, if_chk_orthonormal=.false., beta=proj_coefficients)
+      call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='DGS_vector_against_basis, first pass')
+      ! second pass
+      call orthogonalize_against_basis(y, X, info, if_chk_orthonormal=.false., beta=wrk)
+      call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='DGS_vector_against_basis_${type[0]}$${kind}$, second pass')
+      ! combine passes
+      proj_coefficients = proj_coefficients + wrk
+
+      if (present(beta)) then
+         ! check size
+         call assert_shape(beta, shape(proj_coefficients), 'DGS_vector_against_basis_${type[0]}$${kind}$', 'beta')
+         beta = proj_coefficients
+      end if
+
+    end subroutine DGS_vector_against_basis_${type[0]}$${kind}$
+
+    subroutine DGS_basis_against_basis_${type[0]}$${kind}$(y, X, info, if_chk_orthonormal, beta)
+      !! Computes one step of the double Gram-Schmidt orthogonalization process of the
+      !! `abstract_vector` `y` against the `abstract_vector` basis `X`
+      class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: Y(:)
+      !! Input `abstract_vector` basis to orthogonalize
+      class(abstract_vector_${type[0]}$${kind}$), intent(in)    :: X(:)
+      !! Input `abstract_vector` basis to orthogonalize against
+      integer, intent(out) :: info
+      !! Information flag.
+      logical,                          optional, intent(in)    :: if_chk_orthonormal
+      logical                                                   :: chk_X_orthonormality
+      !! Check that input Krylov vectors `X` form an orthonormal basis (expensive!)
+      ${type}$,                         optional, intent(out)   :: beta(:,:)
+      !! Projection coefficients if requested
+
+      ! internals
+      ${type}$, dimension(size(X),size(Y)) :: proj_coefficients, wrk
+
+      ! optional input argument
+      chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
+
+      info = 0
+
+      proj_coefficients = zero_${type[0]}$${kind}$; wrk = zero_${type[0]}$${kind}$
+
+      ! Orthogonalize Krylov basis Y w.r.t. to Krylov basis X in two passes of GS.
+      ! first pass
+      call orthogonalize_against_basis(Y, X, info, if_chk_orthonormal=.false., beta=proj_coefficients)
+      call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='DGS_basis_against_basis_${type[0]}$${kind}$, first pass')
+      ! second pass
+      call orthogonalize_against_basis(Y, X, info, if_chk_orthonormal=.false., beta=wrk)
+      call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='DGS_basis_against_basis_${type[0]}$${kind}$, second pass')
+      ! combine passes
+      proj_coefficients = proj_coefficients + wrk
+
+      if (present(beta)) then
+         ! check size
+         call assert_shape(beta, shape(proj_coefficients), 'DGS_basis_against_basis_${type[0]}$${kind}$', 'beta')
+         beta = proj_coefficients
+      end if
+
+    end subroutine DGS_basis_against_basis_${type[0]}$${kind}$  
 
     #:endfor
 
@@ -240,17 +375,9 @@ contains
         info = 0 ; R = zero_r${kind}$ ; beta = zero_r${kind}$
         do j = 1, size(Q)
             if (j > 1) then
-               ! First pass
-               call orthogonalize_against_basis(Q(j), Q(1:j-1), info, beta(1:j-1))
-               call check_info(info, 'orthogonalize_against_basis', module=this_module, &
-                                    & procedure='qr_no_pivoting_${type[0]}$${kind}$, first pass')
-               R(1:j-1,j) = beta(1:j-1)
-
-               ! Second pass
-               call orthogonalize_against_basis(Q(j), Q(1:j-1), info, beta(1:j-1))
-               call check_info(info, 'orthogonalize_against_basis', module=this_module, &
-                                    & procedure='qr_no_pivoting_${type[0]}$${kind}$, second pass')
-               R(1:j-1,j) = R(1:j-1,j) + beta(1:j-1)
+                ! Double Gram-Schmidt orthogonalization
+                call double_gram_schmidt_step(Q(j), Q(1:j-1), info, if_chk_orthonormal=.false., beta=R(1:j-1,j))
+                call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='qr_no_pivoting_${type[0]}$${kind}$')
             end if
 
             ! Normalize column.
@@ -313,9 +440,8 @@ contains
             if (abs(Rii(idx)) < tolerance) then
                 do i = j, kdim
                     call Q(i)%rand(.false.)
-                    call orthogonalize_against_basis(Q(i), Q(1:i-1), info)
-                    call check_info(info, 'orthogonalize_against_basis', module=this_module, &
-                                    & procedure='qr_with_pivoting_${type[0]}$${kind}$')
+                    call orthogonalize_against_basis(Q(i), Q(1:i-1), info, if_chk_orthonormal=.false.)
+                    call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='qr_with_pivoting_${type[0]}$${kind}$')
                     beta = Q(i)%norm(); call Q(i)%scal(one_${type[0]}$${kind}$ / beta)
                 enddo
                 info = j
@@ -547,8 +673,9 @@ contains
                 enddo
             endif
 
-            ! Update Hessenberg matrix and orthogonalize w.r.t. previous vectors.
-            call update_hessenberg_matrix_${type[0]}$${kind}$(H, X, k, p)
+            ! Update Hessenberg matrix via batch double Gram-Schmidt step.
+            call double_gram_schmidt_step(X(kp+1:kpp), X(1:kp), info, if_chk_orthonormal=.false., beta=H(1:kp, kpm+1:kp))
+            call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='arnoldi_${type[0]}$${kind}$')
 
             ! Orthogonalize current blk vectors.
             call qr(X(kp+1:kpp), H(kp+1:kpp, kpm+1:kp), info)
@@ -573,40 +700,6 @@ contains
 
         return
     end subroutine arnoldi_${type[0]}$${kind}$
-
-    subroutine update_hessenberg_matrix_${type[0]}$${kind}$(H, X, k, blksize)
-        integer, intent(in) :: k
-        ${type}$, intent(inout) :: H(:, :)
-        class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: X(:)
-        integer, optional, intent(in) :: blksize
-
-        ! Internal variables.
-        ${type}$, allocatable :: wrk(:, :)
-        integer :: p, kpm, kp, kpp, i, j, info
-
-        ! Deals with optional non-unity block size.
-        p = optval(blksize, 1)
-
-        ! Counters and allocations.
-        kpm = (k - 1) * p ; kp = kpm + p ; kpp = kp + p
-        allocate(wrk(1:kp, 1:p)) ; wrk = zero_r${kind}$
-
-        ! Orthogonalize residual vector w.r.t. to previous computed Krylov vectors.
-        ! first pass
-        call orthogonalize_against_basis(X(kp+1:kpp), X(1:kp), info, H(1:kp, kpm+1:kp))
-        call check_info(info, 'orthogonalize_against_basis', module=this_module, &
-                                    & procedure='update_hessenberg_matrix_${type[0]}$${kind}$, first pass')
-
-        ! second pass
-        call orthogonalize_against_basis(X(kp+1:kpp), X(1:kp), info, wrk)
-        call check_info(info, 'orthogonalize_against_basis', module=this_module, &
-                                    & procedure='update_hessenberg_matrix_${type[0]}$${kind}$, second pass')
-
-        ! combine passes
-        H(1:kp, kpm+1:kp) = H(1:kp, kpm+1:kp) + wrk
-
-        return
-    end subroutine update_hessenberg_matrix_${type[0]}$${kind}$
 
     #:endfor
 
@@ -661,9 +754,9 @@ contains
             ! Transpose matrix-vector product.
             call A%rmatvec(U(k), V(k))
 
-            ! Full reorthogonalization of the right Krylov subspace.
+            ! Full re-orthogonalization of the right Krylov subspace.
             if (k > 1 ) then
-               call orthogonalize_against_basis(V(k), V(1:k-1), info)
+               call orthogonalize_against_basis(V(k), V(1:k-1), info, if_chk_orthonormal=.false.)
                call check_info(info, 'orthogonalize_against_basis', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_${type[0]}$${kind}$, first pass')
             end if
@@ -681,7 +774,7 @@ contains
             call A%matvec(V(k), U(k+1))
 
             ! Full re-orthogonalization of the left Krylov subspace.
-            call orthogonalize_against_basis(U(k+1), U(1:k), info)
+            call orthogonalize_against_basis(U(k+1), U(1:k), info, if_chk_orthonormal=.false.)
             call check_info(info, 'orthogonalize_against_basis', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_${type[0]}$${kind}$, second pass')
 
@@ -765,20 +858,18 @@ contains
 
         ! Internal variables.
         class(abstract_vector_${type[0]}$${kind}$), allocatable :: wrk
-        integer :: i
-        ${type}$ :: alpha
+        integer :: i, info
 
-        ! Orthogonalize residual w.r.t. previously computed Krylov vectors.
+        info = 0
+
+        ! Orthogonalize residual w.r.t. previously computed Krylov vectors to obtain coefficients in tridiag. matrix
         do i = max(1, k-1), k
-            alpha = X(i)%dot(X(k+1)) ; call X(k+1)%axpby(one_${type[0]}$${kind}$, X(i), -alpha)
-            ! Update tridiag. matrix.
-            T(i, k) = alpha
+            T(i, k) = X(i)%dot(X(k+1)) ; call X(k+1)%axpby(one_${type[0]}$${kind}$, X(i), -T(i, k))
         enddo
 
-        ! Full re-orthogonalization.
-        do i = 1, k
-            alpha = X(i)%dot(X(k+1)) ; call X(k+1)%axpby(one_${type[0]}$${kind}$, X(i), -alpha)
-        enddo
+        ! Full re-orthogonalization against existing basis
+        call orthogonalize_against_basis(X(k+1), X(1:k), info, if_chk_orthonormal=.false.)
+        call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='update_tridiag_matrix_${type[0]}$${kind}$')
 
         return
     end subroutine update_tridiag_matrix_${type[0]}$${kind}$

--- a/src/BaseKrylov.fypp
+++ b/src/BaseKrylov.fypp
@@ -131,7 +131,7 @@ contains
         return
     end subroutine initialize_krylov_subspace_${type[0]}$${kind}$
 
-    subroutine orthogonalize_vector_against_basis_${type[0]}$${kind}$(y, X, info, beta, ifnorm)
+    subroutine orthogonalize_vector_against_basis_${type[0]}$${kind}$(y, X, info, beta)
       !! Orthonormalizes the `abstract_vector` `y` against a basis `X` of `abstract_vector`.
       class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: y
       !! Input `abstract_vector` to orthogonalize
@@ -141,30 +141,14 @@ contains
       !! Information flag.
       ${type}$,                         optional, intent(out)   :: beta(:)
       !! Projection coefficients if requested
-      logical,                          optional, intent(in)    :: ifnorm
-      logical                                                   :: normalize
-      !! Normalize output?
 
       ! internals
-      character*128 :: msg
       ${type}$ :: proj_coefficients(size(X))
-      ${type}$ :: proj_coefficients_2(size(X))
-      real(${kind}$) :: alpha
-
-      ! optional argument
-      normalize = optval(ifnorm, .false.)
 
       info = 0
 
       ! check for zero vector
-      if (y%norm() < atol_${kind}$) then
-         if (normalize) then
-            info = -1
-            return
-         else
-            info = 1
-         end if
-      end if
+      if (y%norm() < atol_${kind}$) info = 1
 
       ! orthogonalize
       call innerprod(proj_coefficients, X, y)
@@ -173,26 +157,6 @@ contains
          call linear_combination(proj, X, proj_coefficients)
          call y%sub(proj)
       end block
-
-      ! normalize
-      if (normalize) then
-         alpha = y%norm()
-         if (alpha < atol_${kind}$) then ! error
-            info = -2
-            return
-         else if (alpha < rtol_${kind}$) then ! repeat to avoid floating point errors
-            info = 2
-            call innerprod(proj_coefficients_2, X, y)
-            block
-               class(abstract_vector_${type[0]}$${kind}$), allocatable :: proj
-               call linear_combination(proj, X, proj_coefficients_2)
-               call y%sub(proj)
-            end block
-            proj_coefficients = proj_coefficients + proj_coefficients_2 ! for output
-         end if
-         alpha = y%norm()
-         call y%scal(one_${type[0]}$${kind}$ / alpha)
-      end if
 
       if (present(beta)) then
          ! check size
@@ -203,7 +167,7 @@ contains
       return
     end subroutine orthogonalize_vector_against_basis_${type[0]}$${kind}$
 
-    subroutine orthogonalize_basis_against_basis_${type[0]}$${kind}$(Y, X, info, beta, ifnorm)
+    subroutine orthogonalize_basis_against_basis_${type[0]}$${kind}$(Y, X, info, beta)
       !! Orthonormalizes the `abstract_vector` basis `Y` against a basis `X` of `abstract_vector`.
       class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: Y(:)
       !! Input `abstract_vector` basis to orthogonalize
@@ -213,46 +177,19 @@ contains
       !! Information flag.
       ${type}$,                         optional, intent(out)   :: beta(:,:)
       !! Projection coefficients if requested
-      logical,                          optional, intent(in)    :: ifnorm
-      logical                                                   :: normalize
-      !! Normalize output ?
 
       ! internals
-      character*128 :: msg
       ${type}$ :: proj_coefficients(size(X), size(Y))
       ${type}$ :: R(size(Y), size(Y))
       integer :: i
-      logical :: repeat
-
-      ! optional argument
-      normalize = optval(ifnorm, .false.)
 
       info = 0
 
-      if (normalize) then
-         ! check for zero vector
-         do i = 1, size(Y)
-            if ( Y(i)%norm() < atol_${kind}$) then
-               info = -1
-               return
-            end if
-         end do
+      ! check for zero vector
+      do i = 1, size(Y)
+         if ( Y(i)%norm() < atol_${kind}$) info = i
+      end do
       
-         ! check for colinear vectors
-         R = zero_r${kind}$
-         call qr(Y, R, info)
-         call check_info(info, 'qr', module=this_module, procedure='orthogonalize_basis_against_basis_${type[0]}$${kind}$')
-         if (info > 0 .and. normalize) then ! colinear vectors!
-            info = -3
-            return
-         end if
-      else
-         ! check for zero vector
-         do i = 1, size(Y)
-            if ( Y(i)%norm() < atol_${kind}$) info = 1
-         end do
-      end if
-
       ! orthogonalize
       call innerprod(proj_coefficients, X, Y)
       block
@@ -260,21 +197,6 @@ contains
          call linear_combination(proj, X, proj_coefficients)
          call axpby_basis(Y, one_${type[0]}$${kind}$, proj, -one_${type[0]}$${kind}$)
       end block
-         
-      ! normalize
-      if (normalize) then
-         ! check if Y is in the span of X
-         do i = 1, size(Y)
-            if ( Y(i)%norm() < atol_${kind}$) then ! error
-               info = -2
-               return
-            end if
-         end do
-         R = zero_r${kind}$
-         call qr(Y, R, info)
-         call check_info(info, 'qr', module=this_module, procedure='orthogonalize_basis_against_basis_${type[0]}$${kind}$')
-         proj_coefficients = matmul(proj_coefficients, R)
-      end if
 
       if (present(beta)) then
          ! check size
@@ -309,7 +231,7 @@ contains
         ! Internal variables.
         ${type}$ :: alpha
         ${type}$ :: beta(size(Q))
-        integer :: idx, i, j, k, kdim, iwrk
+        integer :: idx, j, kdim, iwrk
 
         ! Deals with the optional args.
         verbose   = optval(verbosity, .false.)
@@ -369,7 +291,7 @@ contains
 
         ! Internal variables
         ${type}$ :: beta
-        integer :: idx, i, j, k, kdim, iwrk
+        integer :: idx, i, j, kdim, iwrk
         integer :: idxv(1)
         ${type}$  :: Rii(size(Q))
 
@@ -391,9 +313,10 @@ contains
             if (abs(Rii(idx)) < tolerance) then
                 do i = j, kdim
                     call Q(i)%rand(.false.)
-                    call orthogonalize_against_basis(Q(i), Q(1:i-1), info, ifnorm=.true.)
+                    call orthogonalize_against_basis(Q(i), Q(1:i-1), info)
                     call check_info(info, 'orthogonalize_against_basis', module=this_module, &
                                     & procedure='qr_with_pivoting_${type[0]}$${kind}$')
+                    beta = Q(i)%norm(); call Q(i)%scal(one_${type[0]}$${kind}$ / beta)
                 enddo
                 info = j
                 exit qr_step

--- a/src/BaseKrylov.fypp
+++ b/src/BaseKrylov.fypp
@@ -17,7 +17,7 @@ module lightkrylov_BaseKrylov
     public :: apply_inverse_permutation_matrix
     public :: arnoldi
     public :: initialize_krylov_subspace
-    public :: orthonormalize
+    public :: orthonormalize_against_basis
     public :: lanczos_bidiagonalization
     public :: lanczos_tridiagonalization
     public :: krylov_schur
@@ -61,10 +61,10 @@ module lightkrylov_BaseKrylov
         #:endfor
     end interface
 
-    interface orthonormalize
+    interface orthonormalize_against_basis
         #:for kind, type in RC_KINDS_TYPES
-        module procedure orthonormalize_vector_${type[0]}$${kind}$
-        module procedure orthonormalize_basis_${type[0]}$${kind}$
+        module procedure orthonormalize_vector_against_basis_${type[0]}$${kind}$
+        module procedure orthonormalize_basis_against_basis_${type[0]}$${kind}$
         #:endfor
     end interface
 
@@ -131,35 +131,46 @@ contains
         return
     end subroutine initialize_krylov_subspace_${t1[0]}$${k1}$
 
-    subroutine orthonormalize_vector_${t1[0]}$${k1}$(y, X, info)
+    subroutine orthonormalize_vector_against_basis_${t1[0]}$${k1}$(y, X)
       !! Orthonormalizes the `abstract_vector` `y` against a basis `X` of `abstract_vector`.
       class(abstract_vector_${t1[0]}$${k1}$), intent(inout) :: y
       !! Input `abstract_vector` to orthonormalize
       class(abstract_vector_${t1[0]}$${k1}$), intent(in)    :: X(:)
       !! Input `abstract_vector` basis to orthonormalize against
-      integer,                    intent(out)   :: info
-      !! Information flag
 
       ! internals
+      character*128 :: msg
       ${t1}$ :: coef(size(X))
       real(${k1}$) :: alpha
 
-      info = 0
-
+      ! check for zero vector
       if (y%norm() < atol_${kind}$) then
-         info = -1
-         return
+         write(msg, *) 'The input vector is (numerically) zero.'
+         call logger%log_error(trim(msg), module=this_module, procedure='orthonormalize_vector_against_basis_${t1[0]}$${k1}$', &
+                              & stat=-1, errmsg='Cannot orthonormalize.')
       end if
 
+      ! orthogonalize
       call innerprod(coef, X, y)
       block
          class(abstract_vector_${t1[0]}$${k1}$), allocatable :: proj
          call linear_combination(proj, X, coef)
          call y%sub(proj)
       end block
+
+      ! normalize
       alpha = y%norm()
       call y%scal(one_${t1[0]}$${k1}$ / alpha)
-      if (alpha < 10*atol_${kind}$) then ! repeat to avoid floating point errors
+
+      if (alpha < atol_${kind}$) then ! error
+         write(msg, *) 'The input vector is in the span of X.'
+         call logger%log_error(trim(msg), module=this_module, procedure='orthonormalize_vector_against_basis_${t1[0]}$${k1}$', & 
+                              & stat=-2, errmsg='Cannot orthonormalize.')
+      else if (alpha < rtol_${kind}$) then ! repeat to avoid floating point errors
+         write(msg, *) 'The norm of the component of y in the orthogonal complement of X is ||y||_orth = ', &
+                        & alpha, ': The input vector is nearly in the span of X. ', &
+                        & 'Repeating orthonormalisation.'
+         call logger%log_warning(trim(msg), module=this_module, procedure='orthonormalize_vector_against_basis_${t1[0]}$${k1}$')
          call innerprod(coef, X, y)
          block
             class(abstract_vector_${t1[0]}$${k1}$), allocatable :: proj
@@ -168,66 +179,70 @@ contains
          end block
          alpha = y%norm()
          call y%scal(one_${t1[0]}$${k1}$ / alpha)
-         info = 1
       end if
       
       return
-    end subroutine orthonormalize_vector_${t1[0]}$${k1}$
+    end subroutine orthonormalize_vector_against_basis_${t1[0]}$${k1}$
 
-    subroutine orthonormalize_basis_${t1[0]}$${k1}$(Y, X, info)
+    subroutine orthonormalize_basis_against_basis_${t1[0]}$${k1}$(Y, X)
       !! Orthonormalizes the `abstract_vector` basis `Y` against a basis `X` of `abstract_vector`.
       class(abstract_vector_${t1[0]}$${k1}$), intent(inout) :: Y(:)
       !! Input `abstract_vector` basis to orthonormalize
       class(abstract_vector_${t1[0]}$${k1}$), intent(in)    :: X(:)
       !! Input `abstract_vector` basis to orthonormalize against
-      integer,                    intent(out)   :: info
-      !! Information flag
 
       ! internals
+      character*128 :: msg
       ${t1}$ :: coef(size(X), size(Y))
       ${t1}$ :: R(size(Y), size(Y))
-      integer :: i
+      integer :: i, info
       logical :: repeat
 
-      info = 0
-
+      ! check for zero vector
       do i = 1, size(Y)
          if ( Y(i)%norm() < atol_${kind}$) then
-            info = -2
-            return
+            write(msg, *) 'Zero vector detected in input basis, column ', i
+            call logger%log_error(trim(msg), module=this_module, &
+                                 & procedure='orthonormalize_basis_against_basis_${t1[0]}$${k1}$', & 
+                                 & stat=-1, errmsg='Cannot orthonormalize.')
          end if
       end do
 
+      ! check for colinear vectors
+      R = 0.0_${k1}$
+      call qr(Y, R, info)
+      call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_against_basis_${t1[0]}$${k1}$')
+      if (info > 0) then ! colinear vectors!
+         write(msg, *) 'Colinear vectors detected in input basis'
+         call logger%log_error(trim(msg), module=this_module, &
+                                 & procedure='orthonormalize_basis_against_basis_${t1[0]}$${k1}$', & 
+                                 & stat=-2, errmsg='Cannot orthonormalize.')
+      end if
+
+      ! orthogonalize
       call innerprod(coef, X, Y)
       block
          class(abstract_vector_${t1[0]}$${k1}$), allocatable :: proj(:)
          call linear_combination(proj, X, coef)
          call axpby_basis(Y, one_${t1[0]}$${k1}$, proj, -one_${t1[0]}$${k1}$)
       end block
-      R = 0.0_${k1}$
-      call qr(Y, R, info)
-      call check_info(info, 'qr', module='LightKrylov_BaseKrylov', procedure='orthonormalize_basis_rdp')
 
       do i = 1, size(Y)
-         if ( Y(i)%norm() < atol_${kind}$) then ! repeat to avoid floating point errors
-            info = 1
+         if ( Y(i)%norm() < atol_${kind}$) then ! error
+            write(msg, *) 'The input vector', i, 'is in the span of X.'
+            call logger%log_error(trim(msg), module=this_module, &
+                                 & procedure='orthonormalize_basis_against_basis_${t1[0]}$${k1}$', & 
+                                 & stat=-3, errmsg='Cannot orthonormalize.')
          end if
       end do
-
-      if (info == 1) then
-         call innerprod(coef, X, Y)
-         block
-            class(abstract_vector_${t1[0]}$${k1}$), allocatable :: proj(:)
-            call linear_combination(proj, X, coef)
-            call axpby_basis(Y, one_${t1[0]}$${k1}$, proj, -one_${t1[0]}$${k1}$)
-         end block
-         R = 0.0_${k1}$
-         call qr(Y, R, info)
-         call check_info(info, 'qr', module='LightKrylov_BaseKrylov', procedure='orthonormalize_basis_rdp, second pass.')
-      end if
+         
+      ! normalize
+      R = 0.0_${k1}$
+      call qr(Y, R, info)
+      call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_against_basis_${t1[0]}$${k1}$')
       
       return
-    end subroutine orthonormalize_basis_${t1[0]}$${k1}$
+    end subroutine orthonormalize_basis_against_basis_${t1[0]}$${k1}$
 
     #:endfor
 

--- a/src/BaseKrylov.fypp
+++ b/src/BaseKrylov.fypp
@@ -3,11 +3,11 @@
 module lightkrylov_BaseKrylov
     use iso_fortran_env
     use stdlib_optval, only: optval
-    use lightkrylov_constants
+    use LightKrylov_constants
     use LightKrylov_Logger
-    use lightkrylov_utils
-    use lightkrylov_AbstractVectors
-    use lightkrylov_AbstractLinops
+    use LightKrylov_Utils
+    use LightKrylov_AbstractVectors
+    use LightKrylov_AbstractLinops
     implicit none
     
     character*128, parameter, private :: this_module = 'LightKrylov_BaseKrylov'
@@ -17,7 +17,7 @@ module lightkrylov_BaseKrylov
     public :: apply_inverse_permutation_matrix
     public :: arnoldi
     public :: initialize_krylov_subspace
-    public :: orthonormalize_against_basis
+    public :: orthogonalize_against_basis
     public :: lanczos_bidiagonalization
     public :: lanczos_tridiagonalization
     public :: krylov_schur
@@ -61,10 +61,10 @@ module lightkrylov_BaseKrylov
         #:endfor
     end interface
 
-    interface orthonormalize_against_basis
+    interface orthogonalize_against_basis
         #:for kind, type in RC_KINDS_TYPES
-        module procedure orthonormalize_vector_against_basis_${type[0]}$${kind}$
-        module procedure orthonormalize_basis_against_basis_${type[0]}$${kind}$
+        module procedure orthogonalize_vector_against_basis_${type[0]}$${kind}$
+        module procedure orthogonalize_basis_against_basis_${type[0]}$${kind}$
         #:endfor
     end interface
 
@@ -131,118 +131,159 @@ contains
         return
     end subroutine initialize_krylov_subspace_${type[0]}$${kind}$
 
-    subroutine orthonormalize_vector_against_basis_${type[0]}$${kind}$(y, X)
+    subroutine orthogonalize_vector_against_basis_${type[0]}$${kind}$(y, X, info, beta, ifnorm)
       !! Orthonormalizes the `abstract_vector` `y` against a basis `X` of `abstract_vector`.
       class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: y
-      !! Input `abstract_vector` to orthonormalize
+      !! Input `abstract_vector` to orthogonalize
       class(abstract_vector_${type[0]}$${kind}$), intent(in)    :: X(:)
-      !! Input `abstract_vector` basis to orthonormalize against
+      !! Input `abstract_vector` basis to orthogonalize against
+      integer, intent(out) :: info
+      !! Information flag.
+      ${type}$,                         optional, intent(out)   :: beta(:)
+      !! Projection coefficients if requested
+      logical,                          optional, intent(in)    :: ifnorm
+      logical                                                   :: normalize
+      !! Normalize output?
 
       ! internals
       character*128 :: msg
-      ${type}$ :: coef(size(X))
+      ${type}$ :: proj_coefficients(size(X))
+      ${type}$ :: proj_coefficients_2(size(X))
       real(${kind}$) :: alpha
+
+      ! optional argument
+      normalize = optval(ifnorm, .false.)
+
+      info = 0
 
       ! check for zero vector
       if (y%norm() < atol_${kind}$) then
-         write(msg, *) 'The input vector is (numerically) zero.'
-         call logger%log_error(trim(msg), module=this_module, procedure='orthonormalize_vector_against_basis_${type[0]}$${kind}$', &
-                              & stat=-1, errmsg='Cannot orthonormalize.')
+         if (normalize) then
+            info = -1
+            return
+         else
+            info = 1
+         end if
       end if
 
       ! orthogonalize
-      call innerprod(coef, X, y)
+      call innerprod(proj_coefficients, X, y)
       block
          class(abstract_vector_${type[0]}$${kind}$), allocatable :: proj
-         call linear_combination(proj, X, coef)
+         call linear_combination(proj, X, proj_coefficients)
          call y%sub(proj)
       end block
 
       ! normalize
-      alpha = y%norm()
-      call y%scal(one_${type[0]}$${kind}$ / alpha)
-
-      if (alpha < atol_${kind}$) then ! error
-         write(msg, *) 'The input vector is in the span of X.'
-         call logger%log_error(trim(msg), module=this_module, procedure='orthonormalize_vector_against_basis_${type[0]}$${kind}$', & 
-                              & stat=-2, errmsg='Cannot orthonormalize.')
-      else if (alpha < rtol_${kind}$) then ! repeat to avoid floating point errors
-         write(msg, *) 'The norm of the component of y in the orthogonal complement of X is ||y||_orth = ', &
-                        & alpha, ': The input vector is nearly in the span of X. ', &
-                        & 'Repeating orthonormalisation.'
-         call logger%log_warning(trim(msg), module=this_module, procedure='orthonormalize_vector_against_basis_${type[0]}$${kind}$')
-         call innerprod(coef, X, y)
-         block
-            class(abstract_vector_${type[0]}$${kind}$), allocatable :: proj
-            call linear_combination(proj, X, coef)
-            call y%sub(proj)
-         end block
+      if (normalize) then
+         alpha = y%norm()
+         if (alpha < atol_${kind}$) then ! error
+            info = -2
+            return
+         else if (alpha < rtol_${kind}$) then ! repeat to avoid floating point errors
+            info = 2
+            call innerprod(proj_coefficients_2, X, y)
+            block
+               class(abstract_vector_${type[0]}$${kind}$), allocatable :: proj
+               call linear_combination(proj, X, proj_coefficients_2)
+               call y%sub(proj)
+            end block
+            proj_coefficients = proj_coefficients + proj_coefficients_2 ! for output
+         end if
          alpha = y%norm()
          call y%scal(one_${type[0]}$${kind}$ / alpha)
       end if
+
+      if (present(beta)) then
+         ! check size
+         call assert_shape(beta, [ size(X) ], 'orthogonalize_vector_against_basis_${type[0]}$${kind}$', 'beta')
+         beta = proj_coefficients
+      end if
       
       return
-    end subroutine orthonormalize_vector_against_basis_${type[0]}$${kind}$
+    end subroutine orthogonalize_vector_against_basis_${type[0]}$${kind}$
 
-    subroutine orthonormalize_basis_against_basis_${type[0]}$${kind}$(Y, X)
+    subroutine orthogonalize_basis_against_basis_${type[0]}$${kind}$(Y, X, info, beta, ifnorm)
       !! Orthonormalizes the `abstract_vector` basis `Y` against a basis `X` of `abstract_vector`.
       class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: Y(:)
-      !! Input `abstract_vector` basis to orthonormalize
+      !! Input `abstract_vector` basis to orthogonalize
       class(abstract_vector_${type[0]}$${kind}$), intent(in)    :: X(:)
-      !! Input `abstract_vector` basis to orthonormalize against
+      !! Input `abstract_vector` basis to orthogonalize against
+      integer, intent(out) :: info
+      !! Information flag.
+      ${type}$,                         optional, intent(out)   :: beta(:,:)
+      !! Projection coefficients if requested
+      logical,                          optional, intent(in)    :: ifnorm
+      logical                                                   :: normalize
+      !! Normalize output ?
 
       ! internals
       character*128 :: msg
-      ${type}$ :: coef(size(X), size(Y))
+      ${type}$ :: proj_coefficients(size(X), size(Y))
       ${type}$ :: R(size(Y), size(Y))
-      integer :: i, info
+      integer :: i
       logical :: repeat
 
-      ! check for zero vector
-      do i = 1, size(Y)
-         if ( Y(i)%norm() < atol_${kind}$) then
-            write(msg, *) 'Zero vector detected in input basis, column ', i
-            call logger%log_error(trim(msg), module=this_module, &
-                                 & procedure='orthonormalize_basis_against_basis_${type[0]}$${kind}$', & 
-                                 & stat=-1, errmsg='Cannot orthonormalize.')
-         end if
-      end do
+      ! optional argument
+      normalize = optval(ifnorm, .false.)
 
-      ! check for colinear vectors
-      R = zero_r${kind}$
-      call qr(Y, R, info)
-      call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_against_basis_${type[0]}$${kind}$')
-      if (info > 0) then ! colinear vectors!
-         write(msg, *) 'Colinear vectors detected in input basis'
-         call logger%log_error(trim(msg), module=this_module, &
-                                 & procedure='orthonormalize_basis_against_basis_${type[0]}$${kind}$', & 
-                                 & stat=-2, errmsg='Cannot orthonormalize.')
+      info = 0
+
+      if (normalize) then
+         ! check for zero vector
+         do i = 1, size(Y)
+            if ( Y(i)%norm() < atol_${kind}$) then
+               info = -1
+               return
+            end if
+         end do
+      
+         ! check for colinear vectors
+         R = zero_r${kind}$
+         call qr(Y, R, info)
+         call check_info(info, 'qr', module=this_module, procedure='orthogonalize_basis_against_basis_${type[0]}$${kind}$')
+         if (info > 0 .and. normalize) then ! colinear vectors!
+            info = -3
+            return
+         end if
+      else
+         ! check for zero vector
+         do i = 1, size(Y)
+            if ( Y(i)%norm() < atol_${kind}$) info = 1
+         end do
       end if
 
       ! orthogonalize
-      call innerprod(coef, X, Y)
+      call innerprod(proj_coefficients, X, Y)
       block
          class(abstract_vector_${type[0]}$${kind}$), allocatable :: proj(:)
-         call linear_combination(proj, X, coef)
+         call linear_combination(proj, X, proj_coefficients)
          call axpby_basis(Y, one_${type[0]}$${kind}$, proj, -one_${type[0]}$${kind}$)
       end block
-
-      do i = 1, size(Y)
-         if ( Y(i)%norm() < atol_${kind}$) then ! error
-            write(msg, *) 'The input vector', i, 'is in the span of X.'
-            call logger%log_error(trim(msg), module=this_module, &
-                                 & procedure='orthonormalize_basis_against_basis_${type[0]}$${kind}$', & 
-                                 & stat=-3, errmsg='Cannot orthonormalize.')
-         end if
-      end do
          
       ! normalize
-      R = zero_r${kind}$
-      call qr(Y, R, info)
-      call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_against_basis_${type[0]}$${kind}$')
+      if (normalize) then
+         ! check if Y is in the span of X
+         do i = 1, size(Y)
+            if ( Y(i)%norm() < atol_${kind}$) then ! error
+               info = -2
+               return
+            end if
+         end do
+         R = zero_r${kind}$
+         call qr(Y, R, info)
+         call check_info(info, 'qr', module=this_module, procedure='orthogonalize_basis_against_basis_${type[0]}$${kind}$')
+         proj_coefficients = matmul(proj_coefficients, R)
+      end if
+
+      if (present(beta)) then
+         ! check size
+         call assert_shape(beta, [ size(X), size(Y) ], 'orthogonalize_basis_against_basis_${type[0]}$${kind}$', 'beta')
+         beta = proj_coefficients
+      end if
       
       return
-    end subroutine orthonormalize_basis_against_basis_${type[0]}$${kind}$
+    end subroutine orthogonalize_basis_against_basis_${type[0]}$${kind}$
 
     #:endfor
 
@@ -253,7 +294,7 @@ contains
     #:for kind, type in RC_KINDS_TYPES
     subroutine qr_no_pivoting_${type[0]}$${kind}$(Q, R, info, verbosity, tol)
         class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: Q(:)
-        !! Array of `abstract_vector` to be orthonormalized.
+        !! Array of `abstract_vector` to be orthogonalized.
         ${type}$, intent(out) :: R(:, :)
         !! Upper triangular matrix \(\mathbf{R}\) resulting from the QR factorization.
         integer, intent(out) :: info
@@ -266,42 +307,43 @@ contains
         real(${kind}$)                       :: tolerance
 
         ! Internal variables.
-        ${type}$ :: beta
+        ${type}$ :: alpha
+        ${type}$ :: beta(size(Q))
         integer :: idx, i, j, k, kdim, iwrk
 
         ! Deals with the optional args.
         verbose   = optval(verbosity, .false.)
         tolerance = optval(tol, rtol_${kind}$)
 
-        info = 0 ; R = zero_r${kind}$
+        info = 0 ; R = zero_r${kind}$ ; beta = zero_r${kind}$
         do j = 1, size(Q)
-            ! First pass
-            do i = 1, j-1
-                beta = Q(i)%dot(Q(j))
-                call Q(j)%axpby(one_${type[0]}$${kind}$, Q(i), -beta)
-                R(i, j) = beta
-            enddo
+            if (j > 1) then
+               ! First pass
+               call orthogonalize_against_basis(Q(j), Q(1:j-1), info, beta(1:j-1))
+               call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+                                    & procedure='qr_no_pivoting_${type[0]}$${kind}$, first pass')
+               R(1:j-1,j) = beta(1:j-1)
 
-            ! Second pass
-            do i = 1, j-1
-                beta = Q(i)%dot(Q(j))
-                call Q(j)%axpby(one_${type[0]}$${kind}$, Q(i), -beta)
-                R(i, j) = R(i, j) + beta
-            enddo
+               ! Second pass
+               call orthogonalize_against_basis(Q(j), Q(1:j-1), info, beta(1:j-1))
+               call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+                                    & procedure='qr_no_pivoting_${type[0]}$${kind}$, second pass')
+               R(1:j-1,j) = R(1:j-1,j) + beta(1:j-1)
+            end if
 
             ! Normalize column.
-            beta = Q(j)%norm()
+            alpha = Q(j)%norm()
 
             ! Check for breakdown.
-            if (abs(beta) < tolerance) then
+            if (abs(alpha) < tolerance) then
                 if(verbose) then
                     write(output_unit, *) "INFO: Colinear columns detected."
-                    write(output_unit, *) "      (j, beta) = (", j, ", ", beta, ")"
+                    write(output_unit, *) "      (j, alpha) = (", j, ", ", alpha, ")"
                 endif
                 info = j
-                R(i, j) = zero_r${kind}$ ; call Q(j)%zero()
+                R(j, j) = zero_r${kind}$ ; call Q(j)%zero()
             else
-                call Q(j)%scal(one_r${kind}$ / beta) ; R(j, j) = beta
+                call Q(j)%scal(one_r${kind}$ / alpha) ; R(j, j) = alpha
             endif
         enddo
 
@@ -310,7 +352,7 @@ contains
 
     subroutine qr_with_pivoting_${type[0]}$${kind}$(Q, R, perm, info, verbosity, tol)
         class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: Q(:)
-        !! Array of `abstract_vector` to be orthonormalized.
+        !! Array of `abstract_vector` to be orthogonalized.
         ${type}$, intent(out) :: R(:, :)
         !! Upper triangular matrix resulting from the QR factorization.
         integer, intent(out) :: perm(size(Q))
@@ -349,12 +391,9 @@ contains
             if (abs(Rii(idx)) < tolerance) then
                 do i = j, kdim
                     call Q(i)%rand(.false.)
-                    ! Orthogonalize against existing columns
-                    do k = 1, i-1
-                        beta = Q(i)%dot(Q(k))
-                        call Q(i)%axpby(one_${type[0]}$${kind}$, Q(k), -beta)
-                    enddo
-                    beta = Q(i)%norm() ; call Q(i)%scal(one_r${kind}$ / beta)
+                    call orthogonalize_against_basis(Q(i), Q(1:i-1), info, ifnorm=.true.)
+                    call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+                                    & procedure='qr_with_pivoting_${type[0]}$${kind}$')
                 enddo
                 info = j
                 exit qr_step
@@ -620,7 +659,7 @@ contains
 
         ! Internal variables.
         ${type}$, allocatable :: wrk(:, :)
-        integer :: p, kpm, kp, kpp, i, j
+        integer :: p, kpm, kp, kpp, i, j, info
 
         ! Deals with optional non-unity block size.
         p = optval(blksize, 1)
@@ -630,21 +669,17 @@ contains
         allocate(wrk(1:kp, 1:p)) ; wrk = zero_r${kind}$
 
         ! Orthogonalize residual vector w.r.t. to previous computed Krylov vectors.
-        call innerprod(H(1:kp, kpm+1:kp), X(1:kp), X(kp+1:kpp))
-        do i = 1, p
-            do j = 1, kp
-                call X(kp+i)%axpby(one_${type[0]}$${kind}$, X(j), -H(j, kpm+i))
-            enddo
-        enddo
+        ! first pass
+        call orthogonalize_against_basis(X(kp+1:kpp), X(1:kp), info, H(1:kp, kpm+1:kp))
+        call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+                                    & procedure='update_hessenberg_matrix_${type[0]}$${kind}$, first pass')
 
-        call innerprod(wrk, X(1:kp), X(kp+1:kpp))
-        do i = 1, p
-            do j = 1, kp
-                call X(kp+i)%axpby(one_${type[0]}$${kind}$, X(j), -wrk(j, i))
-            enddo
-        enddo
+        ! second pass
+        call orthogonalize_against_basis(X(kp+1:kpp), X(1:kp), info, wrk)
+        call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+                                    & procedure='update_hessenberg_matrix_${type[0]}$${kind}$, second pass')
 
-        ! Update Hessenberg matrix with the second pass correction.
+        ! combine passes
         H(1:kp, kpm+1:kp) = H(1:kp, kpm+1:kp) + wrk
 
         return
@@ -683,7 +718,7 @@ contains
         integer :: k_start, k_end
         logical :: verbose
         real(${kind}$) :: tolerance
-        ${type}$ :: alpha, beta, gamma
+        ${type}$ :: alpha, beta
         integer :: i, j, k, kdim
 
 
@@ -704,10 +739,11 @@ contains
             call A%rmatvec(U(k), V(k))
 
             ! Full reorthogonalization of the right Krylov subspace.
-            do j = 1, k-1
-                gamma = V(j)%dot(V(k))
-                call V(k)%axpby(one_${type[0]}$${kind}$, V(j), -gamma)
-            enddo
+            if (k > 1 ) then
+               call orthogonalize_against_basis(V(k), V(1:k-1), info)
+               call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+                                    & procedure='lanczos_bidiagonalization_${type[0]}$${kind}$, first pass')
+            end if
 
             ! Normalization step.
             alpha = V(k)%norm() ; B(k, k) = alpha
@@ -722,10 +758,9 @@ contains
             call A%matvec(V(k), U(k+1))
 
             ! Full re-orthogonalization of the left Krylov subspace.
-            do j = 1, k
-                gamma = U(j)%dot(U(k+1))
-                call U(k+1)%axpby(one_${type[0]}$${kind}$, U(j), -gamma)
-           enddo
+            call orthogonalize_against_basis(U(k+1), U(1:k), info)
+            call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+                                    & procedure='lanczos_bidiagonalization_${type[0]}$${kind}$, second pass')
 
             ! Normalization step
             beta = U(k+1)%norm() ; B(k+1, k) = beta

--- a/src/BaseKrylov.fypp
+++ b/src/BaseKrylov.fypp
@@ -17,6 +17,7 @@ module lightkrylov_BaseKrylov
     public :: apply_inverse_permutation_matrix
     public :: arnoldi
     public :: initialize_krylov_subspace
+    public :: orthonormalize
     public :: lanczos_bidiagonalization
     public :: lanczos_tridiagonalization
     public :: krylov_schur
@@ -57,6 +58,13 @@ module lightkrylov_BaseKrylov
     interface initialize_krylov_subspace
         #:for kind, type in RC_KINDS_TYPES
         module procedure initialize_krylov_subspace_${type[0]}$${kind}$
+        #:endfor
+    end interface
+
+    interface orthonormalize
+        #:for kind, type in RC_KINDS_TYPES
+        module procedure orthonormalize_vector_${type[0]}$${kind}$
+        module procedure orthonormalize_basis_${type[0]}$${kind}$
         #:endfor
     end interface
 
@@ -122,6 +130,104 @@ contains
 
         return
     end subroutine initialize_krylov_subspace_${t1[0]}$${k1}$
+
+    subroutine orthonormalize_vector_${t1[0]}$${k1}$(y, X, info)
+      !! Orthonormalizes the `abstract_vector` `y` against a basis `X` of `abstract_vector`.
+      class(abstract_vector_${t1[0]}$${k1}$), intent(inout) :: y
+      !! Input `abstract_vector` to orthonormalize
+      class(abstract_vector_${t1[0]}$${k1}$), intent(in)    :: X(:)
+      !! Input `abstract_vector` basis to orthonormalize against
+      integer,                    intent(out)   :: info
+      !! Information flag
+
+      ! internals
+      ${t1}$ :: coef(size(X))
+      real(${k1}$) :: alpha
+
+      info = 0
+
+      if (y%norm() < atol_${kind}$) then
+         info = -1
+         return
+      end if
+
+      call innerprod(coef, X, y)
+      block
+         class(abstract_vector_${t1[0]}$${k1}$), allocatable :: proj
+         call linear_combination(proj, X, coef)
+         call y%sub(proj)
+      end block
+      alpha = y%norm()
+      call y%scal(one_${t1[0]}$${k1}$ / alpha)
+      if (alpha < 10*atol_${kind}$) then ! repeat to avoid floating point errors
+         call innerprod(coef, X, y)
+         block
+            class(abstract_vector_${t1[0]}$${k1}$), allocatable :: proj
+            call linear_combination(proj, X, coef)
+            call y%sub(proj)
+         end block
+         alpha = y%norm()
+         call y%scal(one_${t1[0]}$${k1}$ / alpha)
+         info = 1
+      end if
+      
+      return
+    end subroutine orthonormalize_vector_${t1[0]}$${k1}$
+
+    subroutine orthonormalize_basis_${t1[0]}$${k1}$(Y, X, info)
+      !! Orthonormalizes the `abstract_vector` basis `Y` against a basis `X` of `abstract_vector`.
+      class(abstract_vector_${t1[0]}$${k1}$), intent(inout) :: Y(:)
+      !! Input `abstract_vector` basis to orthonormalize
+      class(abstract_vector_${t1[0]}$${k1}$), intent(in)    :: X(:)
+      !! Input `abstract_vector` basis to orthonormalize against
+      integer,                    intent(out)   :: info
+      !! Information flag
+
+      ! internals
+      ${t1}$ :: coef(size(X), size(Y))
+      ${t1}$ :: R(size(Y), size(Y))
+      integer :: i
+      logical :: repeat
+
+      info = 0
+
+      do i = 1, size(Y)
+         if ( Y(i)%norm() < atol_${kind}$) then
+            info = -2
+            return
+         end if
+      end do
+
+      call innerprod(coef, X, Y)
+      block
+         class(abstract_vector_${t1[0]}$${k1}$), allocatable :: proj(:)
+         call linear_combination(proj, X, coef)
+         call axpby_basis(Y, one_${t1[0]}$${k1}$, proj, -one_${t1[0]}$${k1}$)
+      end block
+      R = 0.0_${k1}$
+      call qr(Y, R, info)
+      call check_info(info, 'qr', module='LightKrylov_BaseKrylov', procedure='orthonormalize_basis_rdp')
+
+      do i = 1, size(Y)
+         if ( Y(i)%norm() < atol_${kind}$) then ! repeat to avoid floating point errors
+            info = 1
+         end if
+      end do
+
+      if (info == 1) then
+         call innerprod(coef, X, Y)
+         block
+            class(abstract_vector_${t1[0]}$${k1}$), allocatable :: proj(:)
+            call linear_combination(proj, X, coef)
+            call axpby_basis(Y, one_${t1[0]}$${k1}$, proj, -one_${t1[0]}$${k1}$)
+         end block
+         R = 0.0_${k1}$
+         call qr(Y, R, info)
+         call check_info(info, 'qr', module='LightKrylov_BaseKrylov', procedure='orthonormalize_basis_rdp, second pass.')
+      end if
+      
+      return
+    end subroutine orthonormalize_basis_${t1[0]}$${k1}$
 
     #:endfor
 
@@ -531,14 +637,14 @@ contains
         allocate(wrk(1:kp, 1:p)) ; wrk = 0.0_${kind}$
 
         ! Orthogonalize residual vector w.r.t. to previous computed Krylov vectors.
-        call innerprod_matrix(H(1:kp, kpm+1:kp), X(1:kp), X(kp+1:kpp))
+        call innerprod(H(1:kp, kpm+1:kp), X(1:kp), X(kp+1:kpp))
         do i = 1, p
             do j = 1, kp
                 call X(kp+i)%axpby(one_${type[0]}$${kind}$, X(j), -H(j, kpm+i))
             enddo
         enddo
 
-        call innerprod_matrix(wrk, X(1:kp), X(kp+1:kpp))
+        call innerprod(wrk, X(1:kp), X(kp+1:kpp))
         do i = 1, p
             do j = 1, kp
                 call X(kp+i)%axpby(one_${type[0]}$${kind}$, X(j), -wrk(j, i))

--- a/src/Constants.f90
+++ b/src/Constants.f90
@@ -16,4 +16,15 @@ module lightkrylov_constants
     real(dp), parameter, public :: rtol_dp = sqrt(atol_dp)
     !! Definition of the relative tolerance for double precision computations.
 
+    real(sp), parameter, public :: one_rsp = 1.0_sp
+    real(sp), parameter, public :: zero_rsp = 0.0_sp
+    real(dp), parameter, public :: one_rdp = 1.0_dp
+    real(dp), parameter, public :: zero_rdp = 0.0_dp
+    complex(sp), parameter, public :: one_csp = cmplx(1.0_sp, 0.0_sp, kind=sp)
+    complex(sp), parameter, public :: one_im_csp = cmplx(0.0_sp, 1.0_sp, kind=sp)
+    complex(sp), parameter, public :: zero_csp = cmplx(0.0_sp, 0.0_sp, kind=sp)
+    complex(dp), parameter, public :: one_cdp = cmplx(1.0_dp, 0.0_dp, kind=dp)
+    complex(sp), parameter, public :: one_im_cdp = cmplx(0.0_dp, 1.0_dp, kind=dp)
+    complex(dp), parameter, public :: zero_cdp = cmplx(0.0_dp, 0.0_dp, kind=dp)
+
 end module lightkrylov_constants

--- a/src/Constants.f90
+++ b/src/Constants.f90
@@ -16,15 +16,15 @@ module lightkrylov_constants
     real(dp), parameter, public :: rtol_dp = sqrt(atol_dp)
     !! Definition of the relative tolerance for double precision computations.
 
-    real(sp), parameter, public :: one_rsp = 1.0_sp
+    real(sp), parameter, public :: one_rsp  = 1.0_sp
     real(sp), parameter, public :: zero_rsp = 0.0_sp
-    real(dp), parameter, public :: one_rdp = 1.0_dp
+    real(dp), parameter, public :: one_rdp  = 1.0_dp
     real(dp), parameter, public :: zero_rdp = 0.0_dp
-    complex(sp), parameter, public :: one_csp = cmplx(1.0_sp, 0.0_sp, kind=sp)
+    complex(sp), parameter, public :: one_csp    = cmplx(1.0_sp, 0.0_sp, kind=sp)
     complex(sp), parameter, public :: one_im_csp = cmplx(0.0_sp, 1.0_sp, kind=sp)
-    complex(sp), parameter, public :: zero_csp = cmplx(0.0_sp, 0.0_sp, kind=sp)
-    complex(dp), parameter, public :: one_cdp = cmplx(1.0_dp, 0.0_dp, kind=dp)
+    complex(sp), parameter, public :: zero_csp   = cmplx(0.0_sp, 0.0_sp, kind=sp)
+    complex(dp), parameter, public :: one_cdp    = cmplx(1.0_dp, 0.0_dp, kind=dp)
     complex(sp), parameter, public :: one_im_cdp = cmplx(0.0_dp, 1.0_dp, kind=dp)
-    complex(dp), parameter, public :: zero_cdp = cmplx(0.0_dp, 0.0_dp, kind=dp)
+    complex(dp), parameter, public :: zero_cdp   = cmplx(0.0_dp, 0.0_dp, kind=dp)
 
 end module lightkrylov_constants

--- a/src/ExpmLib.f90
+++ b/src/ExpmLib.f90
@@ -16,7 +16,8 @@ module lightkrylov_expmlib
     use lightkrylov_BaseKrylov
 
     implicit none
-    private
+    
+    character*128, parameter, private :: this_module = 'LightKrylov_ExpmLib'
 
     public :: abstract_exptA_rsp
     public :: abstract_exptA_rdp
@@ -269,7 +270,7 @@ contains
 
                 ! Compute k-th step Arnoldi factorization.
                 call arnoldi(A, X, H, info, kstart=k, kend=k, transpose=transpose)
-                call check_info(info, 'arnoldi', module='LightKrylov_ExpmLib', procedure='kexpm_vec_rsp')
+                call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_vec_rsp')
 
                 ! Compute approximation.
                 if (info == k) then
@@ -403,7 +404,7 @@ contains
 
                 ! Compute the k-th step of the Arnoldi factorization.
                 call arnoldi(A, X, H, info, kstart=k, kend=k, transpose=transpose, blksize=p)
-                call check_info(info, 'arnoldi', module='LightKrylov_ExpmLib', procedure='kexpm_mat_rsp')
+                call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_mat_rsp')
 
 
                 if (info == kp) then
@@ -478,7 +479,7 @@ contains
     subroutine k_exptA_rsp(vec_out, A, vec_in, tau, info, trans)
         class(abstract_vector_rsp), intent(out) :: vec_out
         !! Solution vector.
-        class(abstract_linop_rsp), intent(in) :: A
+        class(abstract_linop_rsp), intent(inout) :: A
         !! Linear operator to be exponentiated.
         class(abstract_vector_rsp), intent(in) :: vec_in
         !! Input vector to be multiplied by \( \exp(\tau \mathbf{A}) \).
@@ -499,7 +500,7 @@ contains
         verbose = .false.
 
         call kexpm(vec_out, A, vec_in, tau, tol, info, trans=trans, verbosity=verbose, kdim=kdim)
-        call check_info(info, 'kexpm', module='LightKrylov_ExpmLib', procedure='k_exptA_rsp')
+        call check_info(info, 'kexpm', module=this_module, procedure='k_exptA_rsp')
 
         return
     end subroutine k_exptA_rsp
@@ -637,7 +638,7 @@ contains
 
                 ! Compute k-th step Arnoldi factorization.
                 call arnoldi(A, X, H, info, kstart=k, kend=k, transpose=transpose)
-                call check_info(info, 'arnoldi', module='LightKrylov_ExpmLib', procedure='kexpm_vec_rdp')
+                call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_vec_rdp')
 
                 ! Compute approximation.
                 if (info == k) then
@@ -771,7 +772,7 @@ contains
 
                 ! Compute the k-th step of the Arnoldi factorization.
                 call arnoldi(A, X, H, info, kstart=k, kend=k, transpose=transpose, blksize=p)
-                call check_info(info, 'arnoldi', module='LightKrylov_ExpmLib', procedure='kexpm_mat_rdp')
+                call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_mat_rdp')
 
 
                 if (info == kp) then
@@ -846,7 +847,7 @@ contains
     subroutine k_exptA_rdp(vec_out, A, vec_in, tau, info, trans)
         class(abstract_vector_rdp), intent(out) :: vec_out
         !! Solution vector.
-        class(abstract_linop_rdp), intent(in) :: A
+        class(abstract_linop_rdp), intent(inout) :: A
         !! Linear operator to be exponentiated.
         class(abstract_vector_rdp), intent(in) :: vec_in
         !! Input vector to be multiplied by \( \exp(\tau \mathbf{A}) \).
@@ -867,7 +868,7 @@ contains
         verbose = .false.
 
         call kexpm(vec_out, A, vec_in, tau, tol, info, trans=trans, verbosity=verbose, kdim=kdim)
-        call check_info(info, 'kexpm', module='LightKrylov_ExpmLib', procedure='k_exptA_rdp')
+        call check_info(info, 'kexpm', module=this_module, procedure='k_exptA_rdp')
 
         return
     end subroutine k_exptA_rdp
@@ -1005,7 +1006,7 @@ contains
 
                 ! Compute k-th step Arnoldi factorization.
                 call arnoldi(A, X, H, info, kstart=k, kend=k, transpose=transpose)
-                call check_info(info, 'arnoldi', module='LightKrylov_ExpmLib', procedure='kexpm_vec_csp')
+                call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_vec_csp')
 
                 ! Compute approximation.
                 if (info == k) then
@@ -1139,7 +1140,7 @@ contains
 
                 ! Compute the k-th step of the Arnoldi factorization.
                 call arnoldi(A, X, H, info, kstart=k, kend=k, transpose=transpose, blksize=p)
-                call check_info(info, 'arnoldi', module='LightKrylov_ExpmLib', procedure='kexpm_mat_csp')
+                call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_mat_csp')
 
 
                 if (info == kp) then
@@ -1214,7 +1215,7 @@ contains
     subroutine k_exptA_csp(vec_out, A, vec_in, tau, info, trans)
         class(abstract_vector_csp), intent(out) :: vec_out
         !! Solution vector.
-        class(abstract_linop_csp), intent(in) :: A
+        class(abstract_linop_csp), intent(inout) :: A
         !! Linear operator to be exponentiated.
         class(abstract_vector_csp), intent(in) :: vec_in
         !! Input vector to be multiplied by \( \exp(\tau \mathbf{A}) \).
@@ -1235,7 +1236,7 @@ contains
         verbose = .false.
 
         call kexpm(vec_out, A, vec_in, tau, tol, info, trans=trans, verbosity=verbose, kdim=kdim)
-        call check_info(info, 'kexpm', module='LightKrylov_ExpmLib', procedure='k_exptA_csp')
+        call check_info(info, 'kexpm', module=this_module, procedure='k_exptA_csp')
 
         return
     end subroutine k_exptA_csp
@@ -1373,7 +1374,7 @@ contains
 
                 ! Compute k-th step Arnoldi factorization.
                 call arnoldi(A, X, H, info, kstart=k, kend=k, transpose=transpose)
-                call check_info(info, 'arnoldi', module='LightKrylov_ExpmLib', procedure='kexpm_vec_cdp')
+                call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_vec_cdp')
 
                 ! Compute approximation.
                 if (info == k) then
@@ -1507,7 +1508,7 @@ contains
 
                 ! Compute the k-th step of the Arnoldi factorization.
                 call arnoldi(A, X, H, info, kstart=k, kend=k, transpose=transpose, blksize=p)
-                call check_info(info, 'arnoldi', module='LightKrylov_ExpmLib', procedure='kexpm_mat_cdp')
+                call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_mat_cdp')
 
 
                 if (info == kp) then
@@ -1582,7 +1583,7 @@ contains
     subroutine k_exptA_cdp(vec_out, A, vec_in, tau, info, trans)
         class(abstract_vector_cdp), intent(out) :: vec_out
         !! Solution vector.
-        class(abstract_linop_cdp), intent(in) :: A
+        class(abstract_linop_cdp), intent(inout) :: A
         !! Linear operator to be exponentiated.
         class(abstract_vector_cdp), intent(in) :: vec_in
         !! Input vector to be multiplied by \( \exp(\tau \mathbf{A}) \).
@@ -1603,7 +1604,7 @@ contains
         verbose = .false.
 
         call kexpm(vec_out, A, vec_in, tau, tol, info, trans=trans, verbosity=verbose, kdim=kdim)
-        call check_info(info, 'kexpm', module='LightKrylov_ExpmLib', procedure='k_exptA_cdp')
+        call check_info(info, 'kexpm', module=this_module, procedure='k_exptA_cdp')
 
         return
     end subroutine k_exptA_cdp

--- a/src/ExpmLib.fypp
+++ b/src/ExpmLib.fypp
@@ -18,7 +18,8 @@ module lightkrylov_expmlib
     use lightkrylov_BaseKrylov
 
     implicit none
-    private
+    
+    character*128, parameter, private :: this_module = 'LightKrylov_ExpmLib'
 
     #:for kind, type in RC_KINDS_TYPES
     public :: abstract_exptA_${type[0]}$${kind}$
@@ -210,7 +211,7 @@ contains
 
                 ! Compute k-th step Arnoldi factorization.
                 call arnoldi(A, X, H, info, kstart=k, kend=k, transpose=transpose)
-                call check_info(info, 'arnoldi', module='LightKrylov_ExpmLib', procedure='kexpm_vec_${type[0]}$${kind}$')
+                call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_vec_${type[0]}$${kind}$')
 
                 ! Compute approximation.
                 if (info == k) then
@@ -344,7 +345,7 @@ contains
 
                 ! Compute the k-th step of the Arnoldi factorization.
                 call arnoldi(A, X, H, info, kstart=k, kend=k, transpose=transpose, blksize=p)
-                call check_info(info, 'arnoldi', module='LightKrylov_ExpmLib', procedure='kexpm_mat_${type[0]}$${kind}$')
+                call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_mat_${type[0]}$${kind}$')
 
 
                 if (info == kp) then
@@ -419,7 +420,7 @@ contains
     subroutine k_exptA_${type[0]}$${kind}$(vec_out, A, vec_in, tau, info, trans)
         class(abstract_vector_${type[0]}$${kind}$), intent(out) :: vec_out
         !! Solution vector.
-        class(abstract_linop_${type[0]}$${kind}$), intent(in) :: A
+        class(abstract_linop_${type[0]}$${kind}$), intent(inout) :: A
         !! Linear operator to be exponentiated.
         class(abstract_vector_${type[0]}$${kind}$), intent(in) :: vec_in
         !! Input vector to be multiplied by \( \exp(\tau \mathbf{A}) \).
@@ -440,7 +441,7 @@ contains
         verbose = .false.
 
         call kexpm(vec_out, A, vec_in, tau, tol, info, trans=trans, verbosity=verbose, kdim=kdim)
-        call check_info(info, 'kexpm', module='LightKrylov_ExpmLib', procedure='k_exptA_${type[0]}$${kind}$')
+        call check_info(info, 'kexpm', module=this_module, procedure='k_exptA_${type[0]}$${kind}$')
 
         return
     end subroutine k_exptA_${type[0]}$${kind}$

--- a/src/IterativeSolvers.f90
+++ b/src/IterativeSolvers.f90
@@ -1657,7 +1657,7 @@ contains
         allocate(V(1:kdim+1), source=b) ; call initialize_krylov_subspace(V)
         allocate(H(kdim+1, kdim)) ; H = 0.0_sp
         allocate(y(kdim)) ; y = 0.0_sp
-        allocate(alpha(kdim)) ; y = 0.0_sp
+        allocate(alpha(kdim)) ; alpha = 0.0_sp
         allocate(e(kdim+1)) ; e = 0.0_sp
 
         info = 0
@@ -1693,20 +1693,10 @@ contains
                 endif
 
                 ! Gram-Schmid orthogonalization (twice is enough).
-                !do j = 1, k
-                !    alpha = V(j)%dot(V(k+1))
-                !    call V(k+1)%axpby(one_rsp, V(j), -alpha)
-                !    H(j, k) = alpha
-                !enddo
                 ! first pass
                 call orthogonalize_against_basis(V(k+1), V(1:k), info, H(1:k, k))
                 call check_info(info, 'orthogonalize_against_basis', module=this_module, &
                                             & procedure='update_hessenberg_matrix_rsp, first pass')
-                !do j = 1, k
-                !    alpha = V(j)%dot(V(k+1))
-                !    call V(k+1)%axpby(one_rsp, V(j), -alpha)
-                !    H(j, k) = H(j, k) + alpha
-                !enddo
                 ! second pass
                 call orthogonalize_against_basis(V(k+1), V(1:k), info, alpha(1:k))
                 call check_info(info, 'orthogonalize_against_basis', module=this_module, &
@@ -1835,7 +1825,7 @@ contains
         allocate(V(1:kdim+1), source=b) ; call initialize_krylov_subspace(V)
         allocate(H(kdim+1, kdim)) ; H = 0.0_dp
         allocate(y(kdim)) ; y = 0.0_dp
-        allocate(alpha(kdim)) ; y = 0.0_dp
+        allocate(alpha(kdim)) ; alpha = 0.0_dp
         allocate(e(kdim+1)) ; e = 0.0_dp
 
         info = 0
@@ -1871,20 +1861,10 @@ contains
                 endif
 
                 ! Gram-Schmid orthogonalization (twice is enough).
-                !do j = 1, k
-                !    alpha = V(j)%dot(V(k+1))
-                !    call V(k+1)%axpby(one_rdp, V(j), -alpha)
-                !    H(j, k) = alpha
-                !enddo
                 ! first pass
                 call orthogonalize_against_basis(V(k+1), V(1:k), info, H(1:k, k))
                 call check_info(info, 'orthogonalize_against_basis', module=this_module, &
                                             & procedure='update_hessenberg_matrix_rdp, first pass')
-                !do j = 1, k
-                !    alpha = V(j)%dot(V(k+1))
-                !    call V(k+1)%axpby(one_rdp, V(j), -alpha)
-                !    H(j, k) = H(j, k) + alpha
-                !enddo
                 ! second pass
                 call orthogonalize_against_basis(V(k+1), V(1:k), info, alpha(1:k))
                 call check_info(info, 'orthogonalize_against_basis', module=this_module, &
@@ -2013,7 +1993,7 @@ contains
         allocate(V(1:kdim+1), source=b) ; call initialize_krylov_subspace(V)
         allocate(H(kdim+1, kdim)) ; H = 0.0_sp
         allocate(y(kdim)) ; y = 0.0_sp
-        allocate(alpha(kdim)) ; y = 0.0_sp
+        allocate(alpha(kdim)) ; alpha = 0.0_sp
         allocate(e(kdim+1)) ; e = 0.0_sp
 
         info = 0
@@ -2049,20 +2029,10 @@ contains
                 endif
 
                 ! Gram-Schmid orthogonalization (twice is enough).
-                !do j = 1, k
-                !    alpha = V(j)%dot(V(k+1))
-                !    call V(k+1)%axpby(one_csp, V(j), -alpha)
-                !    H(j, k) = alpha
-                !enddo
                 ! first pass
                 call orthogonalize_against_basis(V(k+1), V(1:k), info, H(1:k, k))
                 call check_info(info, 'orthogonalize_against_basis', module=this_module, &
                                             & procedure='update_hessenberg_matrix_csp, first pass')
-                !do j = 1, k
-                !    alpha = V(j)%dot(V(k+1))
-                !    call V(k+1)%axpby(one_csp, V(j), -alpha)
-                !    H(j, k) = H(j, k) + alpha
-                !enddo
                 ! second pass
                 call orthogonalize_against_basis(V(k+1), V(1:k), info, alpha(1:k))
                 call check_info(info, 'orthogonalize_against_basis', module=this_module, &
@@ -2191,7 +2161,7 @@ contains
         allocate(V(1:kdim+1), source=b) ; call initialize_krylov_subspace(V)
         allocate(H(kdim+1, kdim)) ; H = 0.0_dp
         allocate(y(kdim)) ; y = 0.0_dp
-        allocate(alpha(kdim)) ; y = 0.0_dp
+        allocate(alpha(kdim)) ; alpha = 0.0_dp
         allocate(e(kdim+1)) ; e = 0.0_dp
 
         info = 0
@@ -2227,20 +2197,10 @@ contains
                 endif
 
                 ! Gram-Schmid orthogonalization (twice is enough).
-                !do j = 1, k
-                !    alpha = V(j)%dot(V(k+1))
-                !    call V(k+1)%axpby(one_cdp, V(j), -alpha)
-                !    H(j, k) = alpha
-                !enddo
                 ! first pass
                 call orthogonalize_against_basis(V(k+1), V(1:k), info, H(1:k, k))
                 call check_info(info, 'orthogonalize_against_basis', module=this_module, &
                                             & procedure='update_hessenberg_matrix_cdp, first pass')
-                !do j = 1, k
-                !    alpha = V(j)%dot(V(k+1))
-                !    call V(k+1)%axpby(one_cdp, V(j), -alpha)
-                !    H(j, k) = H(j, k) + alpha
-                !enddo
                 ! second pass
                 call orthogonalize_against_basis(V(k+1), V(1:k), info, alpha(1:k))
                 call check_info(info, 'orthogonalize_against_basis', module=this_module, &

--- a/src/IterativeSolvers.f90
+++ b/src/IterativeSolvers.f90
@@ -1692,16 +1692,9 @@ contains
                     call A%matvec(wrk, V(k+1))
                 endif
 
-                ! Gram-Schmid orthogonalization (twice is enough).
-                ! first pass
-                call orthogonalize_against_basis(V(k+1), V(1:k), info, H(1:k, k))
-                call check_info(info, 'orthogonalize_against_basis', module=this_module, &
-                                            & procedure='update_hessenberg_matrix_rsp, first pass')
-                ! second pass
-                call orthogonalize_against_basis(V(k+1), V(1:k), info, alpha(1:k))
-                call check_info(info, 'orthogonalize_against_basis', module=this_module, &
-                                            & procedure='update_hessenberg_matrix_rsp, first pass')
-                H(1:k, k) = H(1:k, k) + alpha(1:k)
+                ! Double Gram-Schmid orthogonalization
+                call double_gram_schmidt_step(V(k+1), V(1:k), info, if_chk_orthonormal=.false., beta=H(1:k, k))
+                call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='gmres_rsp')
 
                 ! Update Hessenberg matrix and normalize residual Krylov vector.
                 H(k+1, k) = V(k+1)%norm()
@@ -1860,16 +1853,9 @@ contains
                     call A%matvec(wrk, V(k+1))
                 endif
 
-                ! Gram-Schmid orthogonalization (twice is enough).
-                ! first pass
-                call orthogonalize_against_basis(V(k+1), V(1:k), info, H(1:k, k))
-                call check_info(info, 'orthogonalize_against_basis', module=this_module, &
-                                            & procedure='update_hessenberg_matrix_rdp, first pass')
-                ! second pass
-                call orthogonalize_against_basis(V(k+1), V(1:k), info, alpha(1:k))
-                call check_info(info, 'orthogonalize_against_basis', module=this_module, &
-                                            & procedure='update_hessenberg_matrix_rdp, first pass')
-                H(1:k, k) = H(1:k, k) + alpha(1:k)
+                ! Double Gram-Schmid orthogonalization
+                call double_gram_schmidt_step(V(k+1), V(1:k), info, if_chk_orthonormal=.false., beta=H(1:k, k))
+                call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='gmres_rdp')
 
                 ! Update Hessenberg matrix and normalize residual Krylov vector.
                 H(k+1, k) = V(k+1)%norm()
@@ -2028,16 +2014,9 @@ contains
                     call A%matvec(wrk, V(k+1))
                 endif
 
-                ! Gram-Schmid orthogonalization (twice is enough).
-                ! first pass
-                call orthogonalize_against_basis(V(k+1), V(1:k), info, H(1:k, k))
-                call check_info(info, 'orthogonalize_against_basis', module=this_module, &
-                                            & procedure='update_hessenberg_matrix_csp, first pass')
-                ! second pass
-                call orthogonalize_against_basis(V(k+1), V(1:k), info, alpha(1:k))
-                call check_info(info, 'orthogonalize_against_basis', module=this_module, &
-                                            & procedure='update_hessenberg_matrix_csp, first pass')
-                H(1:k, k) = H(1:k, k) + alpha(1:k)
+                ! Double Gram-Schmid orthogonalization
+                call double_gram_schmidt_step(V(k+1), V(1:k), info, if_chk_orthonormal=.false., beta=H(1:k, k))
+                call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='gmres_csp')
 
                 ! Update Hessenberg matrix and normalize residual Krylov vector.
                 H(k+1, k) = V(k+1)%norm()
@@ -2196,16 +2175,9 @@ contains
                     call A%matvec(wrk, V(k+1))
                 endif
 
-                ! Gram-Schmid orthogonalization (twice is enough).
-                ! first pass
-                call orthogonalize_against_basis(V(k+1), V(1:k), info, H(1:k, k))
-                call check_info(info, 'orthogonalize_against_basis', module=this_module, &
-                                            & procedure='update_hessenberg_matrix_cdp, first pass')
-                ! second pass
-                call orthogonalize_against_basis(V(k+1), V(1:k), info, alpha(1:k))
-                call check_info(info, 'orthogonalize_against_basis', module=this_module, &
-                                            & procedure='update_hessenberg_matrix_cdp, first pass')
-                H(1:k, k) = H(1:k, k) + alpha(1:k)
+                ! Double Gram-Schmid orthogonalization
+                call double_gram_schmidt_step(V(k+1), V(1:k), info, if_chk_orthonormal=.false., beta=H(1:k, k))
+                call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='gmres_cdp')
 
                 ! Update Hessenberg matrix and normalize residual Krylov vector.
                 H(k+1, k) = V(k+1)%norm()

--- a/src/IterativeSolvers.f90
+++ b/src/IterativeSolvers.f90
@@ -840,7 +840,7 @@ contains
         lanczos : do k = 1, kdim_
             ! Symmetric Lanczos step.
             call lanczos_tridiagonalization(A, Xwrk, T, info, kstart=k, kend=k, verbosity=verbose)
-            call check_info(info, 'lanczos_tridiagonalisation', module=this_module, procedure='eighs_rsp')
+            call check_info(info, 'lanczos_tridiagonalization', module=this_module, procedure='eighs_rsp')
 
 
             ! Spectral decomposition of the k x k tridiagonal matrix.
@@ -941,7 +941,7 @@ contains
         lanczos : do k = 1, kdim_
             ! Symmetric Lanczos step.
             call lanczos_tridiagonalization(A, Xwrk, T, info, kstart=k, kend=k, verbosity=verbose)
-            call check_info(info, 'lanczos_tridiagonalisation', module=this_module, procedure='eighs_rdp')
+            call check_info(info, 'lanczos_tridiagonalization', module=this_module, procedure='eighs_rdp')
 
 
             ! Spectral decomposition of the k x k tridiagonal matrix.
@@ -1042,7 +1042,7 @@ contains
         lanczos : do k = 1, kdim_
             ! Symmetric Lanczos step.
             call lanczos_tridiagonalization(A, Xwrk, T, info, kstart=k, kend=k, verbosity=verbose)
-            call check_info(info, 'lanczos_tridiagonalisation', module=this_module, procedure='eighs_csp')
+            call check_info(info, 'lanczos_tridiagonalization', module=this_module, procedure='eighs_csp')
 
 
             ! Spectral decomposition of the k x k tridiagonal matrix.
@@ -1143,7 +1143,7 @@ contains
         lanczos : do k = 1, kdim_
             ! Symmetric Lanczos step.
             call lanczos_tridiagonalization(A, Xwrk, T, info, kstart=k, kend=k, verbosity=verbose)
-            call check_info(info, 'lanczos_tridiagonalisation', module=this_module, procedure='eighs_cdp')
+            call check_info(info, 'lanczos_tridiagonalization', module=this_module, procedure='eighs_cdp')
 
 
             ! Spectral decomposition of the k x k tridiagonal matrix.

--- a/src/IterativeSolvers.f90
+++ b/src/IterativeSolvers.f90
@@ -1624,7 +1624,7 @@ contains
 
         ! Miscellaneous.
         integer :: i, j, k
-        real(sp) :: alpha
+        real(sp), allocatable :: alpha(:)
         class(abstract_vector_rsp), allocatable :: dx, wrk
 
         ! Deals with the optional args.
@@ -1657,6 +1657,7 @@ contains
         allocate(V(1:kdim+1), source=b) ; call initialize_krylov_subspace(V)
         allocate(H(kdim+1, kdim)) ; H = 0.0_sp
         allocate(y(kdim)) ; y = 0.0_sp
+        allocate(alpha(kdim)) ; y = 0.0_sp
         allocate(e(kdim+1)) ; e = 0.0_sp
 
         info = 0
@@ -1692,16 +1693,25 @@ contains
                 endif
 
                 ! Gram-Schmid orthogonalization (twice is enough).
-                do j = 1, k
-                    alpha = V(j)%dot(V(k+1))
-                    call V(k+1)%axpby(one_rsp, V(j), -alpha)
-                    H(j, k) = alpha
-                enddo
-                do j = 1, k
-                    alpha = V(j)%dot(V(k+1))
-                    call V(k+1)%axpby(one_rsp, V(j), -alpha)
-                    H(j, k) = H(j, k) + alpha
-                enddo
+                !do j = 1, k
+                !    alpha = V(j)%dot(V(k+1))
+                !    call V(k+1)%axpby(one_rsp, V(j), -alpha)
+                !    H(j, k) = alpha
+                !enddo
+                ! first pass
+                call orthogonalize_against_basis(V(k+1), V(1:k), info, H(1:k, k))
+                call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+                                            & procedure='update_hessenberg_matrix_rsp, first pass')
+                !do j = 1, k
+                !    alpha = V(j)%dot(V(k+1))
+                !    call V(k+1)%axpby(one_rsp, V(j), -alpha)
+                !    H(j, k) = H(j, k) + alpha
+                !enddo
+                ! second pass
+                call orthogonalize_against_basis(V(k+1), V(1:k), info, alpha(1:k))
+                call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+                                            & procedure='update_hessenberg_matrix_rsp, first pass')
+                H(1:k, k) = H(1:k, k) + alpha(1:k)
 
                 ! Update Hessenberg matrix and normalize residual Krylov vector.
                 H(k+1, k) = V(k+1)%norm()
@@ -1792,7 +1802,7 @@ contains
 
         ! Miscellaneous.
         integer :: i, j, k
-        real(dp) :: alpha
+        real(dp), allocatable :: alpha(:)
         class(abstract_vector_rdp), allocatable :: dx, wrk
 
         ! Deals with the optional args.
@@ -1825,6 +1835,7 @@ contains
         allocate(V(1:kdim+1), source=b) ; call initialize_krylov_subspace(V)
         allocate(H(kdim+1, kdim)) ; H = 0.0_dp
         allocate(y(kdim)) ; y = 0.0_dp
+        allocate(alpha(kdim)) ; y = 0.0_dp
         allocate(e(kdim+1)) ; e = 0.0_dp
 
         info = 0
@@ -1860,16 +1871,25 @@ contains
                 endif
 
                 ! Gram-Schmid orthogonalization (twice is enough).
-                do j = 1, k
-                    alpha = V(j)%dot(V(k+1))
-                    call V(k+1)%axpby(one_rdp, V(j), -alpha)
-                    H(j, k) = alpha
-                enddo
-                do j = 1, k
-                    alpha = V(j)%dot(V(k+1))
-                    call V(k+1)%axpby(one_rdp, V(j), -alpha)
-                    H(j, k) = H(j, k) + alpha
-                enddo
+                !do j = 1, k
+                !    alpha = V(j)%dot(V(k+1))
+                !    call V(k+1)%axpby(one_rdp, V(j), -alpha)
+                !    H(j, k) = alpha
+                !enddo
+                ! first pass
+                call orthogonalize_against_basis(V(k+1), V(1:k), info, H(1:k, k))
+                call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+                                            & procedure='update_hessenberg_matrix_rdp, first pass')
+                !do j = 1, k
+                !    alpha = V(j)%dot(V(k+1))
+                !    call V(k+1)%axpby(one_rdp, V(j), -alpha)
+                !    H(j, k) = H(j, k) + alpha
+                !enddo
+                ! second pass
+                call orthogonalize_against_basis(V(k+1), V(1:k), info, alpha(1:k))
+                call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+                                            & procedure='update_hessenberg_matrix_rdp, first pass')
+                H(1:k, k) = H(1:k, k) + alpha(1:k)
 
                 ! Update Hessenberg matrix and normalize residual Krylov vector.
                 H(k+1, k) = V(k+1)%norm()
@@ -1960,7 +1980,7 @@ contains
 
         ! Miscellaneous.
         integer :: i, j, k
-        complex(sp) :: alpha
+        complex(sp), allocatable :: alpha(:)
         class(abstract_vector_csp), allocatable :: dx, wrk
 
         ! Deals with the optional args.
@@ -1993,6 +2013,7 @@ contains
         allocate(V(1:kdim+1), source=b) ; call initialize_krylov_subspace(V)
         allocate(H(kdim+1, kdim)) ; H = 0.0_sp
         allocate(y(kdim)) ; y = 0.0_sp
+        allocate(alpha(kdim)) ; y = 0.0_sp
         allocate(e(kdim+1)) ; e = 0.0_sp
 
         info = 0
@@ -2028,16 +2049,25 @@ contains
                 endif
 
                 ! Gram-Schmid orthogonalization (twice is enough).
-                do j = 1, k
-                    alpha = V(j)%dot(V(k+1))
-                    call V(k+1)%axpby(one_csp, V(j), -alpha)
-                    H(j, k) = alpha
-                enddo
-                do j = 1, k
-                    alpha = V(j)%dot(V(k+1))
-                    call V(k+1)%axpby(one_csp, V(j), -alpha)
-                    H(j, k) = H(j, k) + alpha
-                enddo
+                !do j = 1, k
+                !    alpha = V(j)%dot(V(k+1))
+                !    call V(k+1)%axpby(one_csp, V(j), -alpha)
+                !    H(j, k) = alpha
+                !enddo
+                ! first pass
+                call orthogonalize_against_basis(V(k+1), V(1:k), info, H(1:k, k))
+                call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+                                            & procedure='update_hessenberg_matrix_csp, first pass')
+                !do j = 1, k
+                !    alpha = V(j)%dot(V(k+1))
+                !    call V(k+1)%axpby(one_csp, V(j), -alpha)
+                !    H(j, k) = H(j, k) + alpha
+                !enddo
+                ! second pass
+                call orthogonalize_against_basis(V(k+1), V(1:k), info, alpha(1:k))
+                call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+                                            & procedure='update_hessenberg_matrix_csp, first pass')
+                H(1:k, k) = H(1:k, k) + alpha(1:k)
 
                 ! Update Hessenberg matrix and normalize residual Krylov vector.
                 H(k+1, k) = V(k+1)%norm()
@@ -2128,7 +2158,7 @@ contains
 
         ! Miscellaneous.
         integer :: i, j, k
-        complex(dp) :: alpha
+        complex(dp), allocatable :: alpha(:)
         class(abstract_vector_cdp), allocatable :: dx, wrk
 
         ! Deals with the optional args.
@@ -2161,6 +2191,7 @@ contains
         allocate(V(1:kdim+1), source=b) ; call initialize_krylov_subspace(V)
         allocate(H(kdim+1, kdim)) ; H = 0.0_dp
         allocate(y(kdim)) ; y = 0.0_dp
+        allocate(alpha(kdim)) ; y = 0.0_dp
         allocate(e(kdim+1)) ; e = 0.0_dp
 
         info = 0
@@ -2196,16 +2227,25 @@ contains
                 endif
 
                 ! Gram-Schmid orthogonalization (twice is enough).
-                do j = 1, k
-                    alpha = V(j)%dot(V(k+1))
-                    call V(k+1)%axpby(one_cdp, V(j), -alpha)
-                    H(j, k) = alpha
-                enddo
-                do j = 1, k
-                    alpha = V(j)%dot(V(k+1))
-                    call V(k+1)%axpby(one_cdp, V(j), -alpha)
-                    H(j, k) = H(j, k) + alpha
-                enddo
+                !do j = 1, k
+                !    alpha = V(j)%dot(V(k+1))
+                !    call V(k+1)%axpby(one_cdp, V(j), -alpha)
+                !    H(j, k) = alpha
+                !enddo
+                ! first pass
+                call orthogonalize_against_basis(V(k+1), V(1:k), info, H(1:k, k))
+                call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+                                            & procedure='update_hessenberg_matrix_cdp, first pass')
+                !do j = 1, k
+                !    alpha = V(j)%dot(V(k+1))
+                !    call V(k+1)%axpby(one_cdp, V(j), -alpha)
+                !    H(j, k) = H(j, k) + alpha
+                !enddo
+                ! second pass
+                call orthogonalize_against_basis(V(k+1), V(1:k), info, alpha(1:k))
+                call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+                                            & procedure='update_hessenberg_matrix_cdp, first pass')
+                H(1:k, k) = H(1:k, k) + alpha(1:k)
 
                 ! Update Hessenberg matrix and normalize residual Krylov vector.
                 H(k+1, k) = V(k+1)%norm()

--- a/src/IterativeSolvers.f90
+++ b/src/IterativeSolvers.f90
@@ -15,7 +15,7 @@ module lightkrylov_IterativeSolvers
 
     implicit none
 
-    private
+    character*128, parameter, private :: this_module = 'LightKrylov_IterativeSolvers'
 
     public :: save_eigenspectrum
     public :: eigs
@@ -311,7 +311,7 @@ contains
            arnoldi_factorization: do k = kstart, kdim_
                 ! Arnoldi step.
                 call arnoldi(A, Xwrk, H, info, kstart=k, kend=k, verbosity=verbose, transpose=transpose)
-                call check_info(info, 'arnoldi', module='LightKrylov_IterativeSolvers', procedure='eigs_rsp')
+                call check_info(info, 'arnoldi', module=this_module, procedure='eigs_rsp')
 
                 ! Spectral decomposition of the k x k Hessenberg matrix.
                 eigvals_wrk = 0.0_sp ; eigvecs_wrk = 0.0_sp
@@ -451,7 +451,7 @@ contains
            arnoldi_factorization: do k = kstart, kdim_
                 ! Arnoldi step.
                 call arnoldi(A, Xwrk, H, info, kstart=k, kend=k, verbosity=verbose, transpose=transpose)
-                call check_info(info, 'arnoldi', module='LightKrylov_IterativeSolvers', procedure='eigs_rdp')
+                call check_info(info, 'arnoldi', module=this_module, procedure='eigs_rdp')
 
                 ! Spectral decomposition of the k x k Hessenberg matrix.
                 eigvals_wrk = 0.0_dp ; eigvecs_wrk = 0.0_dp
@@ -590,7 +590,7 @@ contains
            arnoldi_factorization: do k = kstart, kdim_
                 ! Arnoldi step.
                 call arnoldi(A, Xwrk, H, info, kstart=k, kend=k, verbosity=verbose, transpose=transpose)
-                call check_info(info, 'arnoldi', module='LightKrylov_IterativeSolvers', procedure='eigs_csp')
+                call check_info(info, 'arnoldi', module=this_module, procedure='eigs_csp')
 
                 ! Spectral decomposition of the k x k Hessenberg matrix.
                 eigvals_wrk = 0.0_sp ; eigvecs_wrk = 0.0_sp
@@ -720,7 +720,7 @@ contains
            arnoldi_factorization: do k = kstart, kdim_
                 ! Arnoldi step.
                 call arnoldi(A, Xwrk, H, info, kstart=k, kend=k, verbosity=verbose, transpose=transpose)
-                call check_info(info, 'arnoldi', module='LightKrylov_IterativeSolvers', procedure='eigs_cdp')
+                call check_info(info, 'arnoldi', module=this_module, procedure='eigs_cdp')
 
                 ! Spectral decomposition of the k x k Hessenberg matrix.
                 eigvals_wrk = 0.0_dp ; eigvecs_wrk = 0.0_dp
@@ -840,7 +840,7 @@ contains
         lanczos : do k = 1, kdim_
             ! Symmetric Lanczos step.
             call lanczos_tridiagonalization(A, Xwrk, T, info, kstart=k, kend=k, verbosity=verbose)
-            call check_info(info, 'lanczos_tridiagonalisation', module='LightKrylov_IterativeSolvers', procedure='eighs_rsp')
+            call check_info(info, 'lanczos_tridiagonalisation', module=this_module, procedure='eighs_rsp')
 
 
             ! Spectral decomposition of the k x k tridiagonal matrix.
@@ -941,7 +941,7 @@ contains
         lanczos : do k = 1, kdim_
             ! Symmetric Lanczos step.
             call lanczos_tridiagonalization(A, Xwrk, T, info, kstart=k, kend=k, verbosity=verbose)
-            call check_info(info, 'lanczos_tridiagonalisation', module='LightKrylov_IterativeSolvers', procedure='eighs_rdp')
+            call check_info(info, 'lanczos_tridiagonalisation', module=this_module, procedure='eighs_rdp')
 
 
             ! Spectral decomposition of the k x k tridiagonal matrix.
@@ -1042,7 +1042,7 @@ contains
         lanczos : do k = 1, kdim_
             ! Symmetric Lanczos step.
             call lanczos_tridiagonalization(A, Xwrk, T, info, kstart=k, kend=k, verbosity=verbose)
-            call check_info(info, 'lanczos_tridiagonalisation', module='LightKrylov_IterativeSolvers', procedure='eighs_csp')
+            call check_info(info, 'lanczos_tridiagonalisation', module=this_module, procedure='eighs_csp')
 
 
             ! Spectral decomposition of the k x k tridiagonal matrix.
@@ -1143,7 +1143,7 @@ contains
         lanczos : do k = 1, kdim_
             ! Symmetric Lanczos step.
             call lanczos_tridiagonalization(A, Xwrk, T, info, kstart=k, kend=k, verbosity=verbose)
-            call check_info(info, 'lanczos_tridiagonalisation', module='LightKrylov_IterativeSolvers', procedure='eighs_cdp')
+            call check_info(info, 'lanczos_tridiagonalisation', module=this_module, procedure='eighs_cdp')
 
 
             ! Spectral decomposition of the k x k tridiagonal matrix.
@@ -1251,7 +1251,7 @@ contains
         lanczos : do k = 1, kdim_
             ! Lanczos bidiag. step.
             call lanczos_bidiagonalization(A, Uwrk, Vwrk, B, info, kstart=k, kend=k, verbosity=verbosity, tol=tol)
-            call check_info(info, 'lanczos_bidiagonalization', module='LightKrylov_IterativeSolvers', procedure='svds_rsp')
+            call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='svds_rsp')
 
             ! SVD of the k x k bidiagonal matrix.
             svdvals_wrk = 0.0_sp ; umat = 0.0_sp ; vmat = 0.0_sp
@@ -1348,7 +1348,7 @@ contains
         lanczos : do k = 1, kdim_
             ! Lanczos bidiag. step.
             call lanczos_bidiagonalization(A, Uwrk, Vwrk, B, info, kstart=k, kend=k, verbosity=verbosity, tol=tol)
-            call check_info(info, 'lanczos_bidiagonalization', module='LightKrylov_IterativeSolvers', procedure='svds_rdp')
+            call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='svds_rdp')
 
             ! SVD of the k x k bidiagonal matrix.
             svdvals_wrk = 0.0_dp ; umat = 0.0_dp ; vmat = 0.0_dp
@@ -1445,7 +1445,7 @@ contains
         lanczos : do k = 1, kdim_
             ! Lanczos bidiag. step.
             call lanczos_bidiagonalization(A, Uwrk, Vwrk, B, info, kstart=k, kend=k, verbosity=verbosity, tol=tol)
-            call check_info(info, 'lanczos_bidiagonalization', module='LightKrylov_IterativeSolvers', procedure='svds_csp')
+            call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='svds_csp')
 
             ! SVD of the k x k bidiagonal matrix.
             svdvals_wrk = 0.0_sp ; umat = 0.0_sp ; vmat = 0.0_sp
@@ -1542,7 +1542,7 @@ contains
         lanczos : do k = 1, kdim_
             ! Lanczos bidiag. step.
             call lanczos_bidiagonalization(A, Uwrk, Vwrk, B, info, kstart=k, kend=k, verbosity=verbosity, tol=tol)
-            call check_info(info, 'lanczos_bidiagonalization', module='LightKrylov_IterativeSolvers', procedure='svds_cdp')
+            call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='svds_cdp')
 
             ! SVD of the k x k bidiagonal matrix.
             svdvals_wrk = 0.0_dp ; umat = 0.0_dp ; vmat = 0.0_dp

--- a/src/IterativeSolvers.fypp
+++ b/src/IterativeSolvers.fypp
@@ -616,16 +616,9 @@ contains
                     call A%matvec(wrk, V(k+1))
                 endif
 
-                ! Gram-Schmid orthogonalization (twice is enough).
-                ! first pass
-                call orthogonalize_against_basis(V(k+1), V(1:k), info, H(1:k, k))
-                call check_info(info, 'orthogonalize_against_basis', module=this_module, &
-                                            & procedure='update_hessenberg_matrix_${type[0]}$${kind}$, first pass')
-                ! second pass
-                call orthogonalize_against_basis(V(k+1), V(1:k), info, alpha(1:k))
-                call check_info(info, 'orthogonalize_against_basis', module=this_module, &
-                                            & procedure='update_hessenberg_matrix_${type[0]}$${kind}$, first pass')
-                H(1:k, k) = H(1:k, k) + alpha(1:k)
+                ! Double Gram-Schmid orthogonalization
+                call double_gram_schmidt_step(V(k+1), V(1:k), info, if_chk_orthonormal=.false., beta=H(1:k, k))
+                call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='gmres_${type[0]}$${kind}$')
 
                 ! Update Hessenberg matrix and normalize residual Krylov vector.
                 H(k+1, k) = V(k+1)%norm()

--- a/src/IterativeSolvers.fypp
+++ b/src/IterativeSolvers.fypp
@@ -354,7 +354,7 @@ contains
         lanczos : do k = 1, kdim_
             ! Symmetric Lanczos step.
             call lanczos_tridiagonalization(A, Xwrk, T, info, kstart=k, kend=k, verbosity=verbose)
-            call check_info(info, 'lanczos_tridiagonalisation', module=this_module, procedure='eighs_${type[0]}$${kind}$')
+            call check_info(info, 'lanczos_tridiagonalization', module=this_module, procedure='eighs_${type[0]}$${kind}$')
 
 
             ! Spectral decomposition of the k x k tridiagonal matrix.

--- a/src/IterativeSolvers.fypp
+++ b/src/IterativeSolvers.fypp
@@ -548,7 +548,7 @@ contains
 
         ! Miscellaneous.
         integer :: i, j, k
-        ${type}$ :: alpha
+        ${type}$, allocatable :: alpha(:)
         class(abstract_vector_${type[0]}$${kind}$), allocatable :: dx, wrk
 
         ! Deals with the optional args.
@@ -581,6 +581,7 @@ contains
         allocate(V(1:kdim+1), source=b) ; call initialize_krylov_subspace(V)
         allocate(H(kdim+1, kdim)) ; H = 0.0_${kind}$
         allocate(y(kdim)) ; y = 0.0_${kind}$
+        allocate(alpha(kdim)) ; y = 0.0_${kind}$
         allocate(e(kdim+1)) ; e = 0.0_${kind}$
 
         info = 0
@@ -616,16 +617,15 @@ contains
                 endif
 
                 ! Gram-Schmid orthogonalization (twice is enough).
-                do j = 1, k
-                    alpha = V(j)%dot(V(k+1))
-                    call V(k+1)%axpby(one_${type[0]}$${kind}$, V(j), -alpha)
-                    H(j, k) = alpha
-                enddo
-                do j = 1, k
-                    alpha = V(j)%dot(V(k+1))
-                    call V(k+1)%axpby(one_${type[0]}$${kind}$, V(j), -alpha)
-                    H(j, k) = H(j, k) + alpha
-                enddo
+                ! first pass
+                call orthogonalize_against_basis(V(k+1), V(1:k), info, H(1:k, k))
+                call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+                                            & procedure='update_hessenberg_matrix_${type[0]}$${kind}$, first pass')
+                ! second pass
+                call orthogonalize_against_basis(V(k+1), V(1:k), info, alpha(1:k))
+                call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+                                            & procedure='update_hessenberg_matrix_${type[0]}$${kind}$, first pass')
+                H(1:k, k) = H(1:k, k) + alpha(1:k)
 
                 ! Update Hessenberg matrix and normalize residual Krylov vector.
                 H(k+1, k) = V(k+1)%norm()

--- a/src/IterativeSolvers.fypp
+++ b/src/IterativeSolvers.fypp
@@ -17,7 +17,7 @@ module lightkrylov_IterativeSolvers
 
     implicit none
 
-    private
+    character*128, parameter, private :: this_module = 'LightKrylov_IterativeSolvers'
 
     public :: save_eigenspectrum
     public :: eigs
@@ -215,7 +215,7 @@ contains
            arnoldi_factorization: do k = kstart, kdim_
                 ! Arnoldi step.
                 call arnoldi(A, Xwrk, H, info, kstart=k, kend=k, verbosity=verbose, transpose=transpose)
-                call check_info(info, 'arnoldi', module='LightKrylov_IterativeSolvers', procedure='eigs_${type[0]}$${kind}$')
+                call check_info(info, 'arnoldi', module=this_module, procedure='eigs_${type[0]}$${kind}$')
 
                 ! Spectral decomposition of the k x k Hessenberg matrix.
                 eigvals_wrk = 0.0_${kind}$ ; eigvecs_wrk = 0.0_${kind}$
@@ -354,7 +354,7 @@ contains
         lanczos : do k = 1, kdim_
             ! Symmetric Lanczos step.
             call lanczos_tridiagonalization(A, Xwrk, T, info, kstart=k, kend=k, verbosity=verbose)
-            call check_info(info, 'lanczos_tridiagonalisation', module='LightKrylov_IterativeSolvers', procedure='eighs_${type[0]}$${kind}$')
+            call check_info(info, 'lanczos_tridiagonalisation', module=this_module, procedure='eighs_${type[0]}$${kind}$')
 
 
             ! Spectral decomposition of the k x k tridiagonal matrix.
@@ -464,7 +464,7 @@ contains
         lanczos : do k = 1, kdim_
             ! Lanczos bidiag. step.
             call lanczos_bidiagonalization(A, Uwrk, Vwrk, B, info, kstart=k, kend=k, verbosity=verbosity, tol=tol)
-            call check_info(info, 'lanczos_bidiagonalization', module='LightKrylov_IterativeSolvers', procedure='svds_${type[0]}$${kind}$')
+            call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='svds_${type[0]}$${kind}$')
 
             ! SVD of the k x k bidiagonal matrix.
             svdvals_wrk = 0.0_${kind}$ ; umat = 0.0_${kind}$ ; vmat = 0.0_${kind}$

--- a/src/IterativeSolvers.fypp
+++ b/src/IterativeSolvers.fypp
@@ -581,7 +581,7 @@ contains
         allocate(V(1:kdim+1), source=b) ; call initialize_krylov_subspace(V)
         allocate(H(kdim+1, kdim)) ; H = 0.0_${kind}$
         allocate(y(kdim)) ; y = 0.0_${kind}$
-        allocate(alpha(kdim)) ; y = 0.0_${kind}$
+        allocate(alpha(kdim)) ; alpha = 0.0_${kind}$
         allocate(e(kdim+1)) ; e = 0.0_${kind}$
 
         info = 0

--- a/src/LightKrylov.fypp
+++ b/src/LightKrylov.fypp
@@ -33,22 +33,22 @@ module LightKrylov
 
     ! AbstractVectors exports.
     public :: abstract_vector
-    #:for k1, t1 in RC_KINDS_TYPES
-    public :: abstract_vector_${t1[0]}$${k1}$
+    #:for kind, type in RC_KINDS_TYPES
+    public :: abstract_vector_${type[0]}$${kind}$
     #:endfor
     
     ! AbstractLinops exports.
     public :: abstract_linop
-    #:for k1, t1 in RC_KINDS_TYPES
-    public :: abstract_linop_${t1[0]}$${k1}$
-    public :: adjoint_linop_${t1[0]}$${k1}$
-    public :: Id_${t1[0]}$${k1}$
-    public :: scaled_linop_${t1[0]}$${k1}$
-    public :: axpby_linop_${t1[0]}$${k1}$
-    #:if t1[0] == "r"
-    public :: abstract_sym_linop_${t1[0]}$${k1}$
+    #:for kind, type in RC_KINDS_TYPES
+    public :: abstract_linop_${type[0]}$${kind}$
+    public :: adjoint_linop_${type[0]}$${kind}$
+    public :: Id_${type[0]}$${kind}$
+    public :: scaled_linop_${type[0]}$${kind}$
+    public :: axpby_linop_${type[0]}$${kind}$
+    #:if type[0] == "r"
+    public :: abstract_sym_linop_${type[0]}$${kind}$
     #:else
-    public :: abstract_hermitian_linop_${t1[0]}$${k1}$
+    public :: abstract_hermitian_linop_${type[0]}$${kind}$
     #:endif
     #:endfor
     

--- a/src/Logger.f90
+++ b/src/Logger.f90
@@ -36,91 +36,91 @@ contains
             ! GETREF
             if (info < 0 ) then
                write(msg, *) "The ", -info, "-th argument has illegal value."
-               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=msg)
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             else
                write(msg, *) "U(", info, ",", info, ") is exactly zero. The factorization ", &
                            & "has been completed but the factor U is exactly singular. ", &
                            & "Division by zero will occur if used to solve Ax=b."
-               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=msg)
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
          else if (trim(to_lower(origin)) == 'getri') then
             ! GETRI
             if (info < 0 ) then
                write(msg, *) "The ", -info, "-th argument has illegal value."
-               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=msg)
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             else
                write(msg, *) "U(", info, ",", info, ") is exactly zero. ", &
                            & "The matrix is singular and its inverse cannot be computed."
-               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=msg)
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
          else if (trim(to_lower(origin)) == 'geev') then
             ! GEEV
             if (info < 0) then
                write(msg, *) "The ", -info, "-th argument has illegal value."
-               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=msg)
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             else 
                write(msg, *) "The QR alg. failed to compute all of the eigenvalues.", &
                            & "No eigenvector has been computed."
-               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=msg)
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
          else if (trim(to_lower(origin)) == 'syev') then
             ! SYEV
             if (info < 0) then
                write(msg, *) "The ", -info, "-th argument has illegal value."
-               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=msg)
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             else 
                write(msg, *) "The QR alg. failed to compute all of the eigenvalues.", &
                            & "No eigenvector has been computed."
-               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=msg)
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
          else if (trim(to_lower(origin)) == 'heev') then
             ! HEEV
             if (info < 0) then
                write(msg, *) "The ", -info, "-th argument has illegal value."
-               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=msg)
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             else 
                write(msg, *) "The QR alg. failed to compute all of the eigenvalues.", &
                            & "No eigenvector has been computed."
-               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=msg)
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
          else if (trim(to_lower(origin)) == 'gels') then
             ! GELS
             if (info < 0) then
                write(msg, *) "The ", -info, "-th argument has illegal value."
-               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=msg)
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             else
                write(msg, *) "Undocumented error."
-               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=msg)
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
          else if (trim(to_lower(origin)) == 'gees') then
             ! GEES
             if (info < 0) then
                write(msg, *) "The ", -info, "-th argument has illegal value."
-               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=msg)
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             else
                write(msg, *) "The QR alg. failed to compute all of the eigenvalues.", &
                            & "No eigenvector has been computed."
-               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=msg)
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
          else if (trim(to_lower(origin)) == 'trsen') then
             ! GEES
             if (info < 0) then
                write(msg, *) "The ", -info, "-th argument has illegal value."
-               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=msg)
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             else if (info == 1) then
                write(msg, *) "The reordering of T failed because some eigenvalues are too", &
@@ -128,24 +128,24 @@ contains
                            & "T may have been partially reordered, and WR and WI ", &
                            & "contain the eigenvalues in the same order as in T; S and", &
                            & "SEP (if requested) are set to zero."
-               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=msg)
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             else
                write(msg, *) "Undocumented error."
-               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=msg)
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
          else if (trim(to_lower(origin)) == 'gesvd') then
             ! GESVD
             if (info < 0) then
                write(msg, *) "The ", -info, "-th argument has illegal value."
-               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=msg)
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             else
                write(msg, *) "The QR alg. did not converge. ", info, &
                            & "superdiagonals of an intermediate bidiagonal form B ", &
                            & "did not converge to zero."
-               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=msg)
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
          !
@@ -157,16 +157,41 @@ contains
                call logger%log_warning(trim(msg), module=module, procedure=procedure)
             else if (info == -1) then
                write(msg, *) "The input matrix is not positive (semi-)definite. "
-               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=msg)
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             else
                write(msg, *) "Undocumented error."
-               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=msg)
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
          !
          !   LightKrylov_BaseKrylov
          !
+         else if (trim(to_lower(origin)) == 'orthogonalize_against_basis') then
+            ! orthogonalization
+            if (info == 1) then
+               write(msg, *) 'One or more of the input vectors is numerically zero.'
+               call logger%log_information(trim(msg), module=module, procedure=procedure)
+            else if (info == 2) then
+               write(msg, *) 'One or more of the input vectors is nearly in the span of X. Repeating orthonormalization.'
+               call logger%log_information(trim(msg), module=module, procedure=procedure)
+            else if (info == -1) then
+               write(msg, *) 'One or more of the input vectors is numerically zero. Cannot orthonormalize.'
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
+               ierr = -1
+            else if (info == -2) then
+               write(msg, *) 'One or more of the input vectors is numerically in the span of X. Cannot orthonormalize.'
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
+               ierr = -1
+            else if (info == -3) then
+               write(msg, *) 'Colinear vectors detected in the input basis. Cannot orthonormalize.'
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
+               ierr = -1
+            else
+               write(msg, *) "Undocumented error."
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
+               ierr = -1
+            end if
          else if (trim(to_lower(origin)) == 'qr') then
             ! qr
             if (info > 0) then
@@ -174,7 +199,7 @@ contains
                call logger%log_information(trim(msg), module=module, procedure=procedure)
             else
                write(msg, *) "Undocumented error."
-               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=msg)
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
          else if (trim(to_lower(origin)) == 'qr_pivot') then
@@ -184,7 +209,7 @@ contains
                call logger%log_information(trim(msg), module=module, procedure=procedure)
             else
                write(msg, *) "Undocumented error."
-               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=msg)
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
          else if (trim(to_lower(origin)) == 'arnoldi') then
@@ -194,7 +219,7 @@ contains
                call logger%log_information(trim(msg), module=module, procedure=procedure)
             else
                write(msg, *) "Undocumented error."
-               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=msg)
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
          else if (trim(to_lower(origin)) == 'lanczos_bidiagonalization') then
@@ -204,7 +229,7 @@ contains
                call logger%log_information(trim(msg), module=module, procedure=procedure)
             else
                write(msg, *) "Undocumented error."
-               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=msg)
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
          else if (trim(to_lower(origin)) == 'lanczos_tridiagonalization') then
@@ -214,7 +239,7 @@ contains
                call logger%log_information(trim(msg), module=module, procedure=procedure)
             else
                write(msg, *) "Undocumented error."
-               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=msg)
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
          !
@@ -227,7 +252,7 @@ contains
                call logger%log_information(trim(msg), module=module, procedure=procedure)
             else
                write(msg, *) "Undocumented error."
-               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=msg)
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
          else if (trim(to_lower(origin)) == 'eighs') then
@@ -237,7 +262,7 @@ contains
                call logger%log_information(trim(msg), module=module, procedure=procedure)
             else
                write(msg, *) "Undocumented error."
-               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=msg)
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
          else if (trim(to_lower(origin)) == 'svds') then
@@ -247,7 +272,7 @@ contains
                call logger%log_information(trim(msg), module=module, procedure=procedure)
             else
                write(msg, *) "Undocumented error."
-               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=msg)
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
          else if (trim(to_lower(origin)) == 'gmres') then
@@ -257,7 +282,7 @@ contains
                call logger%log_information(trim(msg), module=module, procedure=procedure)
             else
                write(msg, *) "Undocumented error."
-               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=msg)
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
          else if (trim(to_lower(origin)) == 'cg') then
@@ -267,7 +292,7 @@ contains
                call logger%log_information(trim(msg), module=module, procedure=procedure)
             else
                write(msg, *) "Undocumented error."
-               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=msg)
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
          !
@@ -283,10 +308,10 @@ contains
                call logger%log_information(trim(msg), module=module, procedure=procedure)
             else if (info == -1) then
                write(msg, *) 'kexpm did not converge. Maximum number of Krylov vectors reached.'
-               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=msg)
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             write(msg, *) "Undocumented error."
-               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=msg)
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
          !

--- a/src/Logger.f90
+++ b/src/Logger.f90
@@ -25,9 +25,9 @@ contains
 
       ierr = 0
       if (info == 0) then
-         ! Successful exit
+         ! Successful exit --> only log on debug
          write(msg, *) 'The subroutine "'//trim(origin)//'" returned successfully.'
-         call logger%log_information(trim(msg), module=module, procedure=procedure)
+         call logger%log_debug(trim(msg), module=module, procedure=procedure)
       else
          !
          !   LAPACK

--- a/src/Logger.f90
+++ b/src/Logger.f90
@@ -230,6 +230,16 @@ contains
                call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=msg)
                ierr = -1
             end if
+         else if (trim(to_lower(origin)) == 'eighs') then
+            ! GMRES
+            if (info > 0) then
+               write(msg, *) 'eigs iteration converged after', info, 'iterations'
+               call logger%log_information(trim(msg), module=module, procedure=procedure)
+            else
+               write(msg, *) "Undocumented error."
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=msg)
+               ierr = -1
+            end if
          else if (trim(to_lower(origin)) == 'svds') then
             ! GMRES
             if (info > 0) then
@@ -283,7 +293,7 @@ contains
          !   Default
          !
          else 
-            write(msg,'(A,I2)') 'subroutine "'//trim(origin)//'" returned with flag: ', info
+            write(msg,*) 'subroutine "'//trim(origin)//'" returned with flag: ', info
             call logger%log_error(trim(msg), module=module, procedure=procedure)
             ierr = -1
          end if

--- a/src/Logger.f90
+++ b/src/Logger.f90
@@ -170,23 +170,8 @@ contains
          else if (trim(to_lower(origin)) == 'orthogonalize_against_basis') then
             ! orthogonalization
             if (info == 1) then
-               write(msg, *) 'One or more of the input vectors is numerically zero.'
+               write(msg, *) 'Othogonalization: The ', info, 'th input vector is numerically zero.'
                call logger%log_information(trim(msg), module=module, procedure=procedure)
-            else if (info == 2) then
-               write(msg, *) 'One or more of the input vectors is nearly in the span of X. Repeating orthonormalization.'
-               call logger%log_information(trim(msg), module=module, procedure=procedure)
-            else if (info == -1) then
-               write(msg, *) 'One or more of the input vectors is numerically zero. Cannot orthonormalize.'
-               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
-               ierr = -1
-            else if (info == -2) then
-               write(msg, *) 'One or more of the input vectors is numerically in the span of X. Cannot orthonormalize.'
-               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
-               ierr = -1
-            else if (info == -3) then
-               write(msg, *) 'Colinear vectors detected in the input basis. Cannot orthonormalize.'
-               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
-               ierr = -1
             else
                write(msg, *) "Undocumented error."
                call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))

--- a/src/Logger.f90
+++ b/src/Logger.f90
@@ -170,8 +170,32 @@ contains
          else if (trim(to_lower(origin)) == 'orthogonalize_against_basis') then
             ! orthogonalization
             if (info == 1) then
-               write(msg, *) 'Othogonalization: The ', info, 'th input vector is numerically zero.'
+               write(msg, *) 'Orthogonalization: The ', info, 'th input vector is numerically zero.'
                call logger%log_information(trim(msg), module=module, procedure=procedure)
+            else if (info == -1) then
+               write(msg, *) 'The input Krylov basis is not orthonormal.'
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
+               ierr = -1
+            else if (info == -2) then
+               write(msg, *) 'Orthogonalization: The last column of the input basis is zero.'
+               call logger%log_warning(trim(msg), module=module, procedure=procedure)
+            else
+               write(msg, *) "Undocumented error."
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
+               ierr = -1
+            end if
+         else if (trim(to_lower(origin)) == 'double_gram_schmidt_step') then
+            ! orthogonalization
+            if (info == 1) then
+               write(msg, *) 'Orthogonalization: The ', info, 'th input vector is numerically zero.'
+               call logger%log_information(trim(msg), module=module, procedure=procedure)
+            else if (info == -1) then
+               write(msg, *) 'The input Krylov basis is not orthonormal.'
+               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
+               ierr = -1
+            else if (info == -2) then
+               write(msg, *) 'Orthogonalization: The last column of the input basis is zero.'
+               call logger%log_warning(trim(msg), module=module, procedure=procedure)
             else
                write(msg, *) "Undocumented error."
                call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))

--- a/src/Utils.f90
+++ b/src/Utils.f90
@@ -59,10 +59,14 @@ module lightkrylov_utils
     public :: norml_cdp
 
     interface assert_shape
-        module procedure assert_shape_rsp
-        module procedure assert_shape_rdp
-        module procedure assert_shape_csp
-        module procedure assert_shape_cdp
+        module procedure assert_shape_vector_rsp
+        module procedure assert_shape_matrix_rsp
+        module procedure assert_shape_vector_rdp
+        module procedure assert_shape_matrix_rdp
+        module procedure assert_shape_vector_csp
+        module procedure assert_shape_matrix_csp
+        module procedure assert_shape_vector_cdp
+        module procedure assert_shape_matrix_cdp
     end interface
 
     interface inv
@@ -196,7 +200,26 @@ contains
         return
     end subroutine stop_error
 
-    subroutine assert_shape_rsp(A, size, routine, matname)
+    subroutine assert_shape_vector_rsp(v, size, routine, matname)
+        !! Utility function to assert the shape of a vector.
+        real(sp), intent(in) :: v(:)
+        !! Vector whose dimension need to be asserted.
+        integer, intent(in) :: size(:)
+        !! Expected dimensions of v.
+        character(len=*), intent(in) :: routine
+        !! Name of the routine where assertion is done.
+        character(len=*), intent(in) :: matname
+        !! Name of the asserted vector.
+
+        if(any(shape(v) /= size)) then
+            write(output_unit, *) "In routine "//routine//" vector "//matname//" has illegal length ", shape(v)
+            write(output_unit, *) "Expected length is ", size
+            call stop_error("Aborting due to illegal vector length.")
+        endif
+        return
+    end subroutine assert_shape_vector_rsp
+
+    subroutine assert_shape_matrix_rsp(A, size, routine, matname)
         !! Utility function to assert the shape of a matrix.
         real(sp), intent(in) :: A(:, :)
         !! Matrix whose dimension need to be asserted.
@@ -213,8 +236,27 @@ contains
             call stop_error("Aborting due to illegal matrix size.")
         endif
         return
-    end subroutine assert_shape_rsp
-    subroutine assert_shape_rdp(A, size, routine, matname)
+    end subroutine assert_shape_matrix_rsp
+    subroutine assert_shape_vector_rdp(v, size, routine, matname)
+        !! Utility function to assert the shape of a vector.
+        real(dp), intent(in) :: v(:)
+        !! Vector whose dimension need to be asserted.
+        integer, intent(in) :: size(:)
+        !! Expected dimensions of v.
+        character(len=*), intent(in) :: routine
+        !! Name of the routine where assertion is done.
+        character(len=*), intent(in) :: matname
+        !! Name of the asserted vector.
+
+        if(any(shape(v) /= size)) then
+            write(output_unit, *) "In routine "//routine//" vector "//matname//" has illegal length ", shape(v)
+            write(output_unit, *) "Expected length is ", size
+            call stop_error("Aborting due to illegal vector length.")
+        endif
+        return
+    end subroutine assert_shape_vector_rdp
+
+    subroutine assert_shape_matrix_rdp(A, size, routine, matname)
         !! Utility function to assert the shape of a matrix.
         real(dp), intent(in) :: A(:, :)
         !! Matrix whose dimension need to be asserted.
@@ -231,8 +273,27 @@ contains
             call stop_error("Aborting due to illegal matrix size.")
         endif
         return
-    end subroutine assert_shape_rdp
-    subroutine assert_shape_csp(A, size, routine, matname)
+    end subroutine assert_shape_matrix_rdp
+    subroutine assert_shape_vector_csp(v, size, routine, matname)
+        !! Utility function to assert the shape of a vector.
+        complex(sp), intent(in) :: v(:)
+        !! Vector whose dimension need to be asserted.
+        integer, intent(in) :: size(:)
+        !! Expected dimensions of v.
+        character(len=*), intent(in) :: routine
+        !! Name of the routine where assertion is done.
+        character(len=*), intent(in) :: matname
+        !! Name of the asserted vector.
+
+        if(any(shape(v) /= size)) then
+            write(output_unit, *) "In routine "//routine//" vector "//matname//" has illegal length ", shape(v)
+            write(output_unit, *) "Expected length is ", size
+            call stop_error("Aborting due to illegal vector length.")
+        endif
+        return
+    end subroutine assert_shape_vector_csp
+
+    subroutine assert_shape_matrix_csp(A, size, routine, matname)
         !! Utility function to assert the shape of a matrix.
         complex(sp), intent(in) :: A(:, :)
         !! Matrix whose dimension need to be asserted.
@@ -249,8 +310,27 @@ contains
             call stop_error("Aborting due to illegal matrix size.")
         endif
         return
-    end subroutine assert_shape_csp
-    subroutine assert_shape_cdp(A, size, routine, matname)
+    end subroutine assert_shape_matrix_csp
+    subroutine assert_shape_vector_cdp(v, size, routine, matname)
+        !! Utility function to assert the shape of a vector.
+        complex(dp), intent(in) :: v(:)
+        !! Vector whose dimension need to be asserted.
+        integer, intent(in) :: size(:)
+        !! Expected dimensions of v.
+        character(len=*), intent(in) :: routine
+        !! Name of the routine where assertion is done.
+        character(len=*), intent(in) :: matname
+        !! Name of the asserted vector.
+
+        if(any(shape(v) /= size)) then
+            write(output_unit, *) "In routine "//routine//" vector "//matname//" has illegal length ", shape(v)
+            write(output_unit, *) "Expected length is ", size
+            call stop_error("Aborting due to illegal vector length.")
+        endif
+        return
+    end subroutine assert_shape_vector_cdp
+
+    subroutine assert_shape_matrix_cdp(A, size, routine, matname)
         !! Utility function to assert the shape of a matrix.
         complex(dp), intent(in) :: A(:, :)
         !! Matrix whose dimension need to be asserted.
@@ -267,7 +347,7 @@ contains
             call stop_error("Aborting due to illegal matrix size.")
         endif
         return
-    end subroutine assert_shape_cdp
+    end subroutine assert_shape_matrix_cdp
 
     !-------------------------------------------
     !-----     LAPACK MATRIX INVERSION     -----

--- a/src/Utils.f90
+++ b/src/Utils.f90
@@ -20,20 +20,11 @@ module lightkrylov_utils
     !-----     LightKrylov     -----
     !-------------------------------
     ! Various constants.
-    use lightkrylov_constants
+    use LightKrylov_Constants
 
     implicit none
 
     character*128, parameter, private :: this_module = 'LightKrylov_Utils'
-
-    real(sp), parameter, public :: one_rsp = 1.0_sp
-    real(sp), parameter, public :: zero_rsp = 0.0_sp
-    real(dp), parameter, public :: one_rdp = 1.0_dp
-    real(dp), parameter, public :: zero_rdp = 0.0_dp
-    complex(sp), parameter, public :: one_csp = cmplx(1.0_sp, 0.0_sp, kind=sp)
-    complex(sp), parameter, public :: zero_csp = cmplx(0.0_sp, 0.0_sp, kind=sp)
-    complex(dp), parameter, public :: one_cdp = cmplx(1.0_dp, 0.0_dp, kind=dp)
-    complex(dp), parameter, public :: zero_cdp = cmplx(0.0_dp, 0.0_dp, kind=dp)
 
     public :: stop_error
     public :: assert_shape
@@ -363,7 +354,7 @@ contains
         call check_info(info, 'GEEV', module=this_module, procedure='eig_rsp')
 
         ! Reconstruct eigenvalues
-        vals = cmplx(1.0_sp, 0.0_sp, kind=sp)*wr + cmplx(0.0_sp, 1.0_sp, kind=sp)*wi
+        vals = one_csp*wr + one_im_csp*wi
 
         return
     end subroutine eig_rsp
@@ -417,7 +408,7 @@ contains
         m = size(A, 1) ; n = size(A, 2) ; nrhs = 1
         lda = m ; ldb = m ; lwork = max(1, min(m, n) + max(min(m, n), nrhs))
         a_tilde = a ; b_tilde(:, 1) = b
-        allocate(work(lwork)) ; work = 0.0_sp
+        allocate(work(lwork)) ; work = zero_rsp
 
         ! Solve the least-squares problem.
         call gels(trans, m, n, nrhs, a_tilde, lda, b_tilde, ldb, work, lwork, info)
@@ -621,7 +612,7 @@ contains
         call check_info(info, 'GEEV', module=this_module, procedure='eig_rdp')
 
         ! Reconstruct eigenvalues
-        vals = cmplx(1.0_dp, 0.0_dp, kind=dp)*wr + cmplx(0.0_dp, 1.0_dp, kind=dp)*wi
+        vals = one_cdp*wr + one_im_cdp*wi
 
         return
     end subroutine eig_rdp
@@ -675,7 +666,7 @@ contains
         m = size(A, 1) ; n = size(A, 2) ; nrhs = 1
         lda = m ; ldb = m ; lwork = max(1, min(m, n) + max(min(m, n), nrhs))
         a_tilde = a ; b_tilde(:, 1) = b
-        allocate(work(lwork)) ; work = 0.0_dp
+        allocate(work(lwork)) ; work = zero_rdp
 
         ! Solve the least-squares problem.
         call gels(trans, m, n, nrhs, a_tilde, lda, b_tilde, ldb, work, lwork, info)
@@ -936,7 +927,7 @@ contains
         m = size(A, 1) ; n = size(A, 2) ; nrhs = 1
         lda = m ; ldb = m ; lwork = max(1, min(m, n) + max(min(m, n), nrhs))
         a_tilde = a ; b_tilde(:, 1) = b
-        allocate(work(lwork)) ; work = 0.0_sp
+        allocate(work(lwork)) ; work = zero_csp
 
         ! Solve the least-squares problem.
         call gels(trans, m, n, nrhs, a_tilde, lda, b_tilde, ldb, work, lwork, info)
@@ -1191,7 +1182,7 @@ contains
         m = size(A, 1) ; n = size(A, 2) ; nrhs = 1
         lda = m ; ldb = m ; lwork = max(1, min(m, n) + max(min(m, n), nrhs))
         a_tilde = a ; b_tilde(:, 1) = b
-        allocate(work(lwork)) ; work = 0.0_dp
+        allocate(work(lwork)) ; work = zero_cdp
 
         ! Solve the least-squares problem.
         call gels(trans, m, n, nrhs, a_tilde, lda, b_tilde, ldb, work, lwork, info)
@@ -1323,7 +1314,7 @@ contains
         integer :: i, n
         real(sp) :: row_sum
 
-        norm = 0.0_sp
+        norm = zero_rsp
         n = size(A, 1)
         do i = 1, n
             row_sum = sum(abs(A(i, :)))
@@ -1341,7 +1332,7 @@ contains
         integer :: i, n
         real(dp) :: row_sum
 
-        norm = 0.0_dp
+        norm = zero_rdp
         n = size(A, 1)
         do i = 1, n
             row_sum = sum(abs(A(i, :)))
@@ -1355,7 +1346,7 @@ contains
         integer :: i, n
         real(sp) :: row_sum
 
-        norm = 0.0_sp
+        norm = zero_rsp
         n = size(A, 1)
         do i = 1, n
             row_sum = sum(abs(A(i, :)))
@@ -1369,7 +1360,7 @@ contains
         integer :: i, n
         real(dp) :: row_sum
 
-        norm = 0.0_dp
+        norm = zero_rdp
         n = size(A, 1)
         do i = 1, n
             row_sum = sum(abs(A(i, :)))

--- a/src/Utils.f90
+++ b/src/Utils.f90
@@ -24,7 +24,7 @@ module lightkrylov_utils
 
     implicit none
 
-    private
+    character*128, parameter, private :: this_module = 'LightKrylov_Utils'
 
     real(sp), parameter, public :: one_rsp = 1.0_sp
     real(sp), parameter, public :: zero_rsp = 0.0_sp
@@ -295,11 +295,11 @@ contains
         ! Compute A = LU (in-place).
         n = size(A, 1) ; call assert_shape(A, [n, n], "inv", "A")
         call getrf(n, n, A, n, ipiv, info)
-        call check_info(info, 'GETREF', module='LightKrylov_Utils', procedure='inv_rsp')
+        call check_info(info, 'GETREF', module=this_module, procedure='inv_rsp')
 
         ! Compute inv(A) (in-place).
         call getri(n, A, n, ipiv, work, n, info)
-        call check_info(info, 'GETRI', module='LightKrylov_Utils', procedure='inv_rsp')
+        call check_info(info, 'GETRI', module=this_module, procedure='inv_rsp')
 
         return
     end subroutine inv_rsp
@@ -334,7 +334,7 @@ contains
         A_tilde = A
         call gesvd(jobu, jobvt, m, n, A_tilde, lda, S, U, ldu, Vt, ldvt, work, lwork, info)
         v = transpose(vt)
-        call check_info(info, 'GESVD', module='LightKrylov_Utils', procedure='svd_rsp')
+        call check_info(info, 'GESVD', module=this_module, procedure='svd_rsp')
 
         return
     end subroutine svd_rsp
@@ -360,7 +360,7 @@ contains
 
         ! Eigendecomposition.
         call geev(jobvl, jobvr, n, a_tilde, lda, wr, wi, vl, ldvl, vecs, ldvr, work, lwork, info)
-        call check_info(info, 'GEEV', module='LightKrylov_Utils', procedure='eig_rsp')
+        call check_info(info, 'GEEV', module=this_module, procedure='eig_rsp')
 
         ! Reconstruct eigenvalues
         vals = cmplx(1.0_sp, 0.0_sp, kind=sp)*wr + cmplx(0.0_sp, 1.0_sp, kind=sp)*wi
@@ -390,7 +390,7 @@ contains
 
         ! Eigendecomposition.
         call syev(jobz, uplo, n, a_tilde, lda, vals, work, lwork, info)
-        call check_info(info, 'SYEV', module='LightKrylov_Utils', procedure='eigh_rsp')
+        call check_info(info, 'SYEV', module=this_module, procedure='eigh_rsp')
 
         ! Extract eigenvectors
         vecs = a_tilde
@@ -421,7 +421,7 @@ contains
 
         ! Solve the least-squares problem.
         call gels(trans, m, n, nrhs, a_tilde, lda, b_tilde, ldb, work, lwork, info)
-        call check_info(info, 'GELS', module='LightKrylov_Utils', procedure='lstsq_rsp')
+        call check_info(info, 'GELS', module=this_module, procedure='lstsq_rsp')
 
         ! Return solution.
         x = b_tilde(1:n, 1)
@@ -451,7 +451,7 @@ contains
 
         allocate(wr(size(eigvals)), wi(size(eigvals)))
         call gees(jobvs, sort, dummy_select, n, A, lda, sdim, wr, wi, Z, ldvs, work, lwork, bwork, info)
-        call check_info(info, 'GEES', module='LightKrylov_Utils', procedure='schur_rsp')
+        call check_info(info, 'GEES', module=this_module, procedure='schur_rsp')
 
         ! Reconstruct eigenvalues
         eigvals = cmplx(wr, wi, kind=sp)
@@ -489,7 +489,7 @@ contains
 
         liwork = 1
         call trsen(job, compq, selected, n, T, ldt, Q, ldq, wr, wi, m, s, sep, work, lwork, iwork, liwork, info)
-        call check_info(info, 'TRSEN', module='LightKrylov_Utils', procedure='ordschur_rsp')
+        call check_info(info, 'TRSEN', module=this_module, procedure='ordschur_rsp')
 
         return
     end subroutine ordschur_rsp
@@ -553,11 +553,11 @@ contains
         ! Compute A = LU (in-place).
         n = size(A, 1) ; call assert_shape(A, [n, n], "inv", "A")
         call getrf(n, n, A, n, ipiv, info)
-        call check_info(info, 'GETREF', module='LightKrylov_Utils', procedure='inv_rdp')
+        call check_info(info, 'GETREF', module=this_module, procedure='inv_rdp')
 
         ! Compute inv(A) (in-place).
         call getri(n, A, n, ipiv, work, n, info)
-        call check_info(info, 'GETRI', module='LightKrylov_Utils', procedure='inv_rdp')
+        call check_info(info, 'GETRI', module=this_module, procedure='inv_rdp')
 
         return
     end subroutine inv_rdp
@@ -592,7 +592,7 @@ contains
         A_tilde = A
         call gesvd(jobu, jobvt, m, n, A_tilde, lda, S, U, ldu, Vt, ldvt, work, lwork, info)
         v = transpose(vt)
-        call check_info(info, 'GESVD', module='LightKrylov_Utils', procedure='svd_rdp')
+        call check_info(info, 'GESVD', module=this_module, procedure='svd_rdp')
 
         return
     end subroutine svd_rdp
@@ -618,7 +618,7 @@ contains
 
         ! Eigendecomposition.
         call geev(jobvl, jobvr, n, a_tilde, lda, wr, wi, vl, ldvl, vecs, ldvr, work, lwork, info)
-        call check_info(info, 'GEEV', module='LightKrylov_Utils', procedure='eig_rdp')
+        call check_info(info, 'GEEV', module=this_module, procedure='eig_rdp')
 
         ! Reconstruct eigenvalues
         vals = cmplx(1.0_dp, 0.0_dp, kind=dp)*wr + cmplx(0.0_dp, 1.0_dp, kind=dp)*wi
@@ -648,7 +648,7 @@ contains
 
         ! Eigendecomposition.
         call syev(jobz, uplo, n, a_tilde, lda, vals, work, lwork, info)
-        call check_info(info, 'SYEV', module='LightKrylov_Utils', procedure='eigh_rdp')
+        call check_info(info, 'SYEV', module=this_module, procedure='eigh_rdp')
 
         ! Extract eigenvectors
         vecs = a_tilde
@@ -679,7 +679,7 @@ contains
 
         ! Solve the least-squares problem.
         call gels(trans, m, n, nrhs, a_tilde, lda, b_tilde, ldb, work, lwork, info)
-        call check_info(info, 'GELS', module='LightKrylov_Utils', procedure='lstsq_rdp')
+        call check_info(info, 'GELS', module=this_module, procedure='lstsq_rdp')
 
         ! Return solution.
         x = b_tilde(1:n, 1)
@@ -709,7 +709,7 @@ contains
 
         allocate(wr(size(eigvals)), wi(size(eigvals)))
         call gees(jobvs, sort, dummy_select, n, A, lda, sdim, wr, wi, Z, ldvs, work, lwork, bwork, info)
-        call check_info(info, 'GEES', module='LightKrylov_Utils', procedure='schur_rdp')
+        call check_info(info, 'GEES', module=this_module, procedure='schur_rdp')
 
         ! Reconstruct eigenvalues
         eigvals = cmplx(wr, wi, kind=dp)
@@ -747,7 +747,7 @@ contains
 
         liwork = 1
         call trsen(job, compq, selected, n, T, ldt, Q, ldq, wr, wi, m, s, sep, work, lwork, iwork, liwork, info)
-        call check_info(info, 'TRSEN', module='LightKrylov_Utils', procedure='ordschur_rdp')
+        call check_info(info, 'TRSEN', module=this_module, procedure='ordschur_rdp')
 
         return
     end subroutine ordschur_rdp
@@ -811,11 +811,11 @@ contains
         ! Compute A = LU (in-place).
         n = size(A, 1) ; call assert_shape(A, [n, n], "inv", "A")
         call getrf(n, n, A, n, ipiv, info)
-        call check_info(info, 'GETREF', module='LightKrylov_Utils', procedure='inv_csp')
+        call check_info(info, 'GETREF', module=this_module, procedure='inv_csp')
 
         ! Compute inv(A) (in-place).
         call getri(n, A, n, ipiv, work, n, info)
-        call check_info(info, 'GETRI', module='LightKrylov_Utils', procedure='inv_csp')
+        call check_info(info, 'GETRI', module=this_module, procedure='inv_csp')
 
         return
     end subroutine inv_csp
@@ -852,7 +852,7 @@ contains
         allocate(rwork(5*min(m, n)))
         call gesvd(jobu, jobvt, m, n, A_tilde, lda, S, U, ldu, Vt, ldvt, work, lwork, rwork, info)
         v = transpose(conjg(vt))
-        call check_info(info, 'GESVD', module='LightKrylov_Utils', procedure='svd_csp')
+        call check_info(info, 'GESVD', module=this_module, procedure='svd_csp')
 
         return
     end subroutine svd_csp
@@ -879,7 +879,7 @@ contains
 
         ! Eigendecomposition.
         call geev(jobvl, jobvr, n, a_tilde, lda, vals, vl, ldvl, vecs, ldvr, work, lwork, rwork, info)
-        call check_info(info, 'GEEV', module='LightKrylov_Utils', procedure='eig_csp')
+        call check_info(info, 'GEEV', module=this_module, procedure='eig_csp')
 
 
         return
@@ -909,7 +909,7 @@ contains
 
         ! Eigendecomposition.
         call heev(jobz, uplo, n, a_tilde, lda, vals, work, lwork, rwork, info)
-        call check_info(info, 'HEEV', module='LightKrylov_Utils', procedure='eigh_csp')
+        call check_info(info, 'HEEV', module=this_module, procedure='eigh_csp')
 
         ! Extract eigenvectors
         vecs = a_tilde
@@ -940,7 +940,7 @@ contains
 
         ! Solve the least-squares problem.
         call gels(trans, m, n, nrhs, a_tilde, lda, b_tilde, ldb, work, lwork, info)
-        call check_info(info, 'GELS', module='LightKrylov_Utils', procedure='lstsq_csp')
+        call check_info(info, 'GELS', module=this_module, procedure='lstsq_csp')
 
         ! Return solution.
         x = b_tilde(1:n, 1)
@@ -969,7 +969,7 @@ contains
         allocate(bwork(n)) ; allocate(work(lwork)) ;  allocate(rwork(n)) 
 
         call gees(jobvs, sort, dummy_select, n, A, lda, sdim, eigvals, Z, ldvs, work, lwork, rwork, bwork, info)
-        call check_info(info, 'GEES', module='LightKrylov_Utils', procedure='schur_csp')
+        call check_info(info, 'GEES', module=this_module, procedure='schur_csp')
 
 
         return
@@ -1002,7 +1002,7 @@ contains
         n = size(T, 2) ; ldt = n ; ldq = n ; lwork = max(1, n)
 
         call trsen(job, compq, selected, n, T, ldt, Q, ldq, w, m, s, sep, work, lwork, info)
-        call check_info(info, 'TRSEN', module='LightKrylov_Utils', procedure='ordschur_csp')
+        call check_info(info, 'TRSEN', module=this_module, procedure='ordschur_csp')
 
         return
     end subroutine ordschur_csp
@@ -1066,11 +1066,11 @@ contains
         ! Compute A = LU (in-place).
         n = size(A, 1) ; call assert_shape(A, [n, n], "inv", "A")
         call getrf(n, n, A, n, ipiv, info)
-        call check_info(info, 'GETREF', module='LightKrylov_Utils', procedure='inv_cdp')
+        call check_info(info, 'GETREF', module=this_module, procedure='inv_cdp')
 
         ! Compute inv(A) (in-place).
         call getri(n, A, n, ipiv, work, n, info)
-        call check_info(info, 'GETRI', module='LightKrylov_Utils', procedure='inv_cdp')
+        call check_info(info, 'GETRI', module=this_module, procedure='inv_cdp')
 
         return
     end subroutine inv_cdp
@@ -1107,7 +1107,7 @@ contains
         allocate(rwork(5*min(m, n)))
         call gesvd(jobu, jobvt, m, n, A_tilde, lda, S, U, ldu, Vt, ldvt, work, lwork, rwork, info)
         v = transpose(conjg(vt))
-        call check_info(info, 'GESVD', module='LightKrylov_Utils', procedure='svd_cdp')
+        call check_info(info, 'GESVD', module=this_module, procedure='svd_cdp')
 
         return
     end subroutine svd_cdp
@@ -1134,7 +1134,7 @@ contains
 
         ! Eigendecomposition.
         call geev(jobvl, jobvr, n, a_tilde, lda, vals, vl, ldvl, vecs, ldvr, work, lwork, rwork, info)
-        call check_info(info, 'GEEV', module='LightKrylov_Utils', procedure='eig_cdp')
+        call check_info(info, 'GEEV', module=this_module, procedure='eig_cdp')
 
 
         return
@@ -1164,7 +1164,7 @@ contains
 
         ! Eigendecomposition.
         call heev(jobz, uplo, n, a_tilde, lda, vals, work, lwork, rwork, info)
-        call check_info(info, 'HEEV', module='LightKrylov_Utils', procedure='eigh_cdp')
+        call check_info(info, 'HEEV', module=this_module, procedure='eigh_cdp')
 
         ! Extract eigenvectors
         vecs = a_tilde
@@ -1195,7 +1195,7 @@ contains
 
         ! Solve the least-squares problem.
         call gels(trans, m, n, nrhs, a_tilde, lda, b_tilde, ldb, work, lwork, info)
-        call check_info(info, 'GELS', module='LightKrylov_Utils', procedure='lstsq_cdp')
+        call check_info(info, 'GELS', module=this_module, procedure='lstsq_cdp')
 
         ! Return solution.
         x = b_tilde(1:n, 1)
@@ -1224,7 +1224,7 @@ contains
         allocate(bwork(n)) ; allocate(work(lwork)) ;  allocate(rwork(n)) 
 
         call gees(jobvs, sort, dummy_select, n, A, lda, sdim, eigvals, Z, ldvs, work, lwork, rwork, bwork, info)
-        call check_info(info, 'GEES', module='LightKrylov_Utils', procedure='schur_cdp')
+        call check_info(info, 'GEES', module=this_module, procedure='schur_cdp')
 
 
         return
@@ -1257,7 +1257,7 @@ contains
         n = size(T, 2) ; ldt = n ; ldq = n ; lwork = max(1, n)
 
         call trsen(job, compq, selected, n, T, ldt, Q, ldq, w, m, s, sep, work, lwork, info)
-        call check_info(info, 'TRSEN', module='LightKrylov_Utils', procedure='ordschur_cdp')
+        call check_info(info, 'TRSEN', module=this_module, procedure='ordschur_cdp')
 
         return
     end subroutine ordschur_cdp

--- a/src/Utils.fypp
+++ b/src/Utils.fypp
@@ -22,21 +22,11 @@ module lightkrylov_utils
     !-----     LightKrylov     -----
     !-------------------------------
     ! Various constants.
-    use lightkrylov_constants
+    use LightKrylov_Constants
 
     implicit none
 
     character*128, parameter, private :: this_module = 'LightKrylov_Utils'
-
-    #:for kind, type in RC_KINDS_TYPES
-    #:if type[0] == "c"
-    ${type}$, parameter, public :: one_${type[0]}$${kind}$ = cmplx(1.0_${kind}$, 0.0_${kind}$, kind=${kind}$)
-    ${type}$, parameter, public :: zero_${type[0]}$${kind}$ = cmplx(0.0_${kind}$, 0.0_${kind}$, kind=${kind}$)
-    #:else
-    ${type}$, parameter, public :: one_${type[0]}$${kind}$ = 1.0_${kind}$
-    ${type}$, parameter, public :: zero_${type[0]}$${kind}$ = 0.0_${kind}$
-    #:endif
-    #:endfor
 
     public :: stop_error
     public :: assert_shape
@@ -310,7 +300,7 @@ contains
 
         #:if type[0] == "r"
         ! Reconstruct eigenvalues
-        vals = cmplx(1.0_${kind}$, 0.0_${kind}$, kind=${kind}$)*wr + cmplx(0.0_${kind}$, 1.0_${kind}$, kind=${kind}$)*wi
+        vals = one_c${kind}$*wr + one_im_c${kind}$*wi
         #:endif
 
         return
@@ -378,7 +368,7 @@ contains
         m = size(A, 1) ; n = size(A, 2) ; nrhs = 1
         lda = m ; ldb = m ; lwork = max(1, min(m, n) + max(min(m, n), nrhs))
         a_tilde = a ; b_tilde(:, 1) = b
-        allocate(work(lwork)) ; work = 0.0_${kind}$
+        allocate(work(lwork)) ; work = zero_${type[0]}$${kind}$
 
         ! Solve the least-squares problem.
         call gels(trans, m, n, nrhs, a_tilde, lda, b_tilde, ldb, work, lwork, info)
@@ -559,7 +549,7 @@ contains
         integer :: i, n
         real(${kind}$) :: row_sum
 
-        norm = 0.0_${kind}$
+        norm = zero_r${kind}$
         n = size(A, 1)
         do i = 1, n
             row_sum = sum(abs(A(i, :)))

--- a/src/Utils.fypp
+++ b/src/Utils.fypp
@@ -26,7 +26,7 @@ module lightkrylov_utils
 
     implicit none
 
-    private
+    character*128, parameter, private :: this_module = 'LightKrylov_Utils'
 
     #:for kind, type in RC_KINDS_TYPES
     #:if type[0] == "c"
@@ -214,11 +214,11 @@ contains
         ! Compute A = LU (in-place).
         n = size(A, 1) ; call assert_shape(A, [n, n], "inv", "A")
         call getrf(n, n, A, n, ipiv, info)
-        call check_info(info, 'GETREF', module='LightKrylov_Utils', procedure='inv_${type[0]}$${kind}$')
+        call check_info(info, 'GETREF', module=this_module, procedure='inv_${type[0]}$${kind}$')
 
         ! Compute inv(A) (in-place).
         call getri(n, A, n, ipiv, work, n, info)
-        call check_info(info, 'GETRI', module='LightKrylov_Utils', procedure='inv_${type[0]}$${kind}$')
+        call check_info(info, 'GETRI', module=this_module, procedure='inv_${type[0]}$${kind}$')
 
         return
     end subroutine inv_${type[0]}$${kind}$
@@ -262,7 +262,7 @@ contains
         call gesvd(jobu, jobvt, m, n, A_tilde, lda, S, U, ldu, Vt, ldvt, work, lwork, info)
         v = transpose(vt)
         #:endif
-        call check_info(info, 'GESVD', module='LightKrylov_Utils', procedure='svd_${type[0]}$${kind}$')
+        call check_info(info, 'GESVD', module=this_module, procedure='svd_${type[0]}$${kind}$')
 
         return
     end subroutine svd_${type[0]}$${kind}$
@@ -306,7 +306,7 @@ contains
         #:else
         call geev(jobvl, jobvr, n, a_tilde, lda, wr, wi, vl, ldvl, vecs, ldvr, work, lwork, info)
         #:endif
-        call check_info(info, 'GEEV', module='LightKrylov_Utils', procedure='eig_${type[0]}$${kind}$')
+        call check_info(info, 'GEEV', module=this_module, procedure='eig_${type[0]}$${kind}$')
 
         #:if type[0] == "r"
         ! Reconstruct eigenvalues
@@ -347,10 +347,10 @@ contains
         ! Eigendecomposition.
         #:if type[0] == "r"
         call syev(jobz, uplo, n, a_tilde, lda, vals, work, lwork, info)
-        call check_info(info, 'SYEV', module='LightKrylov_Utils', procedure='eigh_${type[0]}$${kind}$')
+        call check_info(info, 'SYEV', module=this_module, procedure='eigh_${type[0]}$${kind}$')
         #:else
         call heev(jobz, uplo, n, a_tilde, lda, vals, work, lwork, rwork, info)
-        call check_info(info, 'HEEV', module='LightKrylov_Utils', procedure='eigh_${type[0]}$${kind}$')
+        call check_info(info, 'HEEV', module=this_module, procedure='eigh_${type[0]}$${kind}$')
         #:endif
 
         ! Extract eigenvectors
@@ -382,7 +382,7 @@ contains
 
         ! Solve the least-squares problem.
         call gels(trans, m, n, nrhs, a_tilde, lda, b_tilde, ldb, work, lwork, info)
-        call check_info(info, 'GELS', module='LightKrylov_Utils', procedure='lstsq_${type[0]}$${kind}$')
+        call check_info(info, 'GELS', module=this_module, procedure='lstsq_${type[0]}$${kind}$')
 
         ! Return solution.
         x = b_tilde(1:n, 1)
@@ -420,7 +420,7 @@ contains
         #:else
         call gees(jobvs, sort, dummy_select, n, A, lda, sdim, eigvals, Z, ldvs, work, lwork, rwork, bwork, info)
         #:endif
-        call check_info(info, 'GEES', module='LightKrylov_Utils', procedure='schur_${type[0]}$${kind}$')
+        call check_info(info, 'GEES', module=this_module, procedure='schur_${type[0]}$${kind}$')
 
         #:if type[0] == "r"
         ! Reconstruct eigenvalues
@@ -477,7 +477,7 @@ contains
         #:else
         call trsen(job, compq, selected, n, T, ldt, Q, ldq, w, m, s, sep, work, lwork, info)
         #:endif
-        call check_info(info, 'TRSEN', module='LightKrylov_Utils', procedure='ordschur_${type[0]}$${kind}$')
+        call check_info(info, 'TRSEN', module=this_module, procedure='ordschur_${type[0]}$${kind}$')
 
         return
     end subroutine ordschur_${type[0]}$${kind}$

--- a/src/Utils.fypp
+++ b/src/Utils.fypp
@@ -61,8 +61,9 @@ module lightkrylov_utils
     #:endfor
 
     interface assert_shape
-    #:for kind, type in RC_KINDS_TYPES
-        module procedure assert_shape_${type[0]}$${kind}$
+        #:for kind, type in RC_KINDS_TYPES
+        module procedure assert_shape_vector_${type[0]}$${kind}$
+        module procedure assert_shape_matrix_${type[0]}$${kind}$
         #:endfor
     end interface
 
@@ -166,7 +167,26 @@ contains
     end subroutine stop_error
 
     #:for kind, type in RC_KINDS_TYPES
-    subroutine assert_shape_${type[0]}$${kind}$(A, size, routine, matname)
+    subroutine assert_shape_vector_${type[0]}$${kind}$(v, size, routine, matname)
+        !! Utility function to assert the shape of a vector.
+        ${type}$, intent(in) :: v(:)
+        !! Vector whose dimension need to be asserted.
+        integer, intent(in) :: size(:)
+        !! Expected dimensions of v.
+        character(len=*), intent(in) :: routine
+        !! Name of the routine where assertion is done.
+        character(len=*), intent(in) :: matname
+        !! Name of the asserted vector.
+
+        if(any(shape(v) /= size)) then
+            write(output_unit, *) "In routine "//routine//" vector "//matname//" has illegal length ", shape(v)
+            write(output_unit, *) "Expected length is ", size
+            call stop_error("Aborting due to illegal vector length.")
+        endif
+        return
+    end subroutine assert_shape_vector_${type[0]}$${kind}$
+
+    subroutine assert_shape_matrix_${type[0]}$${kind}$(A, size, routine, matname)
         !! Utility function to assert the shape of a matrix.
         ${type}$, intent(in) :: A(:, :)
         !! Matrix whose dimension need to be asserted.
@@ -183,7 +203,7 @@ contains
             call stop_error("Aborting due to illegal matrix size.")
         endif
         return
-    end subroutine assert_shape_${type[0]}$${kind}$
+    end subroutine assert_shape_matrix_${type[0]}$${kind}$
     #:endfor
 
     !-------------------------------------------

--- a/test/TestExpmlib.f90
+++ b/test/TestExpmlib.f90
@@ -17,6 +17,12 @@ module TestExpmlib
     use TestUtils
     use TestKrylov
 
+    implicit none
+
+    private
+
+    character*128, parameter, private :: this_module = 'LightKrylov_TestExpmLib'
+
     real(sp), parameter, public :: one_rsp = 1.0_sp
     real(sp), parameter, public :: zero_rsp = 0.0_sp
     real(dp), parameter, public :: one_rdp = 1.0_dp
@@ -115,7 +121,7 @@ contains
 
         ! Krylov exponential.
         call kexpm(Xkryl, A, Q, tau, rtol_sp, info, verbosity=verb, kdim=nkmax)
-        !call check_info(info, 'kexpm', module='LightKrylov_TestExpmLib', procedure='test_kexptA_rsp')
+        !call check_info(info, 'kexpm', module=this_module, procedure='test_kexptA_rsp')
 
         ! Check result.
         call Xkryl%sub(Xref) ; err = Xkryl%norm()
@@ -180,13 +186,13 @@ contains
         do i = 1,p
             if (verb) write(*,*) '    column',i
             call kexpm(C(i), A, B(i), tau, tol, info, verbosity=verb, kdim=nkmax)
-            !call check_info(info, 'kexpm', module='LightKrylov_TestExpmLib', procedure='test_block_kexptA_rsp, 1')
+            !call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_rsp, 1')
         end do
         
         ! Compute Krylov matrix exponential using block-arnoldi method
         if (verb) write(*,*) 'BLOCK-ARNOLDI'
         call kexpm(Cblk, A, B, tau, tol, info, verbosity=verb, kdim=nkmax)
-        !call check_info(info, 'kexpm', module='LightKrylov_TestExpmLib', procedure='test_block_kexptA_rsp, 2')
+        !call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_rsp, 2')
     
         do i = 1, p
             write(output_unit, *) C(i)%norm(), Cblk(i)%norm()
@@ -292,7 +298,7 @@ contains
 
         ! Krylov exponential.
         call kexpm(Xkryl, A, Q, tau, rtol_dp, info, verbosity=verb, kdim=nkmax)
-        !call check_info(info, 'kexpm', module='LightKrylov_TestExpmLib', procedure='test_kexptA_rdp')
+        !call check_info(info, 'kexpm', module=this_module, procedure='test_kexptA_rdp')
 
         ! Check result.
         call Xkryl%sub(Xref) ; err = Xkryl%norm()
@@ -357,13 +363,13 @@ contains
         do i = 1,p
             if (verb) write(*,*) '    column',i
             call kexpm(C(i), A, B(i), tau, tol, info, verbosity=verb, kdim=nkmax)
-            !call check_info(info, 'kexpm', module='LightKrylov_TestExpmLib', procedure='test_block_kexptA_rdp, 1')
+            !call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_rdp, 1')
         end do
         
         ! Compute Krylov matrix exponential using block-arnoldi method
         if (verb) write(*,*) 'BLOCK-ARNOLDI'
         call kexpm(Cblk, A, B, tau, tol, info, verbosity=verb, kdim=nkmax)
-        !call check_info(info, 'kexpm', module='LightKrylov_TestExpmLib', procedure='test_block_kexptA_rdp, 2')
+        !call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_rdp, 2')
     
         do i = 1, p
             write(output_unit, *) C(i)%norm(), Cblk(i)%norm()
@@ -469,7 +475,7 @@ contains
 
         ! Krylov exponential.
         call kexpm(Xkryl, A, Q, tau, rtol_sp, info, verbosity=verb, kdim=nkmax)
-        !call check_info(info, 'kexpm', module='LightKrylov_TestExpmLib', procedure='test_kexptA_csp')
+        !call check_info(info, 'kexpm', module=this_module, procedure='test_kexptA_csp')
 
         ! Check result.
         call Xkryl%sub(Xref) ; err = Xkryl%norm()
@@ -534,13 +540,13 @@ contains
         do i = 1,p
             if (verb) write(*,*) '    column',i
             call kexpm(C(i), A, B(i), tau, tol, info, verbosity=verb, kdim=nkmax)
-            !call check_info(info, 'kexpm', module='LightKrylov_TestExpmLib', procedure='test_block_kexptA_csp, 1')
+            !call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_csp, 1')
         end do
         
         ! Compute Krylov matrix exponential using block-arnoldi method
         if (verb) write(*,*) 'BLOCK-ARNOLDI'
         call kexpm(Cblk, A, B, tau, tol, info, verbosity=verb, kdim=nkmax)
-        !call check_info(info, 'kexpm', module='LightKrylov_TestExpmLib', procedure='test_block_kexptA_csp, 2')
+        !call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_csp, 2')
     
         do i = 1, p
             write(output_unit, *) C(i)%norm(), Cblk(i)%norm()
@@ -646,7 +652,7 @@ contains
 
         ! Krylov exponential.
         call kexpm(Xkryl, A, Q, tau, rtol_dp, info, verbosity=verb, kdim=nkmax)
-        !call check_info(info, 'kexpm', module='LightKrylov_TestExpmLib', procedure='test_kexptA_cdp')
+        !call check_info(info, 'kexpm', module=this_module, procedure='test_kexptA_cdp')
 
         ! Check result.
         call Xkryl%sub(Xref) ; err = Xkryl%norm()
@@ -711,13 +717,13 @@ contains
         do i = 1,p
             if (verb) write(*,*) '    column',i
             call kexpm(C(i), A, B(i), tau, tol, info, verbosity=verb, kdim=nkmax)
-            !call check_info(info, 'kexpm', module='LightKrylov_TestExpmLib', procedure='test_block_kexptA_cdp, 1')
+            !call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_cdp, 1')
         end do
         
         ! Compute Krylov matrix exponential using block-arnoldi method
         if (verb) write(*,*) 'BLOCK-ARNOLDI'
         call kexpm(Cblk, A, B, tau, tol, info, verbosity=verb, kdim=nkmax)
-        !call check_info(info, 'kexpm', module='LightKrylov_TestExpmLib', procedure='test_block_kexptA_cdp, 2')
+        !call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_cdp, 2')
     
         do i = 1, p
             write(output_unit, *) C(i)%norm(), Cblk(i)%norm()
@@ -794,7 +800,7 @@ contains
      
        ! compute matrix square root
        call sqrtm(A, sqrtmA, info)
-       !call check_info(info, 'sqrtm', module='LightKrylov_TestExpmLib', procedure='test_dense_sqrtm_pos_def_rsp')
+       !call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_def_rsp')
     
        write(*,*) 'max err: ', maxval(matmul(sqrtmA, sqrtmA) - A)
        call check(error, maxval(matmul(sqrtmA, sqrtmA) - A) < rtol_sp)
@@ -832,7 +838,7 @@ contains
     
        ! compute matrix square root
        call sqrtm(A, sqrtmA, info)
-       !call check_info(info, 'sqrtm', module='LightKrylov_TestExpmLib', procedure='test_dense_sqrtm_pos_semi_def_rsp')
+       !call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_semi_def_rsp')
     
        write(*,*) 'max err: ', maxval(matmul(sqrtmA, sqrtmA) - A)
        call check(error, maxval(matmul(sqrtmA, sqrtmA) - A) < rtol_sp)
@@ -880,7 +886,7 @@ contains
      
        ! compute matrix square root
        call sqrtm(A, sqrtmA, info)
-       !call check_info(info, 'sqrtm', module='LightKrylov_TestExpmLib', procedure='test_dense_sqrtm_pos_def_rdp')
+       !call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_def_rdp')
     
        write(*,*) 'max err: ', maxval(matmul(sqrtmA, sqrtmA) - A)
        call check(error, maxval(matmul(sqrtmA, sqrtmA) - A) < rtol_dp)
@@ -918,7 +924,7 @@ contains
     
        ! compute matrix square root
        call sqrtm(A, sqrtmA, info)
-       !call check_info(info, 'sqrtm', module='LightKrylov_TestExpmLib', procedure='test_dense_sqrtm_pos_semi_def_rdp')
+       !call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_semi_def_rdp')
     
        write(*,*) 'max err: ', maxval(matmul(sqrtmA, sqrtmA) - A)
        call check(error, maxval(matmul(sqrtmA, sqrtmA) - A) < rtol_dp)
@@ -967,7 +973,7 @@ contains
      
        ! compute matrix square root
        call sqrtm(A, sqrtmA, info)
-       !call check_info(info, 'sqrtm', module='LightKrylov_TestExpmLib', procedure='test_dense_sqrtm_pos_def_csp')
+       !call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_def_csp')
     
        write(*,*) 'max err: ', maxval(abs(matmul(sqrtmA, sqrtmA) - A))
        call check(error, maxval(abs(matmul(sqrtmA, sqrtmA) - A)) < rtol_sp)
@@ -1006,7 +1012,7 @@ contains
     
        ! compute matrix square root
        call sqrtm(A, sqrtmA, info)
-       !call check_info(info, 'sqrtm', module='LightKrylov_TestExpmLib', procedure='test_dense_sqrtm_pos_semi_def_csp')
+       !call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_semi_def_csp')
     
        write(*,*) 'max err: ', maxval(abs(matmul(sqrtmA, sqrtmA) - A))
        call check(error, maxval(abs(matmul(sqrtmA, sqrtmA) - A)) < rtol_sp)
@@ -1055,7 +1061,7 @@ contains
      
        ! compute matrix square root
        call sqrtm(A, sqrtmA, info)
-       !call check_info(info, 'sqrtm', module='LightKrylov_TestExpmLib', procedure='test_dense_sqrtm_pos_def_cdp')
+       !call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_def_cdp')
     
        write(*,*) 'max err: ', maxval(abs(matmul(sqrtmA, sqrtmA) - A))
        call check(error, maxval(abs(matmul(sqrtmA, sqrtmA) - A)) < rtol_dp)
@@ -1094,7 +1100,7 @@ contains
     
        ! compute matrix square root
        call sqrtm(A, sqrtmA, info)
-       !call check_info(info, 'sqrtm', module='LightKrylov_TestExpmLib', procedure='test_dense_sqrtm_pos_semi_def_cdp')
+       !call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_semi_def_cdp')
     
        write(*,*) 'max err: ', maxval(abs(matmul(sqrtmA, sqrtmA) - A))
        call check(error, maxval(abs(matmul(sqrtmA, sqrtmA) - A)) < rtol_dp)

--- a/test/TestExpmlib.f90
+++ b/test/TestExpmlib.f90
@@ -7,6 +7,7 @@ module TestExpmlib
 
     ! LightKrylov
     use LightKrylov
+    use LightKrylov_Constants
     use LightKrylov_Logger
     use LightKrylov_Utils, only : eig, sqrtm
 
@@ -22,15 +23,6 @@ module TestExpmlib
     private
 
     character*128, parameter, private :: this_module = 'LightKrylov_TestExpmLib'
-
-    real(sp), parameter, public :: one_rsp = 1.0_sp
-    real(sp), parameter, public :: zero_rsp = 0.0_sp
-    real(dp), parameter, public :: one_rdp = 1.0_dp
-    real(dp), parameter, public :: zero_rdp = 0.0_dp
-    complex(sp), parameter, public :: one_csp = cmplx(1.0_sp, 0.0_sp, kind=sp)
-    complex(sp), parameter, public :: zero_csp = cmplx(0.0_sp, 0.0_sp, kind=sp)
-    complex(dp), parameter, public :: one_cdp = cmplx(1.0_dp, 0.0_dp, kind=dp)
-    complex(dp), parameter, public :: zero_cdp = cmplx(0.0_dp, 0.0_dp, kind=dp)
 
     public :: collect_expm_rsp_testsuite
     public :: collect_expm_rdp_testsuite

--- a/test/TestExpmlib.fypp
+++ b/test/TestExpmlib.fypp
@@ -9,6 +9,7 @@ module TestExpmlib
 
     ! LightKrylov
     use LightKrylov
+    use LightKrylov_Constants
     use LightKrylov_Logger
     use LightKrylov_Utils, only : eig, sqrtm
 
@@ -24,16 +25,6 @@ module TestExpmlib
     private
 
     character*128, parameter, private :: this_module = 'LightKrylov_TestExpmLib'
-
-    #:for kind, type in RC_KINDS_TYPES
-    #:if type[0] == "c"
-    ${type}$, parameter, public :: one_${type[0]}$${kind}$ = cmplx(1.0_${kind}$, 0.0_${kind}$, kind=${kind}$)
-    ${type}$, parameter, public :: zero_${type[0]}$${kind}$ = cmplx(0.0_${kind}$, 0.0_${kind}$, kind=${kind}$)
-    #:else
-    ${type}$, parameter, public :: one_${type[0]}$${kind}$ = 1.0_${kind}$
-    ${type}$, parameter, public :: zero_${type[0]}$${kind}$ = 0.0_${kind}$
-    #:endif
-    #:endfor
 
     #:for kind, type in RC_KINDS_TYPES
     public :: collect_expm_${type[0]}$${kind}$_testsuite

--- a/test/TestExpmlib.fypp
+++ b/test/TestExpmlib.fypp
@@ -19,6 +19,12 @@ module TestExpmlib
     use TestUtils
     use TestKrylov
 
+    implicit none
+
+    private
+
+    character*128, parameter, private :: this_module = 'LightKrylov_TestExpmLib'
+
     #:for kind, type in RC_KINDS_TYPES
     #:if type[0] == "c"
     ${type}$, parameter, public :: one_${type[0]}$${kind}$ = cmplx(1.0_${kind}$, 0.0_${kind}$, kind=${kind}$)
@@ -117,7 +123,7 @@ contains
 
         ! Krylov exponential.
         call kexpm(Xkryl, A, Q, tau, rtol_${kind}$, info, verbosity=verb, kdim=nkmax)
-        !call check_info(info, 'kexpm', module='LightKrylov_TestExpmLib', procedure='test_kexptA_${type[0]}$${kind}$')
+        !call check_info(info, 'kexpm', module=this_module, procedure='test_kexptA_${type[0]}$${kind}$')
 
         ! Check result.
         call Xkryl%sub(Xref) ; err = Xkryl%norm()
@@ -182,13 +188,13 @@ contains
         do i = 1,p
             if (verb) write(*,*) '    column',i
             call kexpm(C(i), A, B(i), tau, tol, info, verbosity=verb, kdim=nkmax)
-            !call check_info(info, 'kexpm', module='LightKrylov_TestExpmLib', procedure='test_block_kexptA_${type[0]}$${kind}$, 1')
+            !call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_${type[0]}$${kind}$, 1')
         end do
         
         ! Compute Krylov matrix exponential using block-arnoldi method
         if (verb) write(*,*) 'BLOCK-ARNOLDI'
         call kexpm(Cblk, A, B, tau, tol, info, verbosity=verb, kdim=nkmax)
-        !call check_info(info, 'kexpm', module='LightKrylov_TestExpmLib', procedure='test_block_kexptA_${type[0]}$${kind}$, 2')
+        !call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_${type[0]}$${kind}$, 2')
     
         do i = 1, p
             write(output_unit, *) C(i)%norm(), Cblk(i)%norm()
@@ -282,7 +288,7 @@ contains
      
        ! compute matrix square root
        call sqrtm(A, sqrtmA, info)
-       !call check_info(info, 'sqrtm', module='LightKrylov_TestExpmLib', procedure='test_dense_sqrtm_pos_def_${type[0]}$${kind}$')
+       !call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_def_${type[0]}$${kind}$')
     
        #:if type[0] == "r"
        write(*,*) 'max err: ', maxval(matmul(sqrtmA, sqrtmA) - A)
@@ -340,7 +346,7 @@ contains
     
        ! compute matrix square root
        call sqrtm(A, sqrtmA, info)
-       !call check_info(info, 'sqrtm', module='LightKrylov_TestExpmLib', procedure='test_dense_sqrtm_pos_semi_def_${type[0]}$${kind}$')
+       !call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_semi_def_${type[0]}$${kind}$')
     
        #:if type[0] == "r"
        write(*,*) 'max err: ', maxval(matmul(sqrtmA, sqrtmA) - A)

--- a/test/TestIterativeSolvers.f90
+++ b/test/TestIterativeSolvers.f90
@@ -17,7 +17,10 @@ module TestIterativeSolvers
     use TestKrylov
 
     implicit none
+    
     private
+
+    character*128, parameter, private :: this_module = 'LightKrylov_TestIterativeSolvers'
 
     public :: collect_eig_rsp_testsuite
     public :: collect_svd_rsp_testsuite
@@ -92,7 +95,7 @@ contains
 
         ! Compute spectral decomposition.
         call eigs(A, X, eigvals, residuals, info, select=select_eigs)
-        call check_info(info, 'eigs', module='LightKrylov_TestIterativeSolvers', procedure='test_ks_evp_rsp')
+        call check_info(info, 'eigs', module=this_module, procedure='test_ks_evp_rsp')
 
         ! Analytical eigenvalues.
         true_eigvals = cmplx(0.0_sp, 0.0_sp, kind=sp) ; k = 1
@@ -153,7 +156,7 @@ contains
 
         ! Compute spectral decomposition.
         call eigs(A, X, eigvals, residuals, info)
-        call check_info(info, 'eigs', module='LightKrylov_TestIterativeSolvers', procedure='test_evp_rsp')
+        call check_info(info, 'eigs', module=this_module, procedure='test_evp_rsp')
 
         ! Analytical eigenvalues.
         true_eigvals = cmplx(0.0_sp, 0.0_sp, kind=sp) ; k = 1
@@ -208,7 +211,7 @@ contains
 
         ! Spectral decomposition.
         call eighs(A, X, evals, residuals, info, kdim=test_size)
-        call check_info(info, 'eighs', module='LightKrylov_TestIterativeSolvers', procedure='test_sym_evp_rsp')
+        call check_info(info, 'eighs', module=this_module, procedure='test_sym_evp_rsp')
 
         ! Analytical eigenvalues.
         true_evals = 0.0_sp
@@ -272,7 +275,7 @@ contains
 
         ! Compute spectral decomposition.
         call eigs(A, X, eigvals, residuals, info, select=select_eigs)
-        call check_info(info, 'eigs', module='LightKrylov_TestIterativeSolvers', procedure='test_ks_evp_rdp')
+        call check_info(info, 'eigs', module=this_module, procedure='test_ks_evp_rdp')
 
         ! Analytical eigenvalues.
         true_eigvals = cmplx(0.0_dp, 0.0_dp, kind=dp) ; k = 1
@@ -333,7 +336,7 @@ contains
 
         ! Compute spectral decomposition.
         call eigs(A, X, eigvals, residuals, info)
-        call check_info(info, 'eigs', module='LightKrylov_TestIterativeSolvers', procedure='test_evp_rdp')
+        call check_info(info, 'eigs', module=this_module, procedure='test_evp_rdp')
 
         ! Analytical eigenvalues.
         true_eigvals = cmplx(0.0_dp, 0.0_dp, kind=dp) ; k = 1
@@ -388,7 +391,7 @@ contains
 
         ! Spectral decomposition.
         call eighs(A, X, evals, residuals, info, kdim=test_size)
-        call check_info(info, 'eighs', module='LightKrylov_TestIterativeSolvers', procedure='test_sym_evp_rdp')
+        call check_info(info, 'eighs', module=this_module, procedure='test_sym_evp_rdp')
 
         ! Analytical eigenvalues.
         true_evals = 0.0_dp
@@ -578,7 +581,7 @@ contains
 
         ! Compute spectral decomposition.
         call svds(A, U, S, V, residuals, info)
-        call check_info(info, 'svds', module='LightKrylov_TestIterativeSolvers', procedure='test_svd_rsp')
+        call check_info(info, 'svds', module=this_module, procedure='test_svd_rsp')
 
         ! Analytical singular values.
         do i = 1, test_size
@@ -636,7 +639,7 @@ contains
 
         ! Compute spectral decomposition.
         call svds(A, U, S, V, residuals, info)
-        call check_info(info, 'svds', module='LightKrylov_TestIterativeSolvers', procedure='test_svd_rdp')
+        call check_info(info, 'svds', module=this_module, procedure='test_svd_rdp')
 
         ! Analytical singular values.
         do i = 1, test_size
@@ -742,7 +745,7 @@ contains
         ! GMRES solver.
         opts = gmres_sp_opts(kdim=test_size, verbose=.false.)
         call gmres(A, b, x, info, options=opts)
-        call check_info(info, 'gmres', module='LightKrylov_TestIterativeSolvers', procedure='test_gmres_rsp')
+        call check_info(info, 'gmres', module=this_module, procedure='test_gmres_rsp')
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_sp)
@@ -770,7 +773,7 @@ contains
         ! GMRES solver.
         opts = gmres_sp_opts(kdim=test_size, verbose=.false.)
         call gmres(A, b, x, info, options=opts)
-        call check_info(info, 'gmres', module='LightKrylov_TestIterativeSolvers', procedure='test_gmres_spd_rsp')
+        call check_info(info, 'gmres', module=this_module, procedure='test_gmres_spd_rsp')
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_sp)
@@ -807,7 +810,7 @@ contains
         ! GMRES solver.
         opts = gmres_dp_opts(kdim=test_size, verbose=.false.)
         call gmres(A, b, x, info, options=opts)
-        call check_info(info, 'gmres', module='LightKrylov_TestIterativeSolvers', procedure='test_gmres_rdp')
+        call check_info(info, 'gmres', module=this_module, procedure='test_gmres_rdp')
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_dp)
@@ -835,7 +838,7 @@ contains
         ! GMRES solver.
         opts = gmres_dp_opts(kdim=test_size, verbose=.false.)
         call gmres(A, b, x, info, options=opts)
-        call check_info(info, 'gmres', module='LightKrylov_TestIterativeSolvers', procedure='test_gmres_spd_rdp')
+        call check_info(info, 'gmres', module=this_module, procedure='test_gmres_spd_rdp')
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_dp)
@@ -872,7 +875,7 @@ contains
         ! GMRES solver.
         opts = gmres_sp_opts(kdim=test_size, verbose=.false.)
         call gmres(A, b, x, info, options=opts)
-        call check_info(info, 'gmres', module='LightKrylov_TestIterativeSolvers', procedure='test_gmres_csp')
+        call check_info(info, 'gmres', module=this_module, procedure='test_gmres_csp')
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_sp)
@@ -900,7 +903,7 @@ contains
         ! GMRES solver.
         opts = gmres_sp_opts(kdim=test_size, verbose=.false.)
         call gmres(A, b, x, info, options=opts)
-        call check_info(info, 'gmres', module='LightKrylov_TestIterativeSolvers', procedure='test_gmres_spd_csp')
+        call check_info(info, 'gmres', module=this_module, procedure='test_gmres_spd_csp')
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_sp)
@@ -937,7 +940,7 @@ contains
         ! GMRES solver.
         opts = gmres_dp_opts(kdim=test_size, verbose=.false.)
         call gmres(A, b, x, info, options=opts)
-        call check_info(info, 'gmres', module='LightKrylov_TestIterativeSolvers', procedure='test_gmres_cdp')
+        call check_info(info, 'gmres', module=this_module, procedure='test_gmres_cdp')
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_dp)
@@ -965,7 +968,7 @@ contains
         ! GMRES solver.
         opts = gmres_dp_opts(kdim=test_size, verbose=.false.)
         call gmres(A, b, x, info, options=opts)
-        call check_info(info, 'gmres', module='LightKrylov_TestIterativeSolvers', procedure='test_gmres_spd_cdp')
+        call check_info(info, 'gmres', module=this_module, procedure='test_gmres_spd_cdp')
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_dp)
@@ -1005,7 +1008,7 @@ contains
         ! CG solver.
         opts = cg_sp_opts()
         call cg(A, b, x, info, options=opts)
-        call check_info(info, 'cg', module='LightKrylov_TestIterativeSolvers', procedure='test_cg_rsp')
+        call check_info(info, 'cg', module=this_module, procedure='test_cg_rsp')
 
         write(*, *) norm2(abs(matmul(A%data, x%data) - b%data)), b%norm() * rtol_sp 
 
@@ -1042,7 +1045,7 @@ contains
         ! CG solver.
         opts = cg_dp_opts()
         call cg(A, b, x, info, options=opts)
-        call check_info(info, 'cg', module='LightKrylov_TestIterativeSolvers', procedure='test_cg_rdp')
+        call check_info(info, 'cg', module=this_module, procedure='test_cg_rdp')
 
         write(*, *) norm2(abs(matmul(A%data, x%data) - b%data)), b%norm() * rtol_dp 
 
@@ -1079,7 +1082,7 @@ contains
         ! CG solver.
         opts = cg_sp_opts()
         call cg(A, b, x, info, options=opts)
-        call check_info(info, 'cg', module='LightKrylov_TestIterativeSolvers', procedure='test_cg_csp')
+        call check_info(info, 'cg', module=this_module, procedure='test_cg_csp')
 
         write(*, *) norm2(abs(matmul(A%data, x%data) - b%data)), b%norm() * rtol_sp 
 
@@ -1116,7 +1119,7 @@ contains
         ! CG solver.
         opts = cg_dp_opts()
         call cg(A, b, x, info, options=opts)
-        call check_info(info, 'cg', module='LightKrylov_TestIterativeSolvers', procedure='test_cg_cdp')
+        call check_info(info, 'cg', module=this_module, procedure='test_cg_cdp')
 
         write(*, *) norm2(abs(matmul(A%data, x%data) - b%data)), b%norm() * rtol_dp 
 

--- a/test/TestIterativeSolvers.f90
+++ b/test/TestIterativeSolvers.f90
@@ -7,6 +7,7 @@ module TestIterativeSolvers
 
     ! LightKrylov
     use LightKrylov
+    use LightKrylov_Constants
     use LightKrylov_Logger
 
     ! Testdrive
@@ -72,6 +73,8 @@ contains
         ! Miscellaneous.
         integer :: i, k, n
         integer, parameter :: nev = 8
+        type(vector_rsp), allocatable :: AX(:)
+        complex(sp), allocatable :: eigvec_residuals(:,:)
         complex(sp) :: true_eigvals(test_size)
         real(sp) :: pi = 4.0_sp * atan(1.0_sp)
         real(sp) :: a_, b_
@@ -98,20 +101,31 @@ contains
         call check_info(info, 'eigs', module=this_module, procedure='test_ks_evp_rsp')
 
         ! Analytical eigenvalues.
-        true_eigvals = cmplx(0.0_sp, 0.0_sp, kind=sp) ; k = 1
+        true_eigvals = zero_csp; k = 1
         do i = 1, test_size, 2
-            true_eigvals(i) = a_*cmplx(1.0_sp, 0.0_sp, kind=sp) + (2*b_*cos(k*pi/(test_size+1)))*cmplx(0.0_sp, 1.0_sp, kind=sp)
-            true_eigvals(i+1) = a_*cmplx(1.0_sp, 0.0_sp, kind=sp) - (2*b_*cos(k*pi/(test_size+1)))*cmplx(0.0_sp, 1.0_sp, kind=sp)
+            true_eigvals(i) = a_*one_csp + (2*b_*cos(k*pi/(test_size+1)))*one_im_csp
+            true_eigvals(i+1) = a_*one_csp - (2*b_*cos(k*pi/(test_size+1)))*one_im_csp
             k = k+1
         enddo
 
+        ! check eigenvalues
         call check(error, norm2(abs(eigvals - true_eigvals(:nev))) < rtol_sp)
+        !if (allocated(error)) return
+        !! check eigenvectors
+        !allocate(AX(nev))
+        !allocate(eigvec_residuals(test_size, nev))
+        !do i = 1, nev
+        !    call A%matvec(X(i), AX(i))
+        !    eigvec_residuals(:, i) = AX(i)%data - eigvals(i)*X(i)%data
+        !end do
+        !print *, norm2(abs(eigvec_residuals))
+        !call check(error, norm2(abs(eigvec_residuals)) < rtol_sp)
 
         return
         contains
         function select_eigs(lambda) result(selected)
             complex(sp), intent(in) :: lambda(:)
-            logical                       :: selected(size(lambda))
+            logical :: selected(size(lambda))
 
             selected = abs(lambda) > median(abs(lambda))
             return
@@ -133,6 +147,8 @@ contains
         integer :: info
         ! Miscellaneous.
         integer :: i, k, n
+        type(vector_rsp), allocatable :: AX(:)
+        complex(sp), allocatable :: eigvec_residuals(:,:)
         complex(sp) :: true_eigvals(test_size)
         real(sp) :: pi = 4.0_sp * atan(1.0_sp)
         real(sp) :: a_, b_
@@ -159,14 +175,23 @@ contains
         call check_info(info, 'eigs', module=this_module, procedure='test_evp_rsp')
 
         ! Analytical eigenvalues.
-        true_eigvals = cmplx(0.0_sp, 0.0_sp, kind=sp) ; k = 1
+        true_eigvals = zero_csp; k = 1
         do i = 1, test_size, 2
-            true_eigvals(i) = a_*cmplx(1.0_sp, 0.0_sp, kind=sp) + (2*b_*cos(k*pi/(test_size+1)))*cmplx(0.0_sp, 1.0_sp, kind=sp)
-            true_eigvals(i+1) = a_*cmplx(1.0_sp, 0.0_sp, kind=sp) - (2*b_*cos(k*pi/(test_size+1)))*cmplx(0.0_sp, 1.0_sp, kind=sp)
+            true_eigvals(i) = a_*one_csp + (2*b_*cos(k*pi/(test_size+1)))*one_im_csp
+            true_eigvals(i+1) = a_*one_csp - (2*b_*cos(k*pi/(test_size+1)))*one_im_csp
             k = k+1
         enddo
 
         call check(error, norm2(abs(eigvals - true_eigvals)) < rtol_sp)
+        !if (allocated(error)) return
+        ! check eigenvectors
+        !allocate(AX(test_size))
+        !allocate(eigvec_residuals(test_size, test_size)); eigvec_residuals = zero_csp
+        !do i = 1, test_size
+        !    call A%matvec(X(i), AX(i))
+        !    eigvec_residuals(:, i) = AX(i)%data - eigvals(i)*X(i)%data
+        !end do
+        !call check(error, norm2(abs(eigvec_residuals)) < rtol_sp)
 
         return
     end subroutine test_evp_rsp
@@ -252,6 +277,8 @@ contains
         ! Miscellaneous.
         integer :: i, k, n
         integer, parameter :: nev = 8
+        type(vector_rdp), allocatable :: AX(:)
+        complex(dp), allocatable :: eigvec_residuals(:,:)
         complex(dp) :: true_eigvals(test_size)
         real(dp) :: pi = 4.0_dp * atan(1.0_dp)
         real(dp) :: a_, b_
@@ -278,20 +305,31 @@ contains
         call check_info(info, 'eigs', module=this_module, procedure='test_ks_evp_rdp')
 
         ! Analytical eigenvalues.
-        true_eigvals = cmplx(0.0_dp, 0.0_dp, kind=dp) ; k = 1
+        true_eigvals = zero_cdp; k = 1
         do i = 1, test_size, 2
-            true_eigvals(i) = a_*cmplx(1.0_dp, 0.0_dp, kind=dp) + (2*b_*cos(k*pi/(test_size+1)))*cmplx(0.0_dp, 1.0_dp, kind=dp)
-            true_eigvals(i+1) = a_*cmplx(1.0_dp, 0.0_dp, kind=dp) - (2*b_*cos(k*pi/(test_size+1)))*cmplx(0.0_dp, 1.0_dp, kind=dp)
+            true_eigvals(i) = a_*one_cdp + (2*b_*cos(k*pi/(test_size+1)))*one_im_cdp
+            true_eigvals(i+1) = a_*one_cdp - (2*b_*cos(k*pi/(test_size+1)))*one_im_cdp
             k = k+1
         enddo
 
+        ! check eigenvalues
         call check(error, norm2(abs(eigvals - true_eigvals(:nev))) < rtol_dp)
+        !if (allocated(error)) return
+        !! check eigenvectors
+        !allocate(AX(nev))
+        !allocate(eigvec_residuals(test_size, nev))
+        !do i = 1, nev
+        !    call A%matvec(X(i), AX(i))
+        !    eigvec_residuals(:, i) = AX(i)%data - eigvals(i)*X(i)%data
+        !end do
+        !print *, norm2(abs(eigvec_residuals))
+        !call check(error, norm2(abs(eigvec_residuals)) < rtol_dp)
 
         return
         contains
         function select_eigs(lambda) result(selected)
             complex(dp), intent(in) :: lambda(:)
-            logical                       :: selected(size(lambda))
+            logical :: selected(size(lambda))
 
             selected = abs(lambda) > median(abs(lambda))
             return
@@ -313,6 +351,8 @@ contains
         integer :: info
         ! Miscellaneous.
         integer :: i, k, n
+        type(vector_rdp), allocatable :: AX(:)
+        complex(dp), allocatable :: eigvec_residuals(:,:)
         complex(dp) :: true_eigvals(test_size)
         real(dp) :: pi = 4.0_dp * atan(1.0_dp)
         real(dp) :: a_, b_
@@ -339,14 +379,23 @@ contains
         call check_info(info, 'eigs', module=this_module, procedure='test_evp_rdp')
 
         ! Analytical eigenvalues.
-        true_eigvals = cmplx(0.0_dp, 0.0_dp, kind=dp) ; k = 1
+        true_eigvals = zero_cdp; k = 1
         do i = 1, test_size, 2
-            true_eigvals(i) = a_*cmplx(1.0_dp, 0.0_dp, kind=dp) + (2*b_*cos(k*pi/(test_size+1)))*cmplx(0.0_dp, 1.0_dp, kind=dp)
-            true_eigvals(i+1) = a_*cmplx(1.0_dp, 0.0_dp, kind=dp) - (2*b_*cos(k*pi/(test_size+1)))*cmplx(0.0_dp, 1.0_dp, kind=dp)
+            true_eigvals(i) = a_*one_cdp + (2*b_*cos(k*pi/(test_size+1)))*one_im_cdp
+            true_eigvals(i+1) = a_*one_cdp - (2*b_*cos(k*pi/(test_size+1)))*one_im_cdp
             k = k+1
         enddo
 
         call check(error, norm2(abs(eigvals - true_eigvals)) < rtol_dp)
+        !if (allocated(error)) return
+        ! check eigenvectors
+        !allocate(AX(test_size))
+        !allocate(eigvec_residuals(test_size, test_size)); eigvec_residuals = zero_cdp
+        !do i = 1, test_size
+        !    call A%matvec(X(i), AX(i))
+        !    eigvec_residuals(:, i) = AX(i)%data - eigvals(i)*X(i)%data
+        !end do
+        !call check(error, norm2(abs(eigvec_residuals)) < rtol_dp)
 
         return
     end subroutine test_evp_rdp
@@ -431,6 +480,8 @@ contains
         ! Miscellaneous.
         integer :: i, k, n
         integer, parameter :: nev = 8
+        type(vector_csp), allocatable :: AX(:)
+        complex(sp), allocatable :: eigvec_residuals(:,:)
         complex(sp) :: true_eigvals(test_size)
         real(sp) :: pi = 4.0_sp * atan(1.0_sp)
 
@@ -438,7 +489,7 @@ contains
         contains
         function select_eigs(lambda) result(selected)
             complex(sp), intent(in) :: lambda(:)
-            logical                       :: selected(size(lambda))
+            logical :: selected(size(lambda))
 
             selected = abs(lambda) > median(abs(lambda))
             return
@@ -460,6 +511,8 @@ contains
         integer :: info
         ! Miscellaneous.
         integer :: i, k, n
+        type(vector_csp), allocatable :: AX(:)
+        complex(sp), allocatable :: eigvec_residuals(:,:)
         complex(sp) :: true_eigvals(test_size)
         real(sp) :: pi = 4.0_sp * atan(1.0_sp)
 
@@ -493,6 +546,8 @@ contains
         ! Miscellaneous.
         integer :: i, k, n
         integer, parameter :: nev = 8
+        type(vector_cdp), allocatable :: AX(:)
+        complex(dp), allocatable :: eigvec_residuals(:,:)
         complex(dp) :: true_eigvals(test_size)
         real(dp) :: pi = 4.0_dp * atan(1.0_dp)
 
@@ -500,7 +555,7 @@ contains
         contains
         function select_eigs(lambda) result(selected)
             complex(dp), intent(in) :: lambda(:)
-            logical                       :: selected(size(lambda))
+            logical :: selected(size(lambda))
 
             selected = abs(lambda) > median(abs(lambda))
             return
@@ -522,6 +577,8 @@ contains
         integer :: info
         ! Miscellaneous.
         integer :: i, k, n
+        type(vector_cdp), allocatable :: AX(:)
+        complex(dp), allocatable :: eigvec_residuals(:,:)
         complex(dp) :: true_eigvals(test_size)
         real(dp) :: pi = 4.0_dp * atan(1.0_dp)
 
@@ -574,8 +631,8 @@ contains
             A%data(i, i) = 2.0_sp
             ! Upper diagonal entry.
             if (i < n) then
-                A%data(i, i+1) = -1.0_sp
-                A%data(i+1, i) = -1.0_sp
+                A%data(i, i+1) = -one_rsp
+                A%data(i+1, i) = -one_rsp
             endif
         enddo
 
@@ -585,7 +642,7 @@ contains
 
         ! Analytical singular values.
         do i = 1, test_size
-            true_svdvals(i) = 2.0_sp * (1.0_sp + cos(i*pi/(test_size+1)))
+            true_svdvals(i) = 2.0_sp * (one_rsp + cos(i*pi/(test_size+1)))
         enddo
 
         call check(error, norm2(s - true_svdvals)**2 < rtol_sp)
@@ -632,8 +689,8 @@ contains
             A%data(i, i) = 2.0_dp
             ! Upper diagonal entry.
             if (i < n) then
-                A%data(i, i+1) = -1.0_dp
-                A%data(i+1, i) = -1.0_dp
+                A%data(i, i+1) = -one_rdp
+                A%data(i+1, i) = -one_rdp
             endif
         enddo
 
@@ -643,7 +700,7 @@ contains
 
         ! Analytical singular values.
         do i = 1, test_size
-            true_svdvals(i) = 2.0_dp * (1.0_dp + cos(i*pi/(test_size+1)))
+            true_svdvals(i) = 2.0_dp * (one_rdp + cos(i*pi/(test_size+1)))
         enddo
 
         call check(error, norm2(s - true_svdvals)**2 < rtol_dp)

--- a/test/TestIterativeSolvers.f90
+++ b/test/TestIterativeSolvers.f90
@@ -642,7 +642,7 @@ contains
 
         ! Analytical singular values.
         do i = 1, test_size
-            true_svdvals(i) = 2.0_sp * (one_rsp + cos(i*pi/(test_size+1)))
+            true_svdvals(i) = 2.0_sp * (1.0_sp + cos(i*pi/(test_size+1)))
         enddo
 
         call check(error, norm2(s - true_svdvals)**2 < rtol_sp)
@@ -700,7 +700,7 @@ contains
 
         ! Analytical singular values.
         do i = 1, test_size
-            true_svdvals(i) = 2.0_dp * (one_rdp + cos(i*pi/(test_size+1)))
+            true_svdvals(i) = 2.0_dp * (1.0_dp + cos(i*pi/(test_size+1)))
         enddo
 
         call check(error, norm2(s - true_svdvals)**2 < rtol_dp)

--- a/test/TestIterativeSolvers.fypp
+++ b/test/TestIterativeSolvers.fypp
@@ -11,6 +11,7 @@ module TestIterativeSolvers
     use LightKrylov
     use LightKrylov_Constants
     use LightKrylov_Logger
+    use LightKrylov_AbstractVectors
 
     ! Testdrive
     use testdrive, only: new_unittest, unittest_type, error_type, check
@@ -43,11 +44,11 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
          testsuite = [ &
-                    new_unittest("Eigs computation", test_evp_${type[0]}$${kind}$), &
+                    new_unittest("Eigs computation (eigvals & eigvecs)", test_evp_${type[0]}$${kind}$), &
                     #:if type[0] == "r"
-                    new_unittest("Sym. eigs computation", test_sym_evp_${type[0]}$${kind}$), &
+                    new_unittest("Sym. eigs computation (eigvals, eigvecs & eigvec orthonormality)", test_sym_evp_${type[0]}$${kind}$), &
                     #:endif
-                    new_unittest("KS eigs computation", test_ks_evp_${type[0]}$${kind}$) &
+                    new_unittest("KS eigs computation (eigvals & eigvecs)", test_ks_evp_${type[0]}$${kind}$) &
                     ]
         return
     end subroutine collect_eig_${type[0]}$${kind}$_testsuite
@@ -181,15 +182,16 @@ contains
         enddo
 
         call check(error, norm2(abs(eigvals - true_eigvals)) < rtol_${kind}$)
-        !if (allocated(error)) return
-        ! check eigenvectors
-        !allocate(AX(test_size))
-        !allocate(eigvec_residuals(test_size, test_size)); eigvec_residuals = zero_c${kind}$
-        !do i = 1, test_size
-        !    call A%matvec(X(i), AX(i))
-        !    eigvec_residuals(:, i) = AX(i)%data - eigvals(i)*X(i)%data
-        !end do
-        !call check(error, norm2(abs(eigvec_residuals)) < rtol_${kind}$)
+!        if (allocated(error)) return
+!
+!        ! check eigenvectors
+!        allocate(AX(test_size))
+!        allocate(eigvec_residuals(test_size, test_size)); eigvec_residuals = zero_c${kind}$
+!        do i = 1, test_size
+!            call A%matvec(X(i), AX(i))
+!            eigvec_residuals(:, i) = AX(i)%data - eigvals(i)*X(i)%data
+!        end do
+!        call check(error, norm2(abs(eigvec_residuals)) < rtol_${kind}$)
         #:endif
 
         return
@@ -215,6 +217,9 @@ contains
         integer :: i
         ${type}$ :: alpha, true_evals(test_size)
         ${type}$, parameter :: pi = 4.0_${kind}$ * atan(1.0_${kind}$)
+        type(vector_${type[0]}$${kind}$), allocatable :: AX(:)
+        complex(${kind}$), allocatable :: eigvec_residuals(:,:)
+        ${type}$, allocatable, dimension(:,:) :: G, Id
 
         ! Create the sym. pos. def. Toeplitz matrix.
         call random_number(a_) ; call random_number(b_) ; b_ = -abs(b_)
@@ -246,6 +251,26 @@ contains
 
         ! Check error.
         call check(error, all_close(evals, true_evals, rtol_${kind}$, atol_${kind}$))
+        if (allocated(error)) return
+
+        ! check eigenvectors
+        allocate(AX(test_size))
+        allocate(eigvec_residuals(test_size, test_size)); eigvec_residuals = zero_c${kind}$
+        do i = 1, test_size
+            call A%matvec(X(i), AX(i))
+            eigvec_residuals(:, i) = AX(i)%data - evals(i)*X(i)%data
+        end do
+        call check(error, norm2(abs(eigvec_residuals)) < rtol_${kind}$)
+        if (allocated(error)) return
+
+        ! Compute Gram matrix associated to the Krylov basis.
+        allocate(G(test_size, test_size)) ; allocate(Id(test_size, test_size))
+        G = zero_${type[0]}$${kind}$
+        call innerprod(G, X, X)
+
+        ! Check orthonormality of the eigenvectors.
+        Id = eye(test_size)
+        call check(error, norm2(abs(G - Id)) < rtol_${kind}$)
 
         return
     end subroutine test_sym_evp_${type[0]}$${kind}$
@@ -263,7 +288,7 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-                    new_unittest("SVDS computation", test_svd_${type[0]}$${kind}$) &
+                    new_unittest("SVDS computation (factorization correctness, singular values, left/right orthonormality)", test_svd_${type[0]}$${kind}$) &
                     ]
         return
     end subroutine collect_svd_${type[0]}$${kind}$_testsuite
@@ -285,6 +310,8 @@ contains
         integer :: i, k, n
         real(${kind}$) :: true_svdvals(test_size)
         real(${kind}$) :: pi = 4.0_${kind}$ * atan(1.0_${kind}$)
+        ${type}$, dimension(test_size, test_size) :: G, Id
+        ${type}$, dimension(test_size, test_size) :: Udata, Vdata
         #:if type[0] == "r"
 
         ! Allocate eigenvectors.
@@ -314,6 +341,29 @@ contains
         enddo
 
         call check(error, norm2(s - true_svdvals)**2 < rtol_${kind}$)
+        if (allocated(error)) return
+
+        ! Compute Gram matrix associated to the Krylov basis of the left singular vectors.
+        G = zero_${type[0]}$${kind}$
+        call innerprod(G, U(1:test_size), U(1:test_size))
+
+        ! Check orthonormality of the left singular vectors
+        Id = eye(test_size)
+        call check(error, norm2(abs(G - Id)) < rtol_${kind}$)
+        if (allocated(error)) return
+
+        ! Compute Gram matrix associated to the Krylov basis of the right singular vectors.
+        G = zero_${type[0]}$${kind}$
+        call innerprod(G, V(1:test_size), V(1:test_size))
+
+        ! Check orthonormality of the right singular vectors
+        call check(error, norm2(abs(G - Id)) < rtol_${kind}$)
+        if (allocated(error)) return
+
+        ! Check correctness of full factorization.
+        call get_data(Udata, U)
+        call get_data(Vdata, V)
+        call check(error, maxval(abs(A%data - matmul(Udata, matmul(diag(s), transpose(Vdata))))) < rtol_${kind}$)
         #:endif
 
         return

--- a/test/TestIterativeSolvers.fypp
+++ b/test/TestIterativeSolvers.fypp
@@ -9,6 +9,7 @@ module TestIterativeSolvers
 
     ! LightKrylov
     use LightKrylov
+    use LightKrylov_Constants
     use LightKrylov_Logger
 
     ! Testdrive
@@ -67,6 +68,8 @@ contains
         ! Miscellaneous.
         integer :: i, k, n
         integer, parameter :: nev = 8
+        type(vector_${type[0]}$${kind}$), allocatable :: AX(:)
+        complex(${kind}$), allocatable :: eigvec_residuals(:,:)
         complex(${kind}$) :: true_eigvals(test_size)
         real(${kind}$) :: pi = 4.0_${kind}$ * atan(1.0_${kind}$)
         #:if type[0] == "r"
@@ -94,21 +97,32 @@ contains
         call check_info(info, 'eigs', module=this_module, procedure='test_ks_evp_${type[0]}$${kind}$')
 
         ! Analytical eigenvalues.
-        true_eigvals = cmplx(0.0_${kind}$, 0.0_${kind}$, kind=${kind}$) ; k = 1
+        true_eigvals = zero_c${kind}$; k = 1
         do i = 1, test_size, 2
-            true_eigvals(i) = a_*cmplx(1.0_${kind}$, 0.0_${kind}$, kind=${kind}$) + (2*b_*cos(k*pi/(test_size+1)))*cmplx(0.0_${kind}$, 1.0_${kind}$, kind=${kind}$)
-            true_eigvals(i+1) = a_*cmplx(1.0_${kind}$, 0.0_${kind}$, kind=${kind}$) - (2*b_*cos(k*pi/(test_size+1)))*cmplx(0.0_${kind}$, 1.0_${kind}$, kind=${kind}$)
+            true_eigvals(i) = a_*one_c${kind}$ + (2*b_*cos(k*pi/(test_size+1)))*one_im_c${kind}$
+            true_eigvals(i+1) = a_*one_c${kind}$ - (2*b_*cos(k*pi/(test_size+1)))*one_im_c${kind}$
             k = k+1
         enddo
 
+        ! check eigenvalues
         call check(error, norm2(abs(eigvals - true_eigvals(:nev))) < rtol_${kind}$)
+        !if (allocated(error)) return
+        !! check eigenvectors
+        !allocate(AX(nev))
+        !allocate(eigvec_residuals(test_size, nev))
+        !do i = 1, nev
+        !    call A%matvec(X(i), AX(i))
+        !    eigvec_residuals(:, i) = AX(i)%data - eigvals(i)*X(i)%data
+        !end do
+        !print *, norm2(abs(eigvec_residuals))
+        !call check(error, norm2(abs(eigvec_residuals)) < rtol_${kind}$)
         #:endif
 
         return
         contains
         function select_eigs(lambda) result(selected)
             complex(${kind}$), intent(in) :: lambda(:)
-            logical                       :: selected(size(lambda))
+            logical :: selected(size(lambda))
 
             selected = abs(lambda) > median(abs(lambda))
             return
@@ -130,6 +144,8 @@ contains
         integer :: info
         ! Miscellaneous.
         integer :: i, k, n
+        type(vector_${type[0]}$${kind}$), allocatable :: AX(:)
+        complex(${kind}$), allocatable :: eigvec_residuals(:,:)
         complex(${kind}$) :: true_eigvals(test_size)
         real(${kind}$) :: pi = 4.0_${kind}$ * atan(1.0_${kind}$)
         #:if type[0] == "r"
@@ -157,14 +173,23 @@ contains
         call check_info(info, 'eigs', module=this_module, procedure='test_evp_${type[0]}$${kind}$')
 
         ! Analytical eigenvalues.
-        true_eigvals = cmplx(0.0_${kind}$, 0.0_${kind}$, kind=${kind}$) ; k = 1
+        true_eigvals = zero_c${kind}$; k = 1
         do i = 1, test_size, 2
-            true_eigvals(i) = a_*cmplx(1.0_${kind}$, 0.0_${kind}$, kind=${kind}$) + (2*b_*cos(k*pi/(test_size+1)))*cmplx(0.0_${kind}$, 1.0_${kind}$, kind=${kind}$)
-            true_eigvals(i+1) = a_*cmplx(1.0_${kind}$, 0.0_${kind}$, kind=${kind}$) - (2*b_*cos(k*pi/(test_size+1)))*cmplx(0.0_${kind}$, 1.0_${kind}$, kind=${kind}$)
+            true_eigvals(i) = a_*one_c${kind}$ + (2*b_*cos(k*pi/(test_size+1)))*one_im_c${kind}$
+            true_eigvals(i+1) = a_*one_c${kind}$ - (2*b_*cos(k*pi/(test_size+1)))*one_im_c${kind}$
             k = k+1
         enddo
 
         call check(error, norm2(abs(eigvals - true_eigvals)) < rtol_${kind}$)
+        !if (allocated(error)) return
+        ! check eigenvectors
+        !allocate(AX(test_size))
+        !allocate(eigvec_residuals(test_size, test_size)); eigvec_residuals = zero_c${kind}$
+        !do i = 1, test_size
+        !    call A%matvec(X(i), AX(i))
+        !    eigvec_residuals(:, i) = AX(i)%data - eigvals(i)*X(i)%data
+        !end do
+        !call check(error, norm2(abs(eigvec_residuals)) < rtol_${kind}$)
         #:endif
 
         return
@@ -274,8 +299,8 @@ contains
             A%data(i, i) = 2.0_${kind}$
             ! Upper diagonal entry.
             if (i < n) then
-                A%data(i, i+1) = -1.0_${kind}$
-                A%data(i+1, i) = -1.0_${kind}$
+                A%data(i, i+1) = -one_r${kind}$
+                A%data(i+1, i) = -one_r${kind}$
             endif
         enddo
 

--- a/test/TestIterativeSolvers.fypp
+++ b/test/TestIterativeSolvers.fypp
@@ -19,7 +19,10 @@ module TestIterativeSolvers
     use TestKrylov
 
     implicit none
+    
     private
+
+    character*128, parameter, private :: this_module = 'LightKrylov_TestIterativeSolvers'
 
     #:for kind, type in RC_KINDS_TYPES
     public :: collect_eig_${type[0]}$${kind}$_testsuite
@@ -88,7 +91,7 @@ contains
 
         ! Compute spectral decomposition.
         call eigs(A, X, eigvals, residuals, info, select=select_eigs)
-        call check_info(info, 'eigs', module='LightKrylov_TestIterativeSolvers', procedure='test_ks_evp_${type[0]}$${kind}$')
+        call check_info(info, 'eigs', module=this_module, procedure='test_ks_evp_${type[0]}$${kind}$')
 
         ! Analytical eigenvalues.
         true_eigvals = cmplx(0.0_${kind}$, 0.0_${kind}$, kind=${kind}$) ; k = 1
@@ -151,7 +154,7 @@ contains
 
         ! Compute spectral decomposition.
         call eigs(A, X, eigvals, residuals, info)
-        call check_info(info, 'eigs', module='LightKrylov_TestIterativeSolvers', procedure='test_evp_${type[0]}$${kind}$')
+        call check_info(info, 'eigs', module=this_module, procedure='test_evp_${type[0]}$${kind}$')
 
         ! Analytical eigenvalues.
         true_eigvals = cmplx(0.0_${kind}$, 0.0_${kind}$, kind=${kind}$) ; k = 1
@@ -208,7 +211,7 @@ contains
 
         ! Spectral decomposition.
         call eighs(A, X, evals, residuals, info, kdim=test_size)
-        call check_info(info, 'eighs', module='LightKrylov_TestIterativeSolvers', procedure='test_sym_evp_${type[0]}$${kind}$')
+        call check_info(info, 'eighs', module=this_module, procedure='test_sym_evp_${type[0]}$${kind}$')
 
         ! Analytical eigenvalues.
         true_evals = 0.0_${kind}$
@@ -278,7 +281,7 @@ contains
 
         ! Compute spectral decomposition.
         call svds(A, U, S, V, residuals, info)
-        call check_info(info, 'svds', module='LightKrylov_TestIterativeSolvers', procedure='test_svd_${type[0]}$${kind}$')
+        call check_info(info, 'svds', module=this_module, procedure='test_svd_${type[0]}$${kind}$')
 
         ! Analytical singular values.
         do i = 1, test_size
@@ -327,7 +330,7 @@ contains
         ! GMRES solver.
         opts = gmres_${kind}$_opts(kdim=test_size, verbose=.false.)
         call gmres(A, b, x, info, options=opts)
-        call check_info(info, 'gmres', module='LightKrylov_TestIterativeSolvers', procedure='test_gmres_${type[0]}$${kind}$')
+        call check_info(info, 'gmres', module=this_module, procedure='test_gmres_${type[0]}$${kind}$')
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_${kind}$)
@@ -363,7 +366,7 @@ contains
         ! GMRES solver.
         opts = gmres_${kind}$_opts(kdim=test_size, verbose=.false.)
         call gmres(A, b, x, info, options=opts)
-        call check_info(info, 'gmres', module='LightKrylov_TestIterativeSolvers', procedure='test_gmres_spd_${type[0]}$${kind}$')
+        call check_info(info, 'gmres', module=this_module, procedure='test_gmres_spd_${type[0]}$${kind}$')
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_${kind}$)
@@ -413,7 +416,7 @@ contains
         ! CG solver.
         opts = cg_${kind}$_opts()
         call cg(A, b, x, info, options=opts)
-        call check_info(info, 'cg', module='LightKrylov_TestIterativeSolvers', procedure='test_cg_${type[0]}$${kind}$')
+        call check_info(info, 'cg', module=this_module, procedure='test_cg_${type[0]}$${kind}$')
 
         write(*, *) norm2(abs(matmul(A%data, x%data) - b%data)), b%norm() * rtol_${kind}$ 
 

--- a/test/TestKrylov.f90
+++ b/test/TestKrylov.f90
@@ -665,7 +665,7 @@ contains
         ! Initialize Krylov subspace.
         allocate(X(kdim+1)) ; allocate(X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
-        H = zero_rsptest/Tests.f90
+        H = zero_rsp
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info)

--- a/test/TestKrylov.f90
+++ b/test/TestKrylov.f90
@@ -7,6 +7,7 @@ module TestKrylov
 
     ! LightKrylov
     use LightKrylov
+    use LightKrylov_Constants
     use LightKrylov_Logger
 
     ! Testdrive
@@ -65,7 +66,7 @@ contains
         integer, parameter :: kdim = test_size
         type(vector_rsp), allocatable :: A(:)
         ! Upper triangular matrix.
-        real(sp) :: R(kdim, kdim) = 0.0_sp
+        real(sp) :: R(kdim, kdim) = zero_rsp
         ! Information flag.
         integer :: info
         ! Miscellaneous.
@@ -79,7 +80,7 @@ contains
 
         ! In-place QR factorization.
         call qr(A, R, info)
-        call check_info(info, 'qr', module=this_module, procedure='test_qr_factorization_cdp')
+        call check_info(info, 'qr', module=this_module, procedure='test_qr_factorization_rsp')
 
         ! Get data.
         call get_data(Qdata, A)
@@ -125,7 +126,7 @@ contains
             call random_number(alpha)
             idx = 1 + floor(kdim*alpha)
             if (mask(idx)) then
-                A(idx)%data = 0.0_sp
+                A(idx)%data = zero_rsp
                 mask(idx) = .false.
                 k = k-1
             endif
@@ -136,7 +137,7 @@ contains
 
         ! In-place QR factorization.
         call qr(A, R, perm, info)
-        call check_info(info, 'qr_pivot', module=this_module, procedure='test_pivoting_qr_exact_rank_deficiency_cdp')
+        call check_info(info, 'qr_pivot', module=this_module, procedure='test_pivoting_qr_exact_rank_deficiency_rsp')
 
         ! Extract data
         call get_data(Qdata, A)
@@ -165,7 +166,7 @@ contains
         integer, parameter :: kdim = test_size
         type(vector_rdp), allocatable :: A(:)
         ! Upper triangular matrix.
-        real(dp) :: R(kdim, kdim) = 0.0_dp
+        real(dp) :: R(kdim, kdim) = zero_rdp
         ! Information flag.
         integer :: info
         ! Miscellaneous.
@@ -179,7 +180,7 @@ contains
 
         ! In-place QR factorization.
         call qr(A, R, info)
-        call check_info(info, 'qr', module=this_module, procedure='test_qr_factorization_cdp')
+        call check_info(info, 'qr', module=this_module, procedure='test_qr_factorization_rdp')
 
         ! Get data.
         call get_data(Qdata, A)
@@ -225,7 +226,7 @@ contains
             call random_number(alpha)
             idx = 1 + floor(kdim*alpha)
             if (mask(idx)) then
-                A(idx)%data = 0.0_dp
+                A(idx)%data = zero_rdp
                 mask(idx) = .false.
                 k = k-1
             endif
@@ -236,7 +237,7 @@ contains
 
         ! In-place QR factorization.
         call qr(A, R, perm, info)
-        call check_info(info, 'qr_pivot', module=this_module, procedure='test_pivoting_qr_exact_rank_deficiency_cdp')
+        call check_info(info, 'qr_pivot', module=this_module, procedure='test_pivoting_qr_exact_rank_deficiency_rdp')
 
         ! Extract data
         call get_data(Qdata, A)
@@ -265,7 +266,7 @@ contains
         integer, parameter :: kdim = test_size
         type(vector_csp), allocatable :: A(:)
         ! Upper triangular matrix.
-        complex(sp) :: R(kdim, kdim) = 0.0_sp
+        complex(sp) :: R(kdim, kdim) = zero_csp
         ! Information flag.
         integer :: info
         ! Miscellaneous.
@@ -279,7 +280,7 @@ contains
 
         ! In-place QR factorization.
         call qr(A, R, info)
-        call check_info(info, 'qr', module=this_module, procedure='test_qr_factorization_cdp')
+        call check_info(info, 'qr', module=this_module, procedure='test_qr_factorization_csp')
 
         ! Get data.
         call get_data(Qdata, A)
@@ -325,7 +326,7 @@ contains
             call random_number(alpha)
             idx = 1 + floor(kdim*alpha)
             if (mask(idx)) then
-                A(idx)%data = 0.0_sp
+                A(idx)%data = zero_csp
                 mask(idx) = .false.
                 k = k-1
             endif
@@ -336,7 +337,7 @@ contains
 
         ! In-place QR factorization.
         call qr(A, R, perm, info)
-        call check_info(info, 'qr_pivot', module=this_module, procedure='test_pivoting_qr_exact_rank_deficiency_cdp')
+        call check_info(info, 'qr_pivot', module=this_module, procedure='test_pivoting_qr_exact_rank_deficiency_csp')
 
         ! Extract data
         call get_data(Qdata, A)
@@ -365,7 +366,7 @@ contains
         integer, parameter :: kdim = test_size
         type(vector_cdp), allocatable :: A(:)
         ! Upper triangular matrix.
-        complex(dp) :: R(kdim, kdim) = 0.0_dp
+        complex(dp) :: R(kdim, kdim) = zero_cdp
         ! Information flag.
         integer :: info
         ! Miscellaneous.
@@ -425,7 +426,7 @@ contains
             call random_number(alpha)
             idx = 1 + floor(kdim*alpha)
             if (mask(idx)) then
-                A(idx)%data = 0.0_dp
+                A(idx)%data = zero_cdp
                 mask(idx) = .false.
                 k = k-1
             endif
@@ -487,8 +488,8 @@ contains
         allocate(X(1:kdim+1)) ;
         call initialize_krylov_subspace(X)
         call X(1)%rand(ifnorm=.true.) ; alpha = X(1)%norm()
-        call X(1)%scal(1.0_sp / alpha)
-        H = 0.0_sp
+        call X(1)%scal(one_rsp / alpha)
+        H = zero_rsp
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_arnoldi_factorization_rsp')
@@ -524,14 +525,14 @@ contains
         ! Initialize Krylov subspace.
         allocate (X(1:kdim + 1)); allocate (X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
-        H = 0.0_sp
+        H = zero_rsp
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_arnoldi_basis_orthogonality_rsp')
 
         ! Compute Gram matrix associated to the Krylov basis.
-        G = 0.0_sp
+        G = zero_rsp
         do j = 1, kdim
             do i = 1, kdim
                 G(i, j) = X(i)%dot(X(j))
@@ -570,13 +571,13 @@ contains
         ! Initialize Krylov subspace.
         allocate(X(1:p*(kdim+1))) ; allocate(X0(1:p))
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
-        H = 0.0_sp
+        H = zero_rsp
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, blksize=p)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_block_arnoldi_factorization_rsp')
 
-        G = 0.0_sp
+        G = zero_rsp
         do j = 1, size(G, 2)
             do i = 1, size(G, 1)
                 G(i, j) = X(i)%dot(X(j))
@@ -617,14 +618,14 @@ contains
         allocate (X(1:p*(kdim + 1))); allocate (X0(1:p)); 
         call init_rand(X0)
         call initialize_krylov_subspace(X, X0)
-        H = 0.0_sp
+        H = zero_rsp
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, blksize=p)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_block_arnoldi_basis_orthogonality_rsp')
 
         ! Compute Gram matrix associated to the Krylov basis.
-        G = 0.0_sp
+        G = zero_rsp
         do j = 1, size(G, 2)
             do i = 1, size(G, 1)
                 G(i, j) = X(i)%dot(X(j))
@@ -664,7 +665,7 @@ contains
         ! Initialize Krylov subspace.
         allocate(X(kdim+1)) ; allocate(X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
-        H = 0.0_sp
+        H = zero_rsptest/Tests.f90
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info)
@@ -723,8 +724,8 @@ contains
         allocate(X(1:kdim+1)) ;
         call initialize_krylov_subspace(X)
         call X(1)%rand(ifnorm=.true.) ; alpha = X(1)%norm()
-        call X(1)%scal(1.0_dp / alpha)
-        H = 0.0_dp
+        call X(1)%scal(one_rdp / alpha)
+        H = zero_rdp
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_arnoldi_factorization_rdp')
@@ -760,14 +761,14 @@ contains
         ! Initialize Krylov subspace.
         allocate (X(1:kdim + 1)); allocate (X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
-        H = 0.0_dp
+        H = zero_rdp
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_arnoldi_basis_orthogonality_rdp')
 
         ! Compute Gram matrix associated to the Krylov basis.
-        G = 0.0_dp
+        G = zero_rdp
         do j = 1, kdim
             do i = 1, kdim
                 G(i, j) = X(i)%dot(X(j))
@@ -806,13 +807,13 @@ contains
         ! Initialize Krylov subspace.
         allocate(X(1:p*(kdim+1))) ; allocate(X0(1:p))
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
-        H = 0.0_dp
+        H = zero_rdp
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, blksize=p)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_block_arnoldi_factorization_rdp')
 
-        G = 0.0_dp
+        G = zero_rdp
         do j = 1, size(G, 2)
             do i = 1, size(G, 1)
                 G(i, j) = X(i)%dot(X(j))
@@ -853,14 +854,14 @@ contains
         allocate (X(1:p*(kdim + 1))); allocate (X0(1:p)); 
         call init_rand(X0)
         call initialize_krylov_subspace(X, X0)
-        H = 0.0_dp
+        H = zero_rdp
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, blksize=p)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_block_arnoldi_basis_orthogonality_rdp')
 
         ! Compute Gram matrix associated to the Krylov basis.
-        G = 0.0_dp
+        G = zero_rdp
         do j = 1, size(G, 2)
             do i = 1, size(G, 1)
                 G(i, j) = X(i)%dot(X(j))
@@ -900,7 +901,7 @@ contains
         ! Initialize Krylov subspace.
         allocate(X(kdim+1)) ; allocate(X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
-        H = 0.0_dp
+        H = zero_rdp
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info)
@@ -959,8 +960,8 @@ contains
         allocate(X(1:kdim+1)) ;
         call initialize_krylov_subspace(X)
         call X(1)%rand(ifnorm=.true.) ; alpha = X(1)%norm()
-        call X(1)%scal(1.0_sp / alpha)
-        H = 0.0_sp
+        call X(1)%scal(one_csp / alpha)
+        H = zero_csp
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_arnoldi_factorization_csp')
@@ -996,14 +997,14 @@ contains
         ! Initialize Krylov subspace.
         allocate (X(1:kdim + 1)); allocate (X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
-        H = 0.0_sp
+        H = zero_csp
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_arnoldi_basis_orthogonality_csp')
 
         ! Compute Gram matrix associated to the Krylov basis.
-        G = 0.0_sp
+        G = zero_csp
         do j = 1, kdim
             do i = 1, kdim
                 G(i, j) = X(i)%dot(X(j))
@@ -1042,13 +1043,13 @@ contains
         ! Initialize Krylov subspace.
         allocate(X(1:p*(kdim+1))) ; allocate(X0(1:p))
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
-        H = 0.0_sp
+        H = zero_csp
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, blksize=p)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_block_arnoldi_factorization_csp')
 
-        G = 0.0_sp
+        G = zero_csp
         do j = 1, size(G, 2)
             do i = 1, size(G, 1)
                 G(i, j) = X(i)%dot(X(j))
@@ -1089,14 +1090,14 @@ contains
         allocate (X(1:p*(kdim + 1))); allocate (X0(1:p)); 
         call init_rand(X0)
         call initialize_krylov_subspace(X, X0)
-        H = 0.0_sp
+        H = zero_csp
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, blksize=p)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_block_arnoldi_basis_orthogonality_csp')
 
         ! Compute Gram matrix associated to the Krylov basis.
-        G = 0.0_sp
+        G = zero_csp
         do j = 1, size(G, 2)
             do i = 1, size(G, 1)
                 G(i, j) = X(i)%dot(X(j))
@@ -1136,7 +1137,7 @@ contains
         ! Initialize Krylov subspace.
         allocate(X(kdim+1)) ; allocate(X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
-        H = 0.0_sp
+        H = zero_csp
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info)
@@ -1195,8 +1196,8 @@ contains
         allocate(X(1:kdim+1)) ;
         call initialize_krylov_subspace(X)
         call X(1)%rand(ifnorm=.true.) ; alpha = X(1)%norm()
-        call X(1)%scal(1.0_dp / alpha)
-        H = 0.0_dp
+        call X(1)%scal(one_cdp / alpha)
+        H = zero_cdp
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_arnoldi_factorization_cdp')
@@ -1232,14 +1233,14 @@ contains
         ! Initialize Krylov subspace.
         allocate (X(1:kdim + 1)); allocate (X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
-        H = 0.0_dp
+        H = zero_cdp
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_arnoldi_basis_orthogonality_cdp')
 
         ! Compute Gram matrix associated to the Krylov basis.
-        G = 0.0_dp
+        G = zero_cdp
         do j = 1, kdim
             do i = 1, kdim
                 G(i, j) = X(i)%dot(X(j))
@@ -1278,13 +1279,13 @@ contains
         ! Initialize Krylov subspace.
         allocate(X(1:p*(kdim+1))) ; allocate(X0(1:p))
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
-        H = 0.0_dp
+        H = zero_cdp
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, blksize=p)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_block_arnoldi_factorization_cdp')
 
-        G = 0.0_dp
+        G = zero_cdp
         do j = 1, size(G, 2)
             do i = 1, size(G, 1)
                 G(i, j) = X(i)%dot(X(j))
@@ -1325,14 +1326,14 @@ contains
         allocate (X(1:p*(kdim + 1))); allocate (X0(1:p)); 
         call init_rand(X0)
         call initialize_krylov_subspace(X, X0)
-        H = 0.0_dp
+        H = zero_cdp
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, blksize=p)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_block_arnoldi_basis_orthogonality_cdp')
 
         ! Compute Gram matrix associated to the Krylov basis.
-        G = 0.0_dp
+        G = zero_cdp
         do j = 1, size(G, 2)
             do i = 1, size(G, 1)
                 G(i, j) = X(i)%dot(X(j))
@@ -1372,7 +1373,7 @@ contains
         ! Initialize Krylov subspace.
         allocate(X(kdim+1)) ; allocate(X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
-        H = 0.0_dp
+        H = zero_cdp
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info)
@@ -1437,7 +1438,7 @@ contains
         ! Initialize Krylov subspaces.
         allocate(U(1:kdim+1)) ; allocate(V(1:kdim+1)) ; allocate(X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(U, X0)
-        call initialize_krylov_subspace(V) ; B = 0.0_sp
+        call initialize_krylov_subspace(V) ; B = zero_rsp
 
         ! Lanczos bidiagonalization.
         call lanczos_bidiagonalization(A, U, V, B, info)
@@ -1477,7 +1478,7 @@ contains
         ! Initialize Krylov subspaces.
         allocate(U(1:kdim+1)) ; allocate(V(1:kdim+1)) ; allocate(X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(U, X0)
-        call initialize_krylov_subspace(V) ; B = 0.0_sp
+        call initialize_krylov_subspace(V) ; B = zero_rsp
 
         ! Lanczos bidiagonalization.
         call lanczos_bidiagonalization(A, U, V, B, info)
@@ -1486,7 +1487,7 @@ contains
 
         ! Check correctness.
         Id = eye(kdim)
-        G = 0.0_sp
+        G = zero_rsp
         do j = 1, kdim
             do i = 1, kdim
                 G(i, j) = U(i)%dot(U(j))
@@ -1522,7 +1523,7 @@ contains
         ! Initialize Krylov subspaces.
         allocate(U(1:kdim+1)) ; allocate(V(1:kdim+1)) ; allocate(X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(U, X0)
-        call initialize_krylov_subspace(V) ; B = 0.0_sp
+        call initialize_krylov_subspace(V) ; B = zero_rsp
 
         ! Lanczos bidiagonalization.
         call lanczos_bidiagonalization(A, U, V, B, info)
@@ -1531,7 +1532,7 @@ contains
 
         ! Check correctness.
         Id = eye(kdim)
-        G = 0.0_sp
+        G = zero_rsp
         do j = 1, kdim
             do i = 1, kdim
                 G(i, j) = V(i)%dot(V(j))
@@ -1578,7 +1579,7 @@ contains
         ! Initialize Krylov subspaces.
         allocate(U(1:kdim+1)) ; allocate(V(1:kdim+1)) ; allocate(X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(U, X0)
-        call initialize_krylov_subspace(V) ; B = 0.0_dp
+        call initialize_krylov_subspace(V) ; B = zero_rdp
 
         ! Lanczos bidiagonalization.
         call lanczos_bidiagonalization(A, U, V, B, info)
@@ -1618,7 +1619,7 @@ contains
         ! Initialize Krylov subspaces.
         allocate(U(1:kdim+1)) ; allocate(V(1:kdim+1)) ; allocate(X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(U, X0)
-        call initialize_krylov_subspace(V) ; B = 0.0_dp
+        call initialize_krylov_subspace(V) ; B = zero_rdp
 
         ! Lanczos bidiagonalization.
         call lanczos_bidiagonalization(A, U, V, B, info)
@@ -1627,7 +1628,7 @@ contains
 
         ! Check correctness.
         Id = eye(kdim)
-        G = 0.0_dp
+        G = zero_rdp
         do j = 1, kdim
             do i = 1, kdim
                 G(i, j) = U(i)%dot(U(j))
@@ -1663,7 +1664,7 @@ contains
         ! Initialize Krylov subspaces.
         allocate(U(1:kdim+1)) ; allocate(V(1:kdim+1)) ; allocate(X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(U, X0)
-        call initialize_krylov_subspace(V) ; B = 0.0_dp
+        call initialize_krylov_subspace(V) ; B = zero_rdp
 
         ! Lanczos bidiagonalization.
         call lanczos_bidiagonalization(A, U, V, B, info)
@@ -1672,7 +1673,7 @@ contains
 
         ! Check correctness.
         Id = eye(kdim)
-        G = 0.0_dp
+        G = zero_rdp
         do j = 1, kdim
             do i = 1, kdim
                 G(i, j) = V(i)%dot(V(j))
@@ -1719,7 +1720,7 @@ contains
         ! Initialize Krylov subspaces.
         allocate(U(1:kdim+1)) ; allocate(V(1:kdim+1)) ; allocate(X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(U, X0)
-        call initialize_krylov_subspace(V) ; B = 0.0_sp
+        call initialize_krylov_subspace(V) ; B = zero_csp
 
         ! Lanczos bidiagonalization.
         call lanczos_bidiagonalization(A, U, V, B, info)
@@ -1759,7 +1760,7 @@ contains
         ! Initialize Krylov subspaces.
         allocate(U(1:kdim+1)) ; allocate(V(1:kdim+1)) ; allocate(X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(U, X0)
-        call initialize_krylov_subspace(V) ; B = 0.0_sp
+        call initialize_krylov_subspace(V) ; B = zero_csp
 
         ! Lanczos bidiagonalization.
         call lanczos_bidiagonalization(A, U, V, B, info)
@@ -1768,7 +1769,7 @@ contains
 
         ! Check correctness.
         Id = eye(kdim)
-        G = 0.0_sp
+        G = zero_csp
         do j = 1, kdim
             do i = 1, kdim
                 G(i, j) = U(i)%dot(U(j))
@@ -1804,7 +1805,7 @@ contains
         ! Initialize Krylov subspaces.
         allocate(U(1:kdim+1)) ; allocate(V(1:kdim+1)) ; allocate(X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(U, X0)
-        call initialize_krylov_subspace(V) ; B = 0.0_sp
+        call initialize_krylov_subspace(V) ; B = zero_csp
 
         ! Lanczos bidiagonalization.
         call lanczos_bidiagonalization(A, U, V, B, info)
@@ -1813,7 +1814,7 @@ contains
 
         ! Check correctness.
         Id = eye(kdim)
-        G = 0.0_sp
+        G = zero_csp
         do j = 1, kdim
             do i = 1, kdim
                 G(i, j) = V(i)%dot(V(j))
@@ -1860,7 +1861,7 @@ contains
         ! Initialize Krylov subspaces.
         allocate(U(1:kdim+1)) ; allocate(V(1:kdim+1)) ; allocate(X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(U, X0)
-        call initialize_krylov_subspace(V) ; B = 0.0_dp
+        call initialize_krylov_subspace(V) ; B = zero_cdp
 
         ! Lanczos bidiagonalization.
         call lanczos_bidiagonalization(A, U, V, B, info)
@@ -1900,7 +1901,7 @@ contains
         ! Initialize Krylov subspaces.
         allocate(U(1:kdim+1)) ; allocate(V(1:kdim+1)) ; allocate(X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(U, X0)
-        call initialize_krylov_subspace(V) ; B = 0.0_dp
+        call initialize_krylov_subspace(V) ; B = zero_cdp
 
         ! Lanczos bidiagonalization.
         call lanczos_bidiagonalization(A, U, V, B, info)
@@ -1909,7 +1910,7 @@ contains
 
         ! Check correctness.
         Id = eye(kdim)
-        G = 0.0_dp
+        G = zero_cdp
         do j = 1, kdim
             do i = 1, kdim
                 G(i, j) = U(i)%dot(U(j))
@@ -1945,7 +1946,7 @@ contains
         ! Initialize Krylov subspaces.
         allocate(U(1:kdim+1)) ; allocate(V(1:kdim+1)) ; allocate(X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(U, X0)
-        call initialize_krylov_subspace(V) ; B = 0.0_dp
+        call initialize_krylov_subspace(V) ; B = zero_cdp
 
         ! Lanczos bidiagonalization.
         call lanczos_bidiagonalization(A, U, V, B, info)
@@ -1954,7 +1955,7 @@ contains
 
         ! Check correctness.
         Id = eye(kdim)
-        G = 0.0_dp
+        G = zero_cdp
         do j = 1, kdim
             do i = 1, kdim
                 G(i, j) = V(i)%dot(V(j))
@@ -2003,7 +2004,7 @@ contains
         class(vector_rsp), allocatable :: X0(:)
 
         ! Initialize tridiagonal matrix.
-        T = 0.0_sp
+        T = zero_rsp
 
         ! Initialize operator.
         A = spd_linop_rsp()
@@ -2050,7 +2051,7 @@ contains
         real(sp) :: G(kdim+1, kdim+1)
 
         ! Initialize tridiagonal matrix.
-        T = 0.0_sp
+        T = zero_rsp
 
         ! Initialize operator.
         A = spd_linop_rsp()
@@ -2067,7 +2068,7 @@ contains
         ! Check correctness.
         call get_data(Xdata, X)
         G = matmul(transpose(Xdata), Xdata)
-        Id = 0.0_sp ; Id(1:kdim, 1:kdim) = eye(kdim)
+        Id = zero_rsp ; Id(1:kdim, 1:kdim) = eye(kdim)
         call check(error, norm2(abs(G-Id)) < rtol_sp)
 
         return
@@ -2105,7 +2106,7 @@ contains
         class(vector_rdp), allocatable :: X0(:)
 
         ! Initialize tridiagonal matrix.
-        T = 0.0_dp
+        T = zero_rdp
 
         ! Initialize operator.
         A = spd_linop_rdp()
@@ -2152,7 +2153,7 @@ contains
         real(dp) :: G(kdim+1, kdim+1)
 
         ! Initialize tridiagonal matrix.
-        T = 0.0_dp
+        T = zero_rdp
 
         ! Initialize operator.
         A = spd_linop_rdp()
@@ -2169,7 +2170,7 @@ contains
         ! Check correctness.
         call get_data(Xdata, X)
         G = matmul(transpose(Xdata), Xdata)
-        Id = 0.0_dp ; Id(1:kdim, 1:kdim) = eye(kdim)
+        Id = zero_rdp ; Id(1:kdim, 1:kdim) = eye(kdim)
         call check(error, norm2(abs(G-Id)) < rtol_dp)
 
         return
@@ -2207,7 +2208,7 @@ contains
         class(vector_csp), allocatable :: X0(:)
 
         ! Initialize tridiagonal matrix.
-        T = 0.0_sp
+        T = zero_csp
 
         ! Initialize operator.
         A = hermitian_linop_csp()
@@ -2254,7 +2255,7 @@ contains
         complex(sp) :: G(kdim+1, kdim+1)
 
         ! Initialize tridiagonal matrix.
-        T = 0.0_sp
+        T = zero_csp
 
         ! Initialize operator.
         A = hermitian_linop_csp()
@@ -2271,7 +2272,7 @@ contains
         ! Check correctness.
         call get_data(Xdata, X)
         G = matmul(transpose(conjg(Xdata)), Xdata)
-        Id = 0.0_sp ; Id(1:kdim, 1:kdim) = eye(kdim)
+        Id = zero_csp ; Id(1:kdim, 1:kdim) = eye(kdim)
         call check(error, norm2(abs(G-Id)) < rtol_sp)
 
         return
@@ -2309,7 +2310,7 @@ contains
         class(vector_cdp), allocatable :: X0(:)
 
         ! Initialize tridiagonal matrix.
-        T = 0.0_dp
+        T = zero_cdp
 
         ! Initialize operator.
         A = hermitian_linop_cdp()
@@ -2356,7 +2357,7 @@ contains
         complex(dp) :: G(kdim+1, kdim+1)
 
         ! Initialize tridiagonal matrix.
-        T = 0.0_dp
+        T = zero_cdp
 
         ! Initialize operator.
         A = hermitian_linop_cdp()
@@ -2373,7 +2374,7 @@ contains
         ! Check correctness.
         call get_data(Xdata, X)
         G = matmul(transpose(conjg(Xdata)), Xdata)
-        Id = 0.0_dp ; Id(1:kdim, 1:kdim) = eye(kdim)
+        Id = zero_cdp ; Id(1:kdim, 1:kdim) = eye(kdim)
         call check(error, norm2(abs(G-Id)) < rtol_dp)
 
         return

--- a/test/TestKrylov.f90
+++ b/test/TestKrylov.f90
@@ -16,7 +16,10 @@ module TestKrylov
     use TestUtils
 
     implicit none
+    
     private
+
+    character*128, parameter, private :: this_module = 'LightKrylov_TestKrylov'
 
     public :: collect_qr_rsp_testsuite
     public :: collect_arnoldi_rsp_testsuite
@@ -76,7 +79,7 @@ contains
 
         ! In-place QR factorization.
         call qr(A, R, info)
-        call check_info(info, 'qr', module='LightKrylov_TestKrylov', procedure='test_qr_factorization_cdp')
+        call check_info(info, 'qr', module=this_module, procedure='test_qr_factorization_cdp')
 
         ! Get data.
         call get_data(Qdata, A)
@@ -133,7 +136,7 @@ contains
 
         ! In-place QR factorization.
         call qr(A, R, perm, info)
-        call check_info(info, 'qr_pivot', module='LightKrylov_TestKrylov', procedure='test_pivoting_qr_exact_rank_deficiency_cdp')
+        call check_info(info, 'qr_pivot', module=this_module, procedure='test_pivoting_qr_exact_rank_deficiency_cdp')
 
         ! Extract data
         call get_data(Qdata, A)
@@ -176,7 +179,7 @@ contains
 
         ! In-place QR factorization.
         call qr(A, R, info)
-        call check_info(info, 'qr', module='LightKrylov_TestKrylov', procedure='test_qr_factorization_cdp')
+        call check_info(info, 'qr', module=this_module, procedure='test_qr_factorization_cdp')
 
         ! Get data.
         call get_data(Qdata, A)
@@ -233,7 +236,7 @@ contains
 
         ! In-place QR factorization.
         call qr(A, R, perm, info)
-        call check_info(info, 'qr_pivot', module='LightKrylov_TestKrylov', procedure='test_pivoting_qr_exact_rank_deficiency_cdp')
+        call check_info(info, 'qr_pivot', module=this_module, procedure='test_pivoting_qr_exact_rank_deficiency_cdp')
 
         ! Extract data
         call get_data(Qdata, A)
@@ -276,7 +279,7 @@ contains
 
         ! In-place QR factorization.
         call qr(A, R, info)
-        call check_info(info, 'qr', module='LightKrylov_TestKrylov', procedure='test_qr_factorization_cdp')
+        call check_info(info, 'qr', module=this_module, procedure='test_qr_factorization_cdp')
 
         ! Get data.
         call get_data(Qdata, A)
@@ -333,7 +336,7 @@ contains
 
         ! In-place QR factorization.
         call qr(A, R, perm, info)
-        call check_info(info, 'qr_pivot', module='LightKrylov_TestKrylov', procedure='test_pivoting_qr_exact_rank_deficiency_cdp')
+        call check_info(info, 'qr_pivot', module=this_module, procedure='test_pivoting_qr_exact_rank_deficiency_cdp')
 
         ! Extract data
         call get_data(Qdata, A)
@@ -376,7 +379,7 @@ contains
 
         ! In-place QR factorization.
         call qr(A, R, info)
-        call check_info(info, 'qr', module='LightKrylov_TestKrylov', procedure='test_qr_factorization_cdp')
+        call check_info(info, 'qr', module=this_module, procedure='test_qr_factorization_cdp')
 
         ! Get data.
         call get_data(Qdata, A)
@@ -433,7 +436,7 @@ contains
 
         ! In-place QR factorization.
         call qr(A, R, perm, info)
-        call check_info(info, 'qr_pivot', module='LightKrylov_TestKrylov', procedure='test_pivoting_qr_exact_rank_deficiency_cdp')
+        call check_info(info, 'qr_pivot', module=this_module, procedure='test_pivoting_qr_exact_rank_deficiency_cdp')
 
         ! Extract data
         call get_data(Qdata, A)
@@ -488,7 +491,7 @@ contains
         H = 0.0_sp
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info)
-        call check_info(info, 'arnoldi', module='LightKrylov_TestKrylov', procedure='test_arnoldi_factorization_rsp')
+        call check_info(info, 'arnoldi', module=this_module, procedure='test_arnoldi_factorization_rsp')
 
         ! Check correctness of full factorization.
         call get_data(Xdata, X)
@@ -525,7 +528,7 @@ contains
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info)
-        call check_info(info, 'arnoldi', module='LightKrylov_TestKrylov', procedure='test_arnoldi_basis_orthogonality_rsp')
+        call check_info(info, 'arnoldi', module=this_module, procedure='test_arnoldi_basis_orthogonality_rsp')
 
         ! Compute Gram matrix associated to the Krylov basis.
         G = 0.0_sp
@@ -571,7 +574,7 @@ contains
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, blksize=p)
-        call check_info(info, 'arnoldi', module='LightKrylov_TestKrylov', procedure='test_block_arnoldi_factorization_rsp')
+        call check_info(info, 'arnoldi', module=this_module, procedure='test_block_arnoldi_factorization_rsp')
 
         G = 0.0_sp
         do j = 1, size(G, 2)
@@ -618,7 +621,7 @@ contains
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, blksize=p)
-        call check_info(info, 'arnoldi', module='LightKrylov_TestKrylov', procedure='test_block_arnoldi_basis_orthogonality_rsp')
+        call check_info(info, 'arnoldi', module=this_module, procedure='test_block_arnoldi_basis_orthogonality_rsp')
 
         ! Compute Gram matrix associated to the Krylov basis.
         G = 0.0_sp
@@ -665,7 +668,7 @@ contains
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info)
-        call check_info(info, 'arnoldi', module='LightKrylov_TestKrylov', procedure='test_krylov_schur_rsp')
+        call check_info(info, 'arnoldi', module=this_module, procedure='test_krylov_schur_rsp')
 
         ! Krylov-Schur condensation.
         call krylov_schur(n, X, H, select_eigs)
@@ -724,7 +727,7 @@ contains
         H = 0.0_dp
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info)
-        call check_info(info, 'arnoldi', module='LightKrylov_TestKrylov', procedure='test_arnoldi_factorization_rdp')
+        call check_info(info, 'arnoldi', module=this_module, procedure='test_arnoldi_factorization_rdp')
 
         ! Check correctness of full factorization.
         call get_data(Xdata, X)
@@ -761,7 +764,7 @@ contains
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info)
-        call check_info(info, 'arnoldi', module='LightKrylov_TestKrylov', procedure='test_arnoldi_basis_orthogonality_rdp')
+        call check_info(info, 'arnoldi', module=this_module, procedure='test_arnoldi_basis_orthogonality_rdp')
 
         ! Compute Gram matrix associated to the Krylov basis.
         G = 0.0_dp
@@ -807,7 +810,7 @@ contains
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, blksize=p)
-        call check_info(info, 'arnoldi', module='LightKrylov_TestKrylov', procedure='test_block_arnoldi_factorization_rdp')
+        call check_info(info, 'arnoldi', module=this_module, procedure='test_block_arnoldi_factorization_rdp')
 
         G = 0.0_dp
         do j = 1, size(G, 2)
@@ -854,7 +857,7 @@ contains
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, blksize=p)
-        call check_info(info, 'arnoldi', module='LightKrylov_TestKrylov', procedure='test_block_arnoldi_basis_orthogonality_rdp')
+        call check_info(info, 'arnoldi', module=this_module, procedure='test_block_arnoldi_basis_orthogonality_rdp')
 
         ! Compute Gram matrix associated to the Krylov basis.
         G = 0.0_dp
@@ -901,7 +904,7 @@ contains
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info)
-        call check_info(info, 'arnoldi', module='LightKrylov_TestKrylov', procedure='test_krylov_schur_rdp')
+        call check_info(info, 'arnoldi', module=this_module, procedure='test_krylov_schur_rdp')
 
         ! Krylov-Schur condensation.
         call krylov_schur(n, X, H, select_eigs)
@@ -960,7 +963,7 @@ contains
         H = 0.0_sp
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info)
-        call check_info(info, 'arnoldi', module='LightKrylov_TestKrylov', procedure='test_arnoldi_factorization_csp')
+        call check_info(info, 'arnoldi', module=this_module, procedure='test_arnoldi_factorization_csp')
 
         ! Check correctness of full factorization.
         call get_data(Xdata, X)
@@ -997,7 +1000,7 @@ contains
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info)
-        call check_info(info, 'arnoldi', module='LightKrylov_TestKrylov', procedure='test_arnoldi_basis_orthogonality_csp')
+        call check_info(info, 'arnoldi', module=this_module, procedure='test_arnoldi_basis_orthogonality_csp')
 
         ! Compute Gram matrix associated to the Krylov basis.
         G = 0.0_sp
@@ -1043,7 +1046,7 @@ contains
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, blksize=p)
-        call check_info(info, 'arnoldi', module='LightKrylov_TestKrylov', procedure='test_block_arnoldi_factorization_csp')
+        call check_info(info, 'arnoldi', module=this_module, procedure='test_block_arnoldi_factorization_csp')
 
         G = 0.0_sp
         do j = 1, size(G, 2)
@@ -1090,7 +1093,7 @@ contains
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, blksize=p)
-        call check_info(info, 'arnoldi', module='LightKrylov_TestKrylov', procedure='test_block_arnoldi_basis_orthogonality_csp')
+        call check_info(info, 'arnoldi', module=this_module, procedure='test_block_arnoldi_basis_orthogonality_csp')
 
         ! Compute Gram matrix associated to the Krylov basis.
         G = 0.0_sp
@@ -1137,7 +1140,7 @@ contains
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info)
-        call check_info(info, 'arnoldi', module='LightKrylov_TestKrylov', procedure='test_krylov_schur_csp')
+        call check_info(info, 'arnoldi', module=this_module, procedure='test_krylov_schur_csp')
 
         ! Krylov-Schur condensation.
         call krylov_schur(n, X, H, select_eigs)
@@ -1196,7 +1199,7 @@ contains
         H = 0.0_dp
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info)
-        call check_info(info, 'arnoldi', module='LightKrylov_TestKrylov', procedure='test_arnoldi_factorization_cdp')
+        call check_info(info, 'arnoldi', module=this_module, procedure='test_arnoldi_factorization_cdp')
 
         ! Check correctness of full factorization.
         call get_data(Xdata, X)
@@ -1233,7 +1236,7 @@ contains
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info)
-        call check_info(info, 'arnoldi', module='LightKrylov_TestKrylov', procedure='test_arnoldi_basis_orthogonality_cdp')
+        call check_info(info, 'arnoldi', module=this_module, procedure='test_arnoldi_basis_orthogonality_cdp')
 
         ! Compute Gram matrix associated to the Krylov basis.
         G = 0.0_dp
@@ -1279,7 +1282,7 @@ contains
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, blksize=p)
-        call check_info(info, 'arnoldi', module='LightKrylov_TestKrylov', procedure='test_block_arnoldi_factorization_cdp')
+        call check_info(info, 'arnoldi', module=this_module, procedure='test_block_arnoldi_factorization_cdp')
 
         G = 0.0_dp
         do j = 1, size(G, 2)
@@ -1326,7 +1329,7 @@ contains
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, blksize=p)
-        call check_info(info, 'arnoldi', module='LightKrylov_TestKrylov', procedure='test_block_arnoldi_basis_orthogonality_cdp')
+        call check_info(info, 'arnoldi', module=this_module, procedure='test_block_arnoldi_basis_orthogonality_cdp')
 
         ! Compute Gram matrix associated to the Krylov basis.
         G = 0.0_dp
@@ -1373,7 +1376,7 @@ contains
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info)
-        call check_info(info, 'arnoldi', module='LightKrylov_TestKrylov', procedure='test_krylov_schur_cdp')
+        call check_info(info, 'arnoldi', module=this_module, procedure='test_krylov_schur_cdp')
 
         ! Krylov-Schur condensation.
         call krylov_schur(n, X, H, select_eigs)
@@ -1438,8 +1441,7 @@ contains
 
         ! Lanczos bidiagonalization.
         call lanczos_bidiagonalization(A, U, V, B, info)
-        call check_info(info, 'lanczos_bidiagonalization', module='LightKrylov_TestKrylov',&
-            & procedure='test_lanczos_bidiag_factorization_rsp')
+        call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='test_lanczos_bidiag_factorization_rsp')
 
         ! Check correctness.
         call get_data(Udata, U)
@@ -1479,8 +1481,8 @@ contains
 
         ! Lanczos bidiagonalization.
         call lanczos_bidiagonalization(A, U, V, B, info)
-        call check_info(info, 'lanczos_bidiagonalization', module='LightKrylov_TestKrylov',&
-            & procedure='test_lanczos_bidiag_left_orthogonality_rsp')
+        call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='test_lanczos_bidiag_left_orthogonality_rs&
+            &p')
 
         ! Check correctness.
         Id = eye(kdim)
@@ -1524,8 +1526,8 @@ contains
 
         ! Lanczos bidiagonalization.
         call lanczos_bidiagonalization(A, U, V, B, info)
-        call check_info(info, 'lanczos_bidiagonalization', module='LightKrylov_TestKrylov',&
-            & procedure='test_lanczos_bidiag_right_orthogonality_rsp')
+        call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='test_lanczos_bidiag_right_orthogonality_r&
+            &sp')
 
         ! Check correctness.
         Id = eye(kdim)
@@ -1580,8 +1582,7 @@ contains
 
         ! Lanczos bidiagonalization.
         call lanczos_bidiagonalization(A, U, V, B, info)
-        call check_info(info, 'lanczos_bidiagonalization', module='LightKrylov_TestKrylov',&
-            & procedure='test_lanczos_bidiag_factorization_rdp')
+        call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='test_lanczos_bidiag_factorization_rdp')
 
         ! Check correctness.
         call get_data(Udata, U)
@@ -1621,8 +1622,8 @@ contains
 
         ! Lanczos bidiagonalization.
         call lanczos_bidiagonalization(A, U, V, B, info)
-        call check_info(info, 'lanczos_bidiagonalization', module='LightKrylov_TestKrylov',&
-            & procedure='test_lanczos_bidiag_left_orthogonality_rdp')
+        call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='test_lanczos_bidiag_left_orthogonality_rd&
+            &p')
 
         ! Check correctness.
         Id = eye(kdim)
@@ -1666,8 +1667,8 @@ contains
 
         ! Lanczos bidiagonalization.
         call lanczos_bidiagonalization(A, U, V, B, info)
-        call check_info(info, 'lanczos_bidiagonalization', module='LightKrylov_TestKrylov',&
-            & procedure='test_lanczos_bidiag_right_orthogonality_rdp')
+        call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='test_lanczos_bidiag_right_orthogonality_r&
+            &dp')
 
         ! Check correctness.
         Id = eye(kdim)
@@ -1722,8 +1723,7 @@ contains
 
         ! Lanczos bidiagonalization.
         call lanczos_bidiagonalization(A, U, V, B, info)
-        call check_info(info, 'lanczos_bidiagonalization', module='LightKrylov_TestKrylov',&
-            & procedure='test_lanczos_bidiag_factorization_csp')
+        call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='test_lanczos_bidiag_factorization_csp')
 
         ! Check correctness.
         call get_data(Udata, U)
@@ -1763,8 +1763,8 @@ contains
 
         ! Lanczos bidiagonalization.
         call lanczos_bidiagonalization(A, U, V, B, info)
-        call check_info(info, 'lanczos_bidiagonalization', module='LightKrylov_TestKrylov',&
-            & procedure='test_lanczos_bidiag_left_orthogonality_csp')
+        call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='test_lanczos_bidiag_left_orthogonality_cs&
+            &p')
 
         ! Check correctness.
         Id = eye(kdim)
@@ -1808,8 +1808,8 @@ contains
 
         ! Lanczos bidiagonalization.
         call lanczos_bidiagonalization(A, U, V, B, info)
-        call check_info(info, 'lanczos_bidiagonalization', module='LightKrylov_TestKrylov',&
-            & procedure='test_lanczos_bidiag_right_orthogonality_csp')
+        call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='test_lanczos_bidiag_right_orthogonality_c&
+            &sp')
 
         ! Check correctness.
         Id = eye(kdim)
@@ -1864,8 +1864,7 @@ contains
 
         ! Lanczos bidiagonalization.
         call lanczos_bidiagonalization(A, U, V, B, info)
-        call check_info(info, 'lanczos_bidiagonalization', module='LightKrylov_TestKrylov',&
-            & procedure='test_lanczos_bidiag_factorization_cdp')
+        call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='test_lanczos_bidiag_factorization_cdp')
 
         ! Check correctness.
         call get_data(Udata, U)
@@ -1905,8 +1904,8 @@ contains
 
         ! Lanczos bidiagonalization.
         call lanczos_bidiagonalization(A, U, V, B, info)
-        call check_info(info, 'lanczos_bidiagonalization', module='LightKrylov_TestKrylov',&
-            & procedure='test_lanczos_bidiag_left_orthogonality_cdp')
+        call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='test_lanczos_bidiag_left_orthogonality_cd&
+            &p')
 
         ! Check correctness.
         Id = eye(kdim)
@@ -1950,8 +1949,8 @@ contains
 
         ! Lanczos bidiagonalization.
         call lanczos_bidiagonalization(A, U, V, B, info)
-        call check_info(info, 'lanczos_bidiagonalization', module='LightKrylov_TestKrylov',&
-            & procedure='test_lanczos_bidiag_right_orthogonality_cdp')
+        call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='test_lanczos_bidiag_right_orthogonality_c&
+            &dp')
 
         ! Check correctness.
         Id = eye(kdim)
@@ -2016,8 +2015,8 @@ contains
 
         ! Lanczos factorization.
         call lanczos_tridiagonalization(A, X, T, info)
-        call check_info(info, 'lanczos_tridiagonalization', module='LightKrylov_TestKrylov',&
-            & procedure='test_lanczos_tridiag_full_factorization_rsp')
+        call check_info(info, 'lanczos_tridiagonalization', module=this_module, procedure='test_lanczos_tridiag_full_factorization_&
+            &rsp')
 
         ! Check correctness.
         call get_data(Xdata, X)
@@ -2063,8 +2062,7 @@ contains
 
         ! Lanczos factorization.
         call lanczos_tridiagonalization(A, X, T, info)
-        call check_info(info, 'lanczos_tridiagonalization', module='LightKrylov_TestKrylov',&
-            & procedure='test_lanczos_tridiag_orthogonality_rsp')
+        call check_info(info, 'lanczos_tridiagonalization', module=this_module, procedure='test_lanczos_tridiag_orthogonality_rsp')
 
         ! Check correctness.
         call get_data(Xdata, X)
@@ -2119,8 +2117,8 @@ contains
 
         ! Lanczos factorization.
         call lanczos_tridiagonalization(A, X, T, info)
-        call check_info(info, 'lanczos_tridiagonalization', module='LightKrylov_TestKrylov',&
-            & procedure='test_lanczos_tridiag_full_factorization_rdp')
+        call check_info(info, 'lanczos_tridiagonalization', module=this_module, procedure='test_lanczos_tridiag_full_factorization_&
+            &rdp')
 
         ! Check correctness.
         call get_data(Xdata, X)
@@ -2166,8 +2164,7 @@ contains
 
         ! Lanczos factorization.
         call lanczos_tridiagonalization(A, X, T, info)
-        call check_info(info, 'lanczos_tridiagonalization', module='LightKrylov_TestKrylov',&
-            & procedure='test_lanczos_tridiag_orthogonality_rdp')
+        call check_info(info, 'lanczos_tridiagonalization', module=this_module, procedure='test_lanczos_tridiag_orthogonality_rdp')
 
         ! Check correctness.
         call get_data(Xdata, X)
@@ -2222,8 +2219,8 @@ contains
 
         ! Lanczos factorization.
         call lanczos_tridiagonalization(A, X, T, info)
-        call check_info(info, 'lanczos_tridiagonalization', module='LightKrylov_TestKrylov',&
-            & procedure='test_lanczos_tridiag_full_factorization_csp')
+        call check_info(info, 'lanczos_tridiagonalization', module=this_module, procedure='test_lanczos_tridiag_full_factorization_&
+            &csp')
 
         ! Check correctness.
         call get_data(Xdata, X)
@@ -2269,8 +2266,7 @@ contains
 
         ! Lanczos factorization.
         call lanczos_tridiagonalization(A, X, T, info)
-        call check_info(info, 'lanczos_tridiagonalization', module='LightKrylov_TestKrylov',&
-            & procedure='test_lanczos_tridiag_orthogonality_csp')
+        call check_info(info, 'lanczos_tridiagonalization', module=this_module, procedure='test_lanczos_tridiag_orthogonality_csp')
 
         ! Check correctness.
         call get_data(Xdata, X)
@@ -2325,8 +2321,8 @@ contains
 
         ! Lanczos factorization.
         call lanczos_tridiagonalization(A, X, T, info)
-        call check_info(info, 'lanczos_tridiagonalization', module='LightKrylov_TestKrylov',&
-            & procedure='test_lanczos_tridiag_full_factorization_cdp')
+        call check_info(info, 'lanczos_tridiagonalization', module=this_module, procedure='test_lanczos_tridiag_full_factorization_&
+            &cdp')
 
         ! Check correctness.
         call get_data(Xdata, X)
@@ -2372,8 +2368,7 @@ contains
 
         ! Lanczos factorization.
         call lanczos_tridiagonalization(A, X, T, info)
-        call check_info(info, 'lanczos_tridiagonalization', module='LightKrylov_TestKrylov',&
-            & procedure='test_lanczos_tridiag_orthogonality_cdp')
+        call check_info(info, 'lanczos_tridiagonalization', module=this_module, procedure='test_lanczos_tridiag_orthogonality_cdp')
 
         ! Check correctness.
         call get_data(Xdata, X)

--- a/test/TestKrylov.f90
+++ b/test/TestKrylov.f90
@@ -54,8 +54,9 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-                        new_unittest("QR factorization", test_qr_factorization_rsp), &
-                        new_unittest("Pivoting QR (exact rank def.)", test_pivoting_qr_exact_rank_deficiency_rsp) &
+                        new_unittest("QR factorization (correctness & orthonormality)", test_qr_factorization_rsp), &
+                        new_unittest("Pivoting QR for a rank deficient matrix (correctness & orthonormality))",&
+                            & test_pivoting_qr_exact_rank_deficiency_rsp) &
                     ]
         return
     end subroutine collect_qr_rsp_testsuite
@@ -71,7 +72,8 @@ contains
         ! Information flag.
         integer :: info
         ! Miscellaneous.
-        real(sp) :: Adata(test_size, kdim), Qdata(test_size, kdim)
+        real(sp), dimension(test_size, kdim) :: Adata, Qdata
+        real(sp), dimension(kdim, kdim) :: G, Id
 
         ! Initiliaze matrix.
         allocate(A(1:kdim)) ; call init_rand(A)
@@ -88,6 +90,15 @@ contains
 
         ! Check correctness.
         call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_sp)
+        if (allocated(error)) return
+
+        ! Compute Gram matrix associated to the Krylov basis.
+        G = zero_rsp
+        call innerprod(G, A(1:kdim), A(1:kdim))
+
+        ! Check orthonormality of the computed basis.
+        Id = eye(kdim)
+        call check(error, norm2(abs(G - Id)) < rtol_sp)
 
         return
     end subroutine test_qr_factorization_rsp
@@ -105,15 +116,15 @@ contains
         real(sp) :: R(kdim, kdim)
         ! Permutation vector.
         integer :: perm(kdim)
-        real(sp) :: Id(kdim, kdim)
         ! Information flag.
         integer :: info
        
         ! Miscellaneous.
         integer :: k, idx, rk
-        real(sp) :: Adata(test_size, kdim), Qdata(test_size, kdim)
         real(sp) :: alpha
         logical :: mask(kdim)
+        real(sp), dimension(test_size, kdim) :: Adata, Qdata
+        real(sp), dimension(kdim, kdim) :: G, Id
 
         ! Effective rank.
         rk = kdim - nzero
@@ -146,6 +157,15 @@ contains
 
         ! Check correctness.
         call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_sp)
+        if (allocated(error)) return
+
+        ! Compute Gram matrix associated to the Krylov basis.
+        G = zero_rsp
+        call innerprod(G, A(1:kdim), A(1:kdim))
+
+        ! Check orthonormality of the computed basis.
+        Id = eye(kdim)
+        call check(error, norm2(abs(G - Id)) < rtol_sp)
 
         return
     end subroutine test_pivoting_qr_exact_rank_deficiency_rsp
@@ -154,8 +174,9 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-                        new_unittest("QR factorization", test_qr_factorization_rdp), &
-                        new_unittest("Pivoting QR (exact rank def.)", test_pivoting_qr_exact_rank_deficiency_rdp) &
+                        new_unittest("QR factorization (correctness & orthonormality)", test_qr_factorization_rdp), &
+                        new_unittest("Pivoting QR for a rank deficient matrix (correctness & orthonormality))",&
+                            & test_pivoting_qr_exact_rank_deficiency_rdp) &
                     ]
         return
     end subroutine collect_qr_rdp_testsuite
@@ -171,7 +192,8 @@ contains
         ! Information flag.
         integer :: info
         ! Miscellaneous.
-        real(dp) :: Adata(test_size, kdim), Qdata(test_size, kdim)
+        real(dp), dimension(test_size, kdim) :: Adata, Qdata
+        real(dp), dimension(kdim, kdim) :: G, Id
 
         ! Initiliaze matrix.
         allocate(A(1:kdim)) ; call init_rand(A)
@@ -188,6 +210,15 @@ contains
 
         ! Check correctness.
         call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_dp)
+        if (allocated(error)) return
+
+        ! Compute Gram matrix associated to the Krylov basis.
+        G = zero_rdp
+        call innerprod(G, A(1:kdim), A(1:kdim))
+
+        ! Check orthonormality of the computed basis.
+        Id = eye(kdim)
+        call check(error, norm2(abs(G - Id)) < rtol_dp)
 
         return
     end subroutine test_qr_factorization_rdp
@@ -205,15 +236,15 @@ contains
         real(dp) :: R(kdim, kdim)
         ! Permutation vector.
         integer :: perm(kdim)
-        real(dp) :: Id(kdim, kdim)
         ! Information flag.
         integer :: info
        
         ! Miscellaneous.
         integer :: k, idx, rk
-        real(dp) :: Adata(test_size, kdim), Qdata(test_size, kdim)
         real(dp) :: alpha
         logical :: mask(kdim)
+        real(dp), dimension(test_size, kdim) :: Adata, Qdata
+        real(dp), dimension(kdim, kdim) :: G, Id
 
         ! Effective rank.
         rk = kdim - nzero
@@ -246,6 +277,15 @@ contains
 
         ! Check correctness.
         call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_dp)
+        if (allocated(error)) return
+
+        ! Compute Gram matrix associated to the Krylov basis.
+        G = zero_rdp
+        call innerprod(G, A(1:kdim), A(1:kdim))
+
+        ! Check orthonormality of the computed basis.
+        Id = eye(kdim)
+        call check(error, norm2(abs(G - Id)) < rtol_dp)
 
         return
     end subroutine test_pivoting_qr_exact_rank_deficiency_rdp
@@ -254,8 +294,9 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-                        new_unittest("QR factorization", test_qr_factorization_csp), &
-                        new_unittest("Pivoting QR (exact rank def.)", test_pivoting_qr_exact_rank_deficiency_csp) &
+                        new_unittest("QR factorization (correctness & orthonormality)", test_qr_factorization_csp), &
+                        new_unittest("Pivoting QR for a rank deficient matrix (correctness & orthonormality))",&
+                            & test_pivoting_qr_exact_rank_deficiency_csp) &
                     ]
         return
     end subroutine collect_qr_csp_testsuite
@@ -271,7 +312,8 @@ contains
         ! Information flag.
         integer :: info
         ! Miscellaneous.
-        complex(sp) :: Adata(test_size, kdim), Qdata(test_size, kdim)
+        complex(sp), dimension(test_size, kdim) :: Adata, Qdata
+        complex(sp), dimension(kdim, kdim) :: G, Id
 
         ! Initiliaze matrix.
         allocate(A(1:kdim)) ; call init_rand(A)
@@ -288,6 +330,15 @@ contains
 
         ! Check correctness.
         call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_sp)
+        if (allocated(error)) return
+
+        ! Compute Gram matrix associated to the Krylov basis.
+        G = zero_csp
+        call innerprod(G, A(1:kdim), A(1:kdim))
+
+        ! Check orthonormality of the computed basis.
+        Id = eye(kdim)
+        call check(error, norm2(abs(G - Id)) < rtol_sp)
 
         return
     end subroutine test_qr_factorization_csp
@@ -305,15 +356,15 @@ contains
         complex(sp) :: R(kdim, kdim)
         ! Permutation vector.
         integer :: perm(kdim)
-        complex(sp) :: Id(kdim, kdim)
         ! Information flag.
         integer :: info
        
         ! Miscellaneous.
         integer :: k, idx, rk
-        complex(sp) :: Adata(test_size, kdim), Qdata(test_size, kdim)
         real(sp) :: alpha
         logical :: mask(kdim)
+        complex(sp), dimension(test_size, kdim) :: Adata, Qdata
+        complex(sp), dimension(kdim, kdim) :: G, Id
 
         ! Effective rank.
         rk = kdim - nzero
@@ -346,6 +397,15 @@ contains
 
         ! Check correctness.
         call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_sp)
+        if (allocated(error)) return
+
+        ! Compute Gram matrix associated to the Krylov basis.
+        G = zero_csp
+        call innerprod(G, A(1:kdim), A(1:kdim))
+
+        ! Check orthonormality of the computed basis.
+        Id = eye(kdim)
+        call check(error, norm2(abs(G - Id)) < rtol_sp)
 
         return
     end subroutine test_pivoting_qr_exact_rank_deficiency_csp
@@ -354,8 +414,9 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-                        new_unittest("QR factorization", test_qr_factorization_cdp), &
-                        new_unittest("Pivoting QR (exact rank def.)", test_pivoting_qr_exact_rank_deficiency_cdp) &
+                        new_unittest("QR factorization (correctness & orthonormality)", test_qr_factorization_cdp), &
+                        new_unittest("Pivoting QR for a rank deficient matrix (correctness & orthonormality))",&
+                            & test_pivoting_qr_exact_rank_deficiency_cdp) &
                     ]
         return
     end subroutine collect_qr_cdp_testsuite
@@ -371,7 +432,8 @@ contains
         ! Information flag.
         integer :: info
         ! Miscellaneous.
-        complex(dp) :: Adata(test_size, kdim), Qdata(test_size, kdim)
+        complex(dp), dimension(test_size, kdim) :: Adata, Qdata
+        complex(dp), dimension(kdim, kdim) :: G, Id
 
         ! Initiliaze matrix.
         allocate(A(1:kdim)) ; call init_rand(A)
@@ -388,6 +450,15 @@ contains
 
         ! Check correctness.
         call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_dp)
+        if (allocated(error)) return
+
+        ! Compute Gram matrix associated to the Krylov basis.
+        G = zero_cdp
+        call innerprod(G, A(1:kdim), A(1:kdim))
+
+        ! Check orthonormality of the computed basis.
+        Id = eye(kdim)
+        call check(error, norm2(abs(G - Id)) < rtol_dp)
 
         return
     end subroutine test_qr_factorization_cdp
@@ -405,15 +476,15 @@ contains
         complex(dp) :: R(kdim, kdim)
         ! Permutation vector.
         integer :: perm(kdim)
-        complex(dp) :: Id(kdim, kdim)
         ! Information flag.
         integer :: info
        
         ! Miscellaneous.
         integer :: k, idx, rk
-        complex(dp) :: Adata(test_size, kdim), Qdata(test_size, kdim)
         real(dp) :: alpha
         logical :: mask(kdim)
+        complex(dp), dimension(test_size, kdim) :: Adata, Qdata
+        complex(dp), dimension(kdim, kdim) :: G, Id
 
         ! Effective rank.
         rk = kdim - nzero
@@ -446,6 +517,15 @@ contains
 
         ! Check correctness.
         call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_dp)
+        if (allocated(error)) return
+
+        ! Compute Gram matrix associated to the Krylov basis.
+        G = zero_cdp
+        call innerprod(G, A(1:kdim), A(1:kdim))
+
+        ! Check orthonormality of the computed basis.
+        Id = eye(kdim)
+        call check(error, norm2(abs(G - Id)) < rtol_dp)
 
         return
     end subroutine test_pivoting_qr_exact_rank_deficiency_cdp
@@ -459,9 +539,8 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-            new_unittest("Arnoldi factorization (correctness and basis orthonormality)", test_arnoldi_factorization_rsp), &
-            new_unittest("Block Arnoldi factorization (correctness and basis orthonormality)",&
-                & test_block_arnoldi_factorization_rsp), &
+            new_unittest("Arnoldi factorization (correctness & orthonormality)", test_arnoldi_factorization_rsp), &
+            new_unittest("Block Arnoldi factorization (correctness & orthonormality)", test_block_arnoldi_factorization_rsp), &
             new_unittest("Krylov-Schur factorization", test_krylov_schur_rsp) &
                     ]
         return
@@ -612,9 +691,8 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-            new_unittest("Arnoldi factorization (correctness and basis orthonormality)", test_arnoldi_factorization_rdp), &
-            new_unittest("Block Arnoldi factorization (correctness and basis orthonormality)",&
-                & test_block_arnoldi_factorization_rdp), &
+            new_unittest("Arnoldi factorization (correctness & orthonormality)", test_arnoldi_factorization_rdp), &
+            new_unittest("Block Arnoldi factorization (correctness & orthonormality)", test_block_arnoldi_factorization_rdp), &
             new_unittest("Krylov-Schur factorization", test_krylov_schur_rdp) &
                     ]
         return
@@ -765,9 +843,8 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-            new_unittest("Arnoldi factorization (correctness and basis orthonormality)", test_arnoldi_factorization_csp), &
-            new_unittest("Block Arnoldi factorization (correctness and basis orthonormality)",&
-                & test_block_arnoldi_factorization_csp), &
+            new_unittest("Arnoldi factorization (correctness & orthonormality)", test_arnoldi_factorization_csp), &
+            new_unittest("Block Arnoldi factorization (correctness & orthonormality)", test_block_arnoldi_factorization_csp), &
             new_unittest("Krylov-Schur factorization", test_krylov_schur_csp) &
                     ]
         return
@@ -918,9 +995,8 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-            new_unittest("Arnoldi factorization (correctness and basis orthonormality)", test_arnoldi_factorization_cdp), &
-            new_unittest("Block Arnoldi factorization (correctness and basis orthonormality)",&
-                & test_block_arnoldi_factorization_cdp), &
+            new_unittest("Arnoldi factorization (correctness & orthonormality)", test_arnoldi_factorization_cdp), &
+            new_unittest("Block Arnoldi factorization (correctness & orthonormality)", test_block_arnoldi_factorization_cdp), &
             new_unittest("Krylov-Schur factorization", test_krylov_schur_cdp) &
                     ]
         return
@@ -1358,8 +1434,7 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-             new_unittest("Lanczos Tridiagonalization (correctness and basis orthonormality)",&
-                 & test_lanczos_tridiag_factorization_rsp) &
+             new_unittest("Lanczos Tridiagonalization (correctness & orthonormality)", test_lanczos_tridiag_factorization_rsp) &
             ]
 
         return
@@ -1425,8 +1500,7 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-             new_unittest("Lanczos Tridiagonalization (correctness and basis orthonormality)",&
-                 & test_lanczos_tridiag_factorization_rdp) &
+             new_unittest("Lanczos Tridiagonalization (correctness & orthonormality)", test_lanczos_tridiag_factorization_rdp) &
             ]
 
         return
@@ -1492,8 +1566,7 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-             new_unittest("Lanczos Tridiagonalization (correctness and basis orthonormality)",&
-                 & test_lanczos_tridiag_factorization_csp) &
+             new_unittest("Lanczos Tridiagonalization (correctness & orthonormality)", test_lanczos_tridiag_factorization_csp) &
             ]
 
         return
@@ -1559,8 +1632,7 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-             new_unittest("Lanczos Tridiagonalization (correctness and basis orthonormality)",&
-                 & test_lanczos_tridiag_factorization_cdp) &
+             new_unittest("Lanczos Tridiagonalization (correctness & orthonormality)", test_lanczos_tridiag_factorization_cdp) &
             ]
 
         return

--- a/test/TestKrylov.fypp
+++ b/test/TestKrylov.fypp
@@ -9,6 +9,7 @@ module TestKrylov
 
     ! LightKrylov
     use LightKrylov
+    use LightKrylov_Constants
     use LightKrylov_Logger
 
     ! Testdrive
@@ -23,11 +24,11 @@ module TestKrylov
 
     character*128, parameter, private :: this_module = 'LightKrylov_TestKrylov'
 
-    #:for k1, t1 in RC_KINDS_TYPES
-    public :: collect_qr_${t1[0]}$${k1}$_testsuite
-    public :: collect_arnoldi_${t1[0]}$${k1}$_testsuite
-    public :: collect_lanczos_bidiag_${t1[0]}$${k1}$_testsuite
-    public :: collect_lanczos_tridiag_${t1[0]}$${k1}$_testsuite
+    #:for kind, type in RC_KINDS_TYPES
+    public :: collect_qr_${type[0]}$${kind}$_testsuite
+    public :: collect_arnoldi_${type[0]}$${kind}$_testsuite
+    public :: collect_lanczos_bidiag_${type[0]}$${kind}$_testsuite
+    public :: collect_lanczos_tridiag_${type[0]}$${kind}$_testsuite
 
     #:endfor
 
@@ -37,29 +38,29 @@ contains
     !-----     DEFINITIONS OF THE VARIOUS UNIT TESTS FOR QR     -----
     !----------------------------------------------------------------
 
-    #:for k1, t1 in RC_KINDS_TYPES
-    subroutine collect_qr_${t1[0]}$${k1}$_testsuite(testsuite)
+    #:for kind, type in RC_KINDS_TYPES
+    subroutine collect_qr_${type[0]}$${kind}$_testsuite(testsuite)
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-                        new_unittest("QR factorization", test_qr_factorization_${t1[0]}$${k1}$), &
-                        new_unittest("Pivoting QR (exact rank def.)", test_pivoting_qr_exact_rank_deficiency_${t1[0]}$${k1}$) &
+                        new_unittest("QR factorization", test_qr_factorization_${type[0]}$${kind}$), &
+                        new_unittest("Pivoting QR (exact rank def.)", test_pivoting_qr_exact_rank_deficiency_${type[0]}$${kind}$) &
                     ]
         return
-    end subroutine collect_qr_${t1[0]}$${k1}$_testsuite
+    end subroutine collect_qr_${type[0]}$${kind}$_testsuite
 
-    subroutine test_qr_factorization_${t1[0]}$${k1}$(error)
+    subroutine test_qr_factorization_${type[0]}$${kind}$(error)
         ! Error type to be returned.
         type(error_type), allocatable, intent(out) :: error
         ! Test Vectors.
         integer, parameter :: kdim = test_size
-        type(vector_${t1[0]}$${k1}$), allocatable :: A(:)
+        type(vector_${type[0]}$${kind}$), allocatable :: A(:)
         ! Upper triangular matrix.
-        ${t1}$ :: R(kdim, kdim) = 0.0_${k1}$
+        ${type}$ :: R(kdim, kdim) = zero_${type[0]}$${kind}$
         ! Information flag.
         integer :: info
         ! Miscellaneous.
-        ${t1}$ :: Adata(test_size, kdim), Qdata(test_size, kdim)
+        ${type}$ :: Adata(test_size, kdim), Qdata(test_size, kdim)
 
         ! Initiliaze matrix.
         allocate(A(1:kdim)) ; call init_rand(A)
@@ -75,32 +76,32 @@ contains
         call get_data(Qdata, A)
 
         ! Check correctness.
-        call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_${k1}$)
+        call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_${kind}$)
 
         return
-    end subroutine test_qr_factorization_${t1[0]}$${k1}$
+    end subroutine test_qr_factorization_${type[0]}$${kind}$
 
-    subroutine test_pivoting_qr_exact_rank_deficiency_${t1[0]}$${k1}$(error)
+    subroutine test_pivoting_qr_exact_rank_deficiency_${type[0]}$${kind}$(error)
         ! Error type to be returned.
         type(error_type), allocatable, intent(out) :: error
         ! Test basis.
-        type(vector_${t1[0]}$${k1}$), allocatable :: A(:)
+        type(vector_${type[0]}$${kind}$), allocatable :: A(:)
         ! Krylov subspace dimension.
         integer, parameter :: kdim = 20
         ! Number of zero columns.
         integer, parameter :: nzero = 5
         ! Upper triangular matrix.
-        ${t1}$ :: R(kdim, kdim)
+        ${type}$ :: R(kdim, kdim)
         ! Permutation vector.
         integer :: perm(kdim)
-        ${t1}$ :: Id(kdim, kdim)
+        ${type}$ :: Id(kdim, kdim)
         ! Information flag.
         integer :: info
        
         ! Miscellaneous.
         integer :: k, idx, rk
-        ${t1}$ :: Adata(test_size, kdim), Qdata(test_size, kdim)
-        real(${k1}$) :: alpha
+        ${type}$ :: Adata(test_size, kdim), Qdata(test_size, kdim)
+        real(${kind}$) :: alpha
         logical :: mask(kdim)
 
         ! Effective rank.
@@ -115,7 +116,7 @@ contains
             call random_number(alpha)
             idx = 1 + floor(kdim*alpha)
             if (mask(idx)) then
-                A(idx)%data = 0.0_${k1}$
+                A(idx)%data = zero_${type[0]}$${kind}$
                 mask(idx) = .false.
                 k = k-1
             endif
@@ -133,10 +134,10 @@ contains
         Adata = Adata(:, perm)
 
         ! Check correctness.
-        call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_${k1}$)
+        call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_${kind}$)
 
         return
-    end subroutine test_pivoting_qr_exact_rank_deficiency_${t1[0]}$${k1}$
+    end subroutine test_pivoting_qr_exact_rank_deficiency_${type[0]}$${kind}$
 
     #:endfor
     
@@ -179,8 +180,8 @@ contains
         allocate(X(1:kdim+1)) ;
         call initialize_krylov_subspace(X)
         call X(1)%rand(ifnorm=.true.) ; alpha = X(1)%norm()
-        call X(1)%scal(1.0_${kind}$ / alpha)
-        H = 0.0_${kind}$
+        call X(1)%scal(one_${type[0]}$${kind}$ / alpha)
+        H = zero_${type[0]}$${kind}$
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_arnoldi_factorization_${type[0]}$${kind}$')
@@ -216,14 +217,14 @@ contains
         ! Initialize Krylov subspace.
         allocate (X(1:kdim + 1)); allocate (X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
-        H = 0.0_${kind}$
+        H = zero_${type[0]}$${kind}$
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_arnoldi_basis_orthogonality_${type[0]}$${kind}$')
 
         ! Compute Gram matrix associated to the Krylov basis.
-        G = 0.0_${kind}$
+        G = zero_${type[0]}$${kind}$
         do j = 1, kdim
             do i = 1, kdim
                 G(i, j) = X(i)%dot(X(j))
@@ -262,13 +263,13 @@ contains
         ! Initialize Krylov subspace.
         allocate(X(1:p*(kdim+1))) ; allocate(X0(1:p))
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
-        H = 0.0_${kind}$
+        H = zero_${type[0]}$${kind}$
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, blksize=p)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_block_arnoldi_factorization_${type[0]}$${kind}$')
 
-        G = 0.0_${kind}$
+        G = zero_${type[0]}$${kind}$
         do j = 1, size(G, 2)
             do i = 1, size(G, 1)
                 G(i, j) = X(i)%dot(X(j))
@@ -309,14 +310,14 @@ contains
         allocate (X(1:p*(kdim + 1))); allocate (X0(1:p)); 
         call init_rand(X0)
         call initialize_krylov_subspace(X, X0)
-        H = 0.0_${kind}$
+        H = zero_${type[0]}$${kind}$
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, blksize=p)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_block_arnoldi_basis_orthogonality_${type[0]}$${kind}$')
 
         ! Compute Gram matrix associated to the Krylov basis.
-        G = 0.0_${kind}$
+        G = zero_${type[0]}$${kind}$
         do j = 1, size(G, 2)
             do i = 1, size(G, 1)
                 G(i, j) = X(i)%dot(X(j))
@@ -356,7 +357,7 @@ contains
         ! Initialize Krylov subspace.
         allocate(X(kdim+1)) ; allocate(X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
-        H = 0.0_${kind}$
+        H = zero_${type[0]}$${kind}$
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info)
@@ -423,7 +424,7 @@ contains
         ! Initialize Krylov subspaces.
         allocate(U(1:kdim+1)) ; allocate(V(1:kdim+1)) ; allocate(X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(U, X0)
-        call initialize_krylov_subspace(V) ; B = 0.0_${kind}$
+        call initialize_krylov_subspace(V) ; B = zero_${type[0]}$${kind}$
 
         ! Lanczos bidiagonalization.
         call lanczos_bidiagonalization(A, U, V, B, info)
@@ -463,7 +464,7 @@ contains
         ! Initialize Krylov subspaces.
         allocate(U(1:kdim+1)) ; allocate(V(1:kdim+1)) ; allocate(X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(U, X0)
-        call initialize_krylov_subspace(V) ; B = 0.0_${kind}$
+        call initialize_krylov_subspace(V) ; B = zero_${type[0]}$${kind}$
 
         ! Lanczos bidiagonalization.
         call lanczos_bidiagonalization(A, U, V, B, info)
@@ -471,7 +472,7 @@ contains
 
         ! Check correctness.
         Id = eye(kdim)
-        G = 0.0_${kind}$
+        G = zero_${type[0]}$${kind}$
         do j = 1, kdim
             do i = 1, kdim
                 G(i, j) = U(i)%dot(U(j))
@@ -507,7 +508,7 @@ contains
         ! Initialize Krylov subspaces.
         allocate(U(1:kdim+1)) ; allocate(V(1:kdim+1)) ; allocate(X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(U, X0)
-        call initialize_krylov_subspace(V) ; B = 0.0_${kind}$
+        call initialize_krylov_subspace(V) ; B = zero_${type[0]}$${kind}$
 
         ! Lanczos bidiagonalization.
         call lanczos_bidiagonalization(A, U, V, B, info)
@@ -515,7 +516,7 @@ contains
 
         ! Check correctness.
         Id = eye(kdim)
-        G = 0.0_${kind}$
+        G = zero_${type[0]}$${kind}$
         do j = 1, kdim
             do i = 1, kdim
                 G(i, j) = V(i)%dot(V(j))
@@ -570,7 +571,7 @@ contains
         class(vector_${type[0]}$${kind}$), allocatable :: X0(:)
 
         ! Initialize tridiagonal matrix.
-        T = 0.0_${kind}$
+        T = zero_${type[0]}$${kind}$
 
         ! Initialize operator.
         #:if type[0] == "r"
@@ -624,7 +625,7 @@ contains
         ${type}$ :: G(kdim+1, kdim+1)
 
         ! Initialize tridiagonal matrix.
-        T = 0.0_${kind}$
+        T = zero_${type[0]}$${kind}$
 
         ! Initialize operator.
         #:if type[0] == "r"
@@ -649,7 +650,7 @@ contains
         #:else
         G = matmul(transpose(conjg(Xdata)), Xdata)
         #:endif
-        Id = 0.0_${kind}$ ; Id(1:kdim, 1:kdim) = eye(kdim)
+        Id = zero_${type[0]}$${kind}$ ; Id(1:kdim, 1:kdim) = eye(kdim)
         call check(error, norm2(abs(G-Id)) < rtol_${kind}$)
 
         return

--- a/test/TestKrylov.fypp
+++ b/test/TestKrylov.fypp
@@ -44,8 +44,8 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-                        new_unittest("QR factorization", test_qr_factorization_${type[0]}$${kind}$), &
-                        new_unittest("Pivoting QR (exact rank def.)", test_pivoting_qr_exact_rank_deficiency_${type[0]}$${kind}$) &
+                        new_unittest("QR factorization (correctness & orthonormality)", test_qr_factorization_${type[0]}$${kind}$), &
+                        new_unittest("Pivoting QR for a rank deficient matrix (correctness & orthonormality))", test_pivoting_qr_exact_rank_deficiency_${type[0]}$${kind}$) &
                     ]
         return
     end subroutine collect_qr_${type[0]}$${kind}$_testsuite
@@ -61,7 +61,8 @@ contains
         ! Information flag.
         integer :: info
         ! Miscellaneous.
-        ${type}$ :: Adata(test_size, kdim), Qdata(test_size, kdim)
+        ${type}$, dimension(test_size, kdim) :: Adata, Qdata
+        ${type}$, dimension(kdim, kdim) :: G, Id
 
         ! Initiliaze matrix.
         allocate(A(1:kdim)) ; call init_rand(A)
@@ -78,6 +79,15 @@ contains
 
         ! Check correctness.
         call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_${kind}$)
+        if (allocated(error)) return
+
+        ! Compute Gram matrix associated to the Krylov basis.
+        G = zero_${type[0]}$${kind}$
+        call innerprod(G, A(1:kdim), A(1:kdim))
+
+        ! Check orthonormality of the computed basis.
+        Id = eye(kdim)
+        call check(error, norm2(abs(G - Id)) < rtol_${kind}$)
 
         return
     end subroutine test_qr_factorization_${type[0]}$${kind}$
@@ -95,15 +105,15 @@ contains
         ${type}$ :: R(kdim, kdim)
         ! Permutation vector.
         integer :: perm(kdim)
-        ${type}$ :: Id(kdim, kdim)
         ! Information flag.
         integer :: info
        
         ! Miscellaneous.
         integer :: k, idx, rk
-        ${type}$ :: Adata(test_size, kdim), Qdata(test_size, kdim)
         real(${kind}$) :: alpha
         logical :: mask(kdim)
+        ${type}$, dimension(test_size, kdim) :: Adata, Qdata
+        ${type}$, dimension(kdim, kdim) :: G, Id
 
         ! Effective rank.
         rk = kdim - nzero
@@ -136,6 +146,15 @@ contains
 
         ! Check correctness.
         call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_${kind}$)
+        if (allocated(error)) return
+
+        ! Compute Gram matrix associated to the Krylov basis.
+        G = zero_${type[0]}$${kind}$
+        call innerprod(G, A(1:kdim), A(1:kdim))
+
+        ! Check orthonormality of the computed basis.
+        Id = eye(kdim)
+        call check(error, norm2(abs(G - Id)) < rtol_${kind}$)
 
         return
     end subroutine test_pivoting_qr_exact_rank_deficiency_${type[0]}$${kind}$
@@ -151,8 +170,8 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-            new_unittest("Arnoldi factorization (correctness and basis orthonormality)", test_arnoldi_factorization_${type[0]}$${kind}$), &
-            new_unittest("Block Arnoldi factorization (correctness and basis orthonormality)", test_block_arnoldi_factorization_${type[0]}$${kind}$), &
+            new_unittest("Arnoldi factorization (correctness & orthonormality)", test_arnoldi_factorization_${type[0]}$${kind}$), &
+            new_unittest("Block Arnoldi factorization (correctness & orthonormality)", test_block_arnoldi_factorization_${type[0]}$${kind}$), &
             new_unittest("Krylov-Schur factorization", test_krylov_schur_${type[0]}$${kind}$) &
                     ]
         return
@@ -386,7 +405,7 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-             new_unittest("Lanczos Tridiagonalization (correctness and basis orthonormality)", test_lanczos_tridiag_factorization_${type[0]}$${kind}$) &
+             new_unittest("Lanczos Tridiagonalization (correctness & orthonormality)", test_lanczos_tridiag_factorization_${type[0]}$${kind}$) &
             ]
 
         return

--- a/test/TestKrylov.fypp
+++ b/test/TestKrylov.fypp
@@ -18,7 +18,10 @@ module TestKrylov
     use TestUtils
 
     implicit none
+    
     private
+
+    character*128, parameter, private :: this_module = 'LightKrylov_TestKrylov'
 
     #:for k1, t1 in RC_KINDS_TYPES
     public :: collect_qr_${t1[0]}$${k1}$_testsuite
@@ -66,7 +69,7 @@ contains
 
         ! In-place QR factorization.
         call qr(A, R, info)
-        call check_info(info, 'qr', module='LightKrylov_TestKrylov', procedure='test_qr_factorization_${type[0]}$${kind}$')
+        call check_info(info, 'qr', module=this_module, procedure='test_qr_factorization_${type[0]}$${kind}$')
 
         ! Get data.
         call get_data(Qdata, A)
@@ -123,7 +126,7 @@ contains
 
         ! In-place QR factorization.
         call qr(A, R, perm, info)
-        call check_info(info, 'qr_pivot', module='LightKrylov_TestKrylov', procedure='test_pivoting_qr_exact_rank_deficiency_${type[0]}$${kind}$')
+        call check_info(info, 'qr_pivot', module=this_module, procedure='test_pivoting_qr_exact_rank_deficiency_${type[0]}$${kind}$')
 
         ! Extract data
         call get_data(Qdata, A)
@@ -180,7 +183,7 @@ contains
         H = 0.0_${kind}$
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info)
-        call check_info(info, 'arnoldi', module='LightKrylov_TestKrylov', procedure='test_arnoldi_factorization_${type[0]}$${kind}$')
+        call check_info(info, 'arnoldi', module=this_module, procedure='test_arnoldi_factorization_${type[0]}$${kind}$')
 
         ! Check correctness of full factorization.
         call get_data(Xdata, X)
@@ -217,7 +220,7 @@ contains
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info)
-        call check_info(info, 'arnoldi', module='LightKrylov_TestKrylov', procedure='test_arnoldi_basis_orthogonality_${type[0]}$${kind}$')
+        call check_info(info, 'arnoldi', module=this_module, procedure='test_arnoldi_basis_orthogonality_${type[0]}$${kind}$')
 
         ! Compute Gram matrix associated to the Krylov basis.
         G = 0.0_${kind}$
@@ -263,7 +266,7 @@ contains
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, blksize=p)
-        call check_info(info, 'arnoldi', module='LightKrylov_TestKrylov', procedure='test_block_arnoldi_factorization_${type[0]}$${kind}$')
+        call check_info(info, 'arnoldi', module=this_module, procedure='test_block_arnoldi_factorization_${type[0]}$${kind}$')
 
         G = 0.0_${kind}$
         do j = 1, size(G, 2)
@@ -310,7 +313,7 @@ contains
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, blksize=p)
-        call check_info(info, 'arnoldi', module='LightKrylov_TestKrylov', procedure='test_block_arnoldi_basis_orthogonality_${type[0]}$${kind}$')
+        call check_info(info, 'arnoldi', module=this_module, procedure='test_block_arnoldi_basis_orthogonality_${type[0]}$${kind}$')
 
         ! Compute Gram matrix associated to the Krylov basis.
         G = 0.0_${kind}$
@@ -357,7 +360,7 @@ contains
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info)
-        call check_info(info, 'arnoldi', module='LightKrylov_TestKrylov', procedure='test_krylov_schur_${type[0]}$${kind}$')
+        call check_info(info, 'arnoldi', module=this_module, procedure='test_krylov_schur_${type[0]}$${kind}$')
 
         ! Krylov-Schur condensation.
         call krylov_schur(n, X, H, select_eigs)
@@ -424,7 +427,7 @@ contains
 
         ! Lanczos bidiagonalization.
         call lanczos_bidiagonalization(A, U, V, B, info)
-        call check_info(info, 'lanczos_bidiagonalization', module='LightKrylov_TestKrylov', procedure='test_lanczos_bidiag_factorization_${type[0]}$${kind}$')
+        call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='test_lanczos_bidiag_factorization_${type[0]}$${kind}$')
 
         ! Check correctness.
         call get_data(Udata, U)
@@ -464,7 +467,7 @@ contains
 
         ! Lanczos bidiagonalization.
         call lanczos_bidiagonalization(A, U, V, B, info)
-        call check_info(info, 'lanczos_bidiagonalization', module='LightKrylov_TestKrylov', procedure='test_lanczos_bidiag_left_orthogonality_${type[0]}$${kind}$')
+        call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='test_lanczos_bidiag_left_orthogonality_${type[0]}$${kind}$')
 
         ! Check correctness.
         Id = eye(kdim)
@@ -508,7 +511,7 @@ contains
 
         ! Lanczos bidiagonalization.
         call lanczos_bidiagonalization(A, U, V, B, info)
-        call check_info(info, 'lanczos_bidiagonalization', module='LightKrylov_TestKrylov', procedure='test_lanczos_bidiag_right_orthogonality_${type[0]}$${kind}$')
+        call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='test_lanczos_bidiag_right_orthogonality_${type[0]}$${kind}$')
 
         ! Check correctness.
         Id = eye(kdim)
@@ -583,7 +586,7 @@ contains
 
         ! Lanczos factorization.
         call lanczos_tridiagonalization(A, X, T, info)
-        call check_info(info, 'lanczos_tridiagonalization', module='LightKrylov_TestKrylov', procedure='test_lanczos_tridiag_full_factorization_${type[0]}$${kind}$')
+        call check_info(info, 'lanczos_tridiagonalization', module=this_module, procedure='test_lanczos_tridiag_full_factorization_${type[0]}$${kind}$')
 
         ! Check correctness.
         call get_data(Xdata, X)
@@ -637,7 +640,7 @@ contains
 
         ! Lanczos factorization.
         call lanczos_tridiagonalization(A, X, T, info)
-        call check_info(info, 'lanczos_tridiagonalization', module='LightKrylov_TestKrylov', procedure='test_lanczos_tridiag_orthogonality_${type[0]}$${kind}$')
+        call check_info(info, 'lanczos_tridiagonalization', module=this_module, procedure='test_lanczos_tridiag_orthogonality_${type[0]}$${kind}$')
 
         ! Check correctness.
         call get_data(Xdata, X)

--- a/test/TestKrylov.fypp
+++ b/test/TestKrylov.fypp
@@ -11,6 +11,7 @@ module TestKrylov
     use LightKrylov
     use LightKrylov_Constants
     use LightKrylov_Logger
+    use LightKrylov_AbstractVectors
 
     ! Testdrive
     use testdrive, only: new_unittest, unittest_type, error_type, check
@@ -150,10 +151,8 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-            new_unittest("Arnoldi factorization", test_arnoldi_factorization_${type[0]}$${kind}$), &
-            new_unittest("Arnoldi orthogonality", test_arnoldi_basis_orthogonality_${type[0]}$${kind}$), &
-            new_unittest("Block Arnoldi factorization", test_block_arnoldi_factorization_${type[0]}$${kind}$), &
-            new_unittest("Block Arnoldi orthogonality", test_block_arnoldi_basis_orthogonality_${type[0]}$${kind}$), &
+            new_unittest("Arnoldi factorization (correctness and basis orthonormality)", test_arnoldi_factorization_${type[0]}$${kind}$), &
+            new_unittest("Block Arnoldi factorization (correctness and basis orthonormality)", test_block_arnoldi_factorization_${type[0]}$${kind}$), &
             new_unittest("Krylov-Schur factorization", test_krylov_schur_${type[0]}$${kind}$) &
                     ]
         return
@@ -166,21 +165,21 @@ contains
         type(linop_${type[0]}$${kind}$), allocatable :: A
         ! Krylov subspace.
         type(vector_${type[0]}$${kind}$), allocatable :: X(:)
+        type(vector_${type[0]}$${kind}$), dimension(:), allocatable :: X0
         integer, parameter :: kdim = test_size
         ! Hessenberg matrix.
         ${type}$ :: H(kdim+1, kdim)
         ! Information flag.
         integer :: info
         ! Miscellaneous.
-        ${type}$ :: Xdata(test_size, kdim+1), alpha
-    
+        ${type}$ :: Xdata(test_size, kdim+1)
+        ${type}$, dimension(kdim, kdim) :: G, Id
+           
         ! Initialize linear operator.
         A = linop_${type[0]}$${kind}$() ; call init_rand(A)
         ! Initialize Krylov subspace.
-        allocate(X(1:kdim+1)) ;
-        call initialize_krylov_subspace(X)
-        call X(1)%rand(ifnorm=.true.) ; alpha = X(1)%norm()
-        call X(1)%scal(one_${type[0]}$${kind}$ / alpha)
+        allocate(X(1:kdim+1)) ; allocate (X0(1))
+        call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
         H = zero_${type[0]}$${kind}$
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info)
@@ -188,56 +187,19 @@ contains
 
         ! Check correctness of full factorization.
         call get_data(Xdata, X)
-
         call check(error, maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, H))) < rtol_${kind}$)
-
-        return
-    end subroutine test_arnoldi_factorization_${type[0]}$${kind}$
-
-    subroutine test_arnoldi_basis_orthogonality_${type[0]}$${kind}$(error)
-        ! Error type to be returned.
-        type(error_type), allocatable, intent(out) :: error
-        ! Test matrix.
-        type(linop_${type[0]}$${kind}$), allocatable :: A
-        ! Krylov subspace.
-        type(vector_${type[0]}$${kind}$), dimension(:), allocatable :: X
-        type(vector_${type[0]}$${kind}$), dimension(:), allocatable :: X0
-        ! Krylov subspace dimension.
-        integer, parameter :: kdim = test_size
-        ! Hessenberg matrix.
-        ${type}$, dimension(kdim + 1, kdim) :: H
-        ! Information flag.
-        integer :: info
-        ! Misc.
-        ${type}$, dimension(kdim, kdim) :: G, Id
-        integer :: i, j
-
-        ! Initialize random matrix.
-        A = linop_${type[0]}$${kind}$(); call init_rand(A)
-        ! Initialize Krylov subspace.
-        allocate (X(1:kdim + 1)); allocate (X0(1))
-        call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
-        H = zero_${type[0]}$${kind}$
-
-        ! Arnoldi factorization.
-        call arnoldi(A, X, H, info)
-        call check_info(info, 'arnoldi', module=this_module, procedure='test_arnoldi_basis_orthogonality_${type[0]}$${kind}$')
+        if (allocated(error)) return
 
         ! Compute Gram matrix associated to the Krylov basis.
         G = zero_${type[0]}$${kind}$
-        do j = 1, kdim
-            do i = 1, kdim
-                G(i, j) = X(i)%dot(X(j))
-            enddo
-        enddo
-        ! call innerprod_matrix(G, X(1:kdim), X(1:kdim))
+        call innerprod(G, X(1:kdim), X(1:kdim))
 
-        ! Check result.
+        ! Check orthonormality of the computed basis.
         Id = eye(kdim)
         call check(error, norm2(abs(G - Id)) < rtol_${kind}$)
 
         return
-    end subroutine test_arnoldi_basis_orthogonality_${type[0]}$${kind}$
+    end subroutine test_arnoldi_factorization_${type[0]}$${kind}$
 
     subroutine test_block_arnoldi_factorization_${type[0]}$${kind}$(error)
         ! Error type to be returned.
@@ -254,8 +216,9 @@ contains
         integer :: info
         ! Miscellaneous.
         type(vector_${type[0]}$${kind}$), allocatable :: X0(:)
-        ${type}$ :: Xdata(test_size, p*(kdim+1)), G(p*(kdim+1), p*(kdim+1))
-        integer :: i, j
+        ${type}$, dimension(test_size, p*(kdim+1)) :: Xdata
+        ${type}$, dimension(p*kdim, p*kdim) :: G
+        real(${kind}$), dimension(p*kdim, p*kdim) :: Id
 
         ! Initialize linear operator.
         A = linop_${type[0]}$${kind}$() ; call init_rand(A)
@@ -269,67 +232,21 @@ contains
         call arnoldi(A, X, H, info, blksize=p)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_block_arnoldi_factorization_${type[0]}$${kind}$')
 
-        G = zero_${type[0]}$${kind}$
-        do j = 1, size(G, 2)
-            do i = 1, size(G, 1)
-                G(i, j) = X(i)%dot(X(j))
-            enddo
-        enddo
-
-        ! Check correctness.
+        ! Check correctness of full factorization.
         call get_data(Xdata, X)
-        
         call check(error, maxval(abs(matmul(A%data, Xdata(:, 1:p*kdim)) - matmul(Xdata, H))) < rtol_${kind}$)
-
-        return
-    end subroutine test_block_arnoldi_factorization_${type[0]}$${kind}$
-
-    subroutine test_block_arnoldi_basis_orthogonality_${type[0]}$${kind}$(error)
-        ! Error type to be returned.
-        type(error_type), allocatable, intent(out) :: error
-        ! Test matrix.
-        class(linop_${type[0]}$${kind}$), allocatable :: A
-        ! Krylov subspace.
-        type(vector_${type[0]}$${kind}$), dimension(:), allocatable :: X
-        type(vector_${type[0]}$${kind}$), dimension(:), allocatable :: X0
-        ! Krylov subspace dimension.
-        integer, parameter :: p = 2
-        integer, parameter :: kdim = test_size/2
-        ! Hessenberg matrix.
-        ${type}$, dimension(p*(kdim + 1), p*kdim) :: H
-        ! Information flag.
-        integer :: info
-        ! Misc.
-        ${type}$, dimension(p*kdim, p*kdim) :: G, Id
-        integer :: i, j
-
-        ! Initialize random matrix.
-        A = linop_${type[0]}$${kind}$(); call init_rand(A)
-
-        ! Initialize Krylov subspace.
-        allocate (X(1:p*(kdim + 1))); allocate (X0(1:p)); 
-        call init_rand(X0)
-        call initialize_krylov_subspace(X, X0)
-        H = zero_${type[0]}$${kind}$
-
-        ! Arnoldi factorization.
-        call arnoldi(A, X, H, info, blksize=p)
-        call check_info(info, 'arnoldi', module=this_module, procedure='test_block_arnoldi_basis_orthogonality_${type[0]}$${kind}$')
+        if (allocated(error)) return
 
         ! Compute Gram matrix associated to the Krylov basis.
         G = zero_${type[0]}$${kind}$
-        do j = 1, size(G, 2)
-            do i = 1, size(G, 1)
-                G(i, j) = X(i)%dot(X(j))
-            enddo
-        enddo
+        call innerprod(G, X(1:p*kdim), X(1:p*kdim))
 
-        ! Check result.
+        ! Check orthonormality of the computed basis.
         Id = eye(p*kdim)
         call check(error, norm2(abs(G - Id)) < rtol_${kind}$)
 
         return
-    end subroutine test_block_arnoldi_basis_orthogonality_${type[0]}$${kind}$
+    end subroutine test_block_arnoldi_factorization_${type[0]}$${kind}$
 
     subroutine test_krylov_schur_${type[0]}$${kind}$(error)
         ! Error type to be returned.
@@ -393,9 +310,7 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-            new_unittest("Lanczos Bidiagonalization", test_lanczos_bidiag_factorization_${type[0]}$${kind}$), &
-            new_unittest("Lanczos left orthogonality", test_lanczos_bidiag_left_orthogonality_${type[0]}$${kind}$), &
-            new_unittest("Lanczos right orthogonality", test_lanczos_bidiag_right_orthogonality_${type[0]}$${kind}$) &
+            new_unittest("Lanczos Bidiagonalization (correctness and left/right orthonormality)", test_lanczos_bidiag_factorization_${type[0]}$${kind}$) &
                 ]
         return
     end subroutine collect_lanczos_bidiag_${type[0]}$${kind}$_testsuite
@@ -415,7 +330,8 @@ contains
         integer :: info
         ! Miscellaneous.
         real(${kind}$) :: alpha
-        ${type}$ :: Udata(test_size, kdim+1), Vdata(test_size, kdim+1)
+        ${type}$, dimension(test_size, kdim+1) :: Udata, Vdata
+        ${type}$, dimension(kdim, kdim) :: G, Id
         type(vector_${type[0]}$${kind}$), allocatable :: X0(:)
 
         ! Initialize linear operator.
@@ -428,7 +344,8 @@ contains
 
         ! Lanczos bidiagonalization.
         call lanczos_bidiagonalization(A, U, V, B, info)
-        call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='test_lanczos_bidiag_factorization_${type[0]}$${kind}$')
+        call check_info(info, 'lanczos_bidiagonalization', module=this_module, &
+                        & procedure='test_lanczos_bidiag_factorization_${type[0]}$${kind}$')
 
         ! Check correctness.
         call get_data(Udata, U)
@@ -436,97 +353,26 @@ contains
 
         alpha = maxval(abs(matmul(A%data, Vdata(:, 1:kdim)) - matmul(Udata, B)))
         call check(error, alpha < rtol_${kind}$)
+        if (allocated(error)) return
+
+        ! Compute Gram matrix associated to the left Krylov basis.
+        G = zero_${type[0]}$${kind}$
+        call innerprod(G, U(1:kdim), U(1:kdim))
+
+        ! Check orthonormality of the left basis.
+        Id = eye(kdim)
+        call check(error, norm2(abs(G - Id)) < rtol_${kind}$)
+        if (allocated(error)) return
+
+        ! Compute Gram matrix associated to the right Krylov basis.
+        G = zero_${type[0]}$${kind}$
+        call innerprod(G, V(1:kdim), V(1:kdim))
+
+        ! Check orthonormality of the right basis.
+        call check(error, norm2(abs(G - Id)) < rtol_${kind}$)
 
         return
     end subroutine test_lanczos_bidiag_factorization_${type[0]}$${kind}$
-
-    subroutine test_lanczos_bidiag_left_orthogonality_${type[0]}$${kind}$(error)
-        ! Error type to be returned.
-        type(error_type), allocatable, intent(out) :: error
-        ! Test Linear Operator
-        type(linop_${type[0]}$${kind}$), allocatable :: A
-        ! Left and right Krylov bases.
-        type(vector_${type[0]}$${kind}$), allocatable :: U(:), V(:)
-        ! Krylov subspace dimension.
-        integer, parameter :: kdim = 3!test_size
-        ! Bidiagonal matrix.
-        ${type}$ :: B(kdim+1, kdim)
-        ! Information flag.
-        integer :: info
-        ! Miscellaneous.
-        real(${kind}$) :: Id(kdim, kdim), G(kdim, kdim)
-        type(vector_${type[0]}$${kind}$), allocatable :: X0(:)
-        integer :: i, j
-
-        ! Initialize linear operator.
-        A = linop_${type[0]}$${kind}$() ; call init_rand(A)
-
-        ! Initialize Krylov subspaces.
-        allocate(U(1:kdim+1)) ; allocate(V(1:kdim+1)) ; allocate(X0(1))
-        call init_rand(X0) ; call initialize_krylov_subspace(U, X0)
-        call initialize_krylov_subspace(V) ; B = zero_${type[0]}$${kind}$
-
-        ! Lanczos bidiagonalization.
-        call lanczos_bidiagonalization(A, U, V, B, info)
-        call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='test_lanczos_bidiag_left_orthogonality_${type[0]}$${kind}$')
-
-        ! Check correctness.
-        Id = eye(kdim)
-        G = zero_${type[0]}$${kind}$
-        do j = 1, kdim
-            do i = 1, kdim
-                G(i, j) = U(i)%dot(U(j))
-            enddo
-        enddo
-
-        call check(error, maxval(abs(Id - G)) < rtol_${kind}$)
-
-        return
-    end subroutine test_lanczos_bidiag_left_orthogonality_${type[0]}$${kind}$
-
-    subroutine test_lanczos_bidiag_right_orthogonality_${type[0]}$${kind}$(error)
-        ! Error type to be returned.
-        type(error_type), allocatable, intent(out) :: error
-        ! Test Linear Operator
-        type(linop_${type[0]}$${kind}$), allocatable :: A
-        ! Left and right Krylov bases.
-        type(vector_${type[0]}$${kind}$), allocatable :: U(:), V(:)
-        ! Krylov subspace dimension.
-        integer, parameter :: kdim = 3!test_size
-        ! Bidiagonal matrix.
-        ${type}$ :: B(kdim+1, kdim)
-        ! Information flag.
-        integer :: info
-        ! Miscellaneous.
-        real(${kind}$) :: Id(kdim, kdim), G(kdim, kdim)
-        type(vector_${type[0]}$${kind}$), allocatable :: X0(:)
-        integer :: i, j
-
-        ! Initialize linear operator.
-        A = linop_${type[0]}$${kind}$() ; call init_rand(A)
-
-        ! Initialize Krylov subspaces.
-        allocate(U(1:kdim+1)) ; allocate(V(1:kdim+1)) ; allocate(X0(1))
-        call init_rand(X0) ; call initialize_krylov_subspace(U, X0)
-        call initialize_krylov_subspace(V) ; B = zero_${type[0]}$${kind}$
-
-        ! Lanczos bidiagonalization.
-        call lanczos_bidiagonalization(A, U, V, B, info)
-        call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='test_lanczos_bidiag_right_orthogonality_${type[0]}$${kind}$')
-
-        ! Check correctness.
-        Id = eye(kdim)
-        G = zero_${type[0]}$${kind}$
-        do j = 1, kdim
-            do i = 1, kdim
-                G(i, j) = V(i)%dot(V(j))
-            enddo
-        enddo
-
-        call check(error, maxval(abs(Id - G)) < rtol_${kind}$)
-
-        return
-    end subroutine test_lanczos_bidiag_right_orthogonality_${type[0]}$${kind}$
 
    #:endfor
 
@@ -540,14 +386,13 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-             new_unittest("Lanczos Tridiagonalization", test_lanczos_tridiag_full_factorization_${type[0]}$${kind}$), &
-             new_unittest("Lanczos Tridiagonalization orthogonality", test_lanczos_tridiag_orthogonality_${type[0]}$${kind}$) &
-                    ]
+             new_unittest("Lanczos Tridiagonalization (correctness and basis orthonormality)", test_lanczos_tridiag_factorization_${type[0]}$${kind}$) &
+            ]
 
         return
     end subroutine collect_lanczos_tridiag_${type[0]}$${kind}$_testsuite
 
-    subroutine test_lanczos_tridiag_full_factorization_${type[0]}$${kind}$(error)
+    subroutine test_lanczos_tridiag_factorization_${type[0]}$${kind}$(error)
         ! Error type to be returned.
         type(error_type), allocatable, intent(out) :: error
         ! Test matrix.
@@ -569,6 +414,7 @@ contains
         ${type}$ :: Xdata(test_size, kdim+1)
         real(${kind}$) :: alpha
         class(vector_${type[0]}$${kind}$), allocatable :: X0(:)
+        ${type}$, dimension(kdim, kdim) :: G, Id
 
         ! Initialize tridiagonal matrix.
         T = zero_${type[0]}$${kind}$
@@ -587,7 +433,8 @@ contains
 
         ! Lanczos factorization.
         call lanczos_tridiagonalization(A, X, T, info)
-        call check_info(info, 'lanczos_tridiagonalization', module=this_module, procedure='test_lanczos_tridiag_full_factorization_${type[0]}$${kind}$')
+        call check_info(info, 'lanczos_tridiagonalization', module=this_module, & 
+                        & procedure='test_lanczos_tridiag_full_factorization_${type[0]}$${kind}$')
 
         ! Check correctness.
         call get_data(Xdata, X)
@@ -595,67 +442,18 @@ contains
         ! Infinity-norm check.
         alpha = maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, T)))
         call check(error, alpha < rtol_${kind}$)
+        if (allocated(error)) return
+
+        ! Compute Gram matrix associated to the right Krylov basis.
+        G = zero_${type[0]}$${kind}$
+        call innerprod(G, X(1:kdim), X(1:kdim))
+
+        ! Check orthonormality of the Krylov basis.
+        Id = eye(kdim)
+        call check(error, norm2(abs(G - Id)) < rtol_${kind}$)
 
         return
-    end subroutine test_lanczos_tridiag_full_factorization_${type[0]}$${kind}$
-
-    subroutine test_lanczos_tridiag_orthogonality_${type[0]}$${kind}$(error)
-        ! Error type to be returned.
-        type(error_type), allocatable, intent(out) :: error
-        ! Test matrix.
-        #:if type[0] == "r"
-        type(spd_linop_${type[0]}$${kind}$), allocatable :: A
-        #:else
-        type(hermitian_linop_${type[0]}$${kind}$), allocatable :: A
-        #:endif
-        ! Krylov subspace.
-        type(vector_${type[0]}$${kind}$), allocatable :: X(:)
-        ! Krylov subspace dimension.
-        integer, parameter :: kdim = test_size
-        ! Tridiagonal matrix.
-        ${type}$ :: T(kdim+1, kdim)
-        ! Information flag.
-        integer :: info
-
-        ! Internal variables.
-        real(${kind}$) :: alpha
-        ${type}$ :: Xdata(test_size, kdim+1)
-        class(vector_${type[0]}$${kind}$), allocatable :: X0(:)
-        real(${kind}$) :: Id(kdim+1, kdim+1)
-        ${type}$ :: G(kdim+1, kdim+1)
-
-        ! Initialize tridiagonal matrix.
-        T = zero_${type[0]}$${kind}$
-
-        ! Initialize operator.
-        #:if type[0] == "r"
-        A = spd_linop_${type[0]}$${kind}$()
-        #:else
-        A = hermitian_linop_${type[0]}$${kind}$()
-        #:endif
-        call init_rand(A)
-
-        ! Initialize Krylov subspace.
-        allocate(X(kdim+1)) ; allocate(X0(1))
-        call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
-
-        ! Lanczos factorization.
-        call lanczos_tridiagonalization(A, X, T, info)
-        call check_info(info, 'lanczos_tridiagonalization', module=this_module, procedure='test_lanczos_tridiag_orthogonality_${type[0]}$${kind}$')
-
-        ! Check correctness.
-        call get_data(Xdata, X)
-        #:if type[0] == "r"
-        G = matmul(transpose(Xdata), Xdata)
-        #:else
-        G = matmul(transpose(conjg(Xdata)), Xdata)
-        #:endif
-        Id = zero_${type[0]}$${kind}$ ; Id(1:kdim, 1:kdim) = eye(kdim)
-        call check(error, norm2(abs(G-Id)) < rtol_${kind}$)
-
-        return
-    end subroutine test_lanczos_tridiag_orthogonality_${type[0]}$${kind}$
+    end subroutine test_lanczos_tridiag_factorization_${type[0]}$${kind}$
 
     #:endfor
-
 end module TestKrylov

--- a/test/TestLinops.f90
+++ b/test/TestLinops.f90
@@ -10,7 +10,10 @@ module TestLinops
     use TestVectors
 
     implicit none
+    
     private
+
+    character*128, parameter, private :: this_module = 'LightKrylov_TestLinops'
 
     public :: collect_linop_rsp_testsuite
     public :: collect_linop_rdp_testsuite

--- a/test/TestLinops.f90
+++ b/test/TestLinops.f90
@@ -4,6 +4,7 @@ module TestLinops
 
     ! LightKrylov
     use LightKrylov
+    use LightKrylov_Constants
     
     ! Testdrive
     use testdrive, only: new_unittest, unittest_type, error_type, check
@@ -21,7 +22,7 @@ module TestLinops
     public :: collect_linop_cdp_testsuite
 
     type, extends(abstract_linop_rsp), public :: linop_rsp
-        real(sp), dimension(test_size, test_size) :: data = 0.0_sp
+        real(sp), dimension(test_size, test_size) :: data = zero_rsp
     contains
         private
         procedure, pass(self), public :: matvec  => matvec_rsp
@@ -29,7 +30,7 @@ module TestLinops
     end type
 
     type, extends(abstract_sym_linop_rsp), public :: spd_linop_rsp
-        real(sp), dimension(test_size, test_size) :: data = 0.0_sp
+        real(sp), dimension(test_size, test_size) :: data = zero_rsp
     contains
         private
         procedure, pass(self), public :: matvec => sdp_matvec_rsp
@@ -37,7 +38,7 @@ module TestLinops
     end type
 
     type, extends(abstract_linop_rdp), public :: linop_rdp
-        real(dp), dimension(test_size, test_size) :: data = 0.0_dp
+        real(dp), dimension(test_size, test_size) :: data = zero_rdp
     contains
         private
         procedure, pass(self), public :: matvec  => matvec_rdp
@@ -45,7 +46,7 @@ module TestLinops
     end type
 
     type, extends(abstract_sym_linop_rdp), public :: spd_linop_rdp
-        real(dp), dimension(test_size, test_size) :: data = 0.0_dp
+        real(dp), dimension(test_size, test_size) :: data = zero_rdp
     contains
         private
         procedure, pass(self), public :: matvec => sdp_matvec_rdp
@@ -53,7 +54,7 @@ module TestLinops
     end type
 
     type, extends(abstract_linop_csp), public :: linop_csp
-        complex(sp), dimension(test_size, test_size) :: data = 0.0_sp
+        complex(sp), dimension(test_size, test_size) :: data = zero_csp
     contains
         private
         procedure, pass(self), public :: matvec  => matvec_csp
@@ -61,7 +62,7 @@ module TestLinops
     end type
 
     type, extends(abstract_hermitian_linop_csp), public :: hermitian_linop_csp
-        complex(sp), dimension(test_size, test_size) :: data = 0.0_sp
+        complex(sp), dimension(test_size, test_size) :: data = zero_csp
     contains
         private
         procedure, pass(self), public :: matvec => hermitian_matvec_csp
@@ -69,7 +70,7 @@ module TestLinops
     end type
 
     type, extends(abstract_linop_cdp), public :: linop_cdp
-        complex(dp), dimension(test_size, test_size) :: data = 0.0_dp
+        complex(dp), dimension(test_size, test_size) :: data = zero_cdp
     contains
         private
         procedure, pass(self), public :: matvec  => matvec_cdp
@@ -77,7 +78,7 @@ module TestLinops
     end type
 
     type, extends(abstract_hermitian_linop_cdp), public :: hermitian_linop_cdp
-        complex(dp), dimension(test_size, test_size) :: data = 0.0_dp
+        complex(dp), dimension(test_size, test_size) :: data = zero_cdp
     contains
         private
         procedure, pass(self), public :: matvec => hermitian_matvec_cdp

--- a/test/TestLinops.fypp
+++ b/test/TestLinops.fypp
@@ -6,6 +6,7 @@ module TestLinops
 
     ! LightKrylov
     use LightKrylov
+    use LightKrylov_Constants
     
     ! Testdrive
     use testdrive, only: new_unittest, unittest_type, error_type, check
@@ -17,34 +18,34 @@ module TestLinops
 
     character*128, parameter, private :: this_module = 'LightKrylov_TestLinops'
 
-    #:for k1, t1 in RC_KINDS_TYPES
-    public :: collect_linop_${t1[0]}$${k1}$_testsuite
+    #:for kind, type in RC_KINDS_TYPES
+    public :: collect_linop_${type[0]}$${kind}$_testsuite
     #:endfor
 
-    #:for k1, t1 in RC_KINDS_TYPES
-    type, extends(abstract_linop_${t1[0]}$${k1}$), public :: linop_${t1[0]}$${k1}$
-        ${t1}$, dimension(test_size, test_size) :: data = 0.0_${k1}$
+    #:for kind, type in RC_KINDS_TYPES
+    type, extends(abstract_linop_${type[0]}$${kind}$), public :: linop_${type[0]}$${kind}$
+        ${type}$, dimension(test_size, test_size) :: data = zero_${type[0]}$${kind}$
     contains
         private
-        procedure, pass(self), public :: matvec  => matvec_${t1[0]}$${k1}$
-        procedure, pass(self), public :: rmatvec => rmatvec_${t1[0]}$${k1}$
+        procedure, pass(self), public :: matvec  => matvec_${type[0]}$${kind}$
+        procedure, pass(self), public :: rmatvec => rmatvec_${type[0]}$${kind}$
     end type
 
-    #:if t1[0] == "r"
-    type, extends(abstract_sym_linop_${t1[0]}$${k1}$), public :: spd_linop_${t1[0]}$${k1}$
-        ${t1}$, dimension(test_size, test_size) :: data = 0.0_${k1}$
+    #:if type[0] == "r"
+    type, extends(abstract_sym_linop_${type[0]}$${kind}$), public :: spd_linop_${type[0]}$${kind}$
+        ${type}$, dimension(test_size, test_size) :: data = zero_${type[0]}$${kind}$
     contains
         private
-        procedure, pass(self), public :: matvec => sdp_matvec_${t1[0]}$${k1}$
-        procedure, pass(self), public :: rmatvec => sdp_matvec_${t1[0]}$${k1}$
+        procedure, pass(self), public :: matvec => sdp_matvec_${type[0]}$${kind}$
+        procedure, pass(self), public :: rmatvec => sdp_matvec_${type[0]}$${kind}$
     end type
     #:else
-    type, extends(abstract_hermitian_linop_${t1[0]}$${k1}$), public :: hermitian_linop_${t1[0]}$${k1}$
-        ${t1}$, dimension(test_size, test_size) :: data = 0.0_${k1}$
+    type, extends(abstract_hermitian_linop_${type[0]}$${kind}$), public :: hermitian_linop_${type[0]}$${kind}$
+        ${type}$, dimension(test_size, test_size) :: data = zero_${type[0]}$${kind}$
     contains
         private
-        procedure, pass(self), public :: matvec => hermitian_matvec_${t1[0]}$${k1}$
-        procedure, pass(self), public :: rmatvec => hermitian_matvec_${t1[0]}$${k1}$
+        procedure, pass(self), public :: matvec => hermitian_matvec_${type[0]}$${kind}$
+        procedure, pass(self), public :: rmatvec => hermitian_matvec_${type[0]}$${kind}$
     end type
     #:endif
 
@@ -55,16 +56,16 @@ contains
     !-----     DEFINITIONS OF THE VARIOUS TYPE-BOUND PROCEDURES     -----
     !--------------------------------------------------------------------
 
-    #:for k1, t1 in RC_KINDS_TYPES
-    subroutine matvec_${t1[0]}$${k1}$(self, vec_in, vec_out)
-        class(linop_${t1[0]}$${k1}$), intent(in)  :: self
-        class(abstract_vector_${t1[0]}$${k1}$)       , intent(in)  :: vec_in
-        class(abstract_vector_${t1[0]}$${k1}$)       , intent(out) :: vec_out
+    #:for kind, type in RC_KINDS_TYPES
+    subroutine matvec_${type[0]}$${kind}$(self, vec_in, vec_out)
+        class(linop_${type[0]}$${kind}$), intent(in)  :: self
+        class(abstract_vector_${type[0]}$${kind}$)       , intent(in)  :: vec_in
+        class(abstract_vector_${type[0]}$${kind}$)       , intent(out) :: vec_out
 
         select type(vec_in)
-        type is(vector_${t1[0]}$${k1}$)
+        type is(vector_${type[0]}$${kind}$)
             select type(vec_out)
-            type is(vector_${t1[0]}$${k1}$)
+            type is(vector_${type[0]}$${kind}$)
 
             vec_out%data = matmul(self%data, vec_in%data)
 
@@ -72,19 +73,19 @@ contains
         end select
 
         return
-    end subroutine matvec_${t1[0]}$${k1}$
+    end subroutine matvec_${type[0]}$${kind}$
 
-    subroutine rmatvec_${t1[0]}$${k1}$(self, vec_in, vec_out)
-        class(linop_${t1[0]}$${k1}$), intent(in)  :: self
-        class(abstract_vector_${t1[0]}$${k1}$)       , intent(in)  :: vec_in
-        class(abstract_vector_${t1[0]}$${k1}$)       , intent(out) :: vec_out
+    subroutine rmatvec_${type[0]}$${kind}$(self, vec_in, vec_out)
+        class(linop_${type[0]}$${kind}$), intent(in)  :: self
+        class(abstract_vector_${type[0]}$${kind}$)       , intent(in)  :: vec_in
+        class(abstract_vector_${type[0]}$${kind}$)       , intent(out) :: vec_out
 
         select type(vec_in)
-        type is(vector_${t1[0]}$${k1}$)
+        type is(vector_${type[0]}$${kind}$)
             select type(vec_out)
-            type is(vector_${t1[0]}$${k1}$)
+            type is(vector_${type[0]}$${kind}$)
 
-            #:if t1[0] == "c"
+            #:if type[0] == "c"
             vec_out%data = matmul(transpose(conjg(self%data)), vec_in%data)
             #:else
             vec_out%data = matmul(transpose(self%data), vec_in%data)
@@ -94,18 +95,18 @@ contains
         end select
 
         return
-    end subroutine rmatvec_${t1[0]}$${k1}$
+    end subroutine rmatvec_${type[0]}$${kind}$
 
-    #:if t1[0] == "r"
-    subroutine sdp_matvec_${t1[0]}$${k1}$(self, vec_in, vec_out)
-        class(spd_linop_${t1[0]}$${k1}$), intent(in)  :: self
-        class(abstract_vector_${t1[0]}$${k1}$)       , intent(in)  :: vec_in
-        class(abstract_vector_${t1[0]}$${k1}$)       , intent(out) :: vec_out
+    #:if type[0] == "r"
+    subroutine sdp_matvec_${type[0]}$${kind}$(self, vec_in, vec_out)
+        class(spd_linop_${type[0]}$${kind}$), intent(in)  :: self
+        class(abstract_vector_${type[0]}$${kind}$)       , intent(in)  :: vec_in
+        class(abstract_vector_${type[0]}$${kind}$)       , intent(out) :: vec_out
 
         select type(vec_in)
-        type is(vector_${t1[0]}$${k1}$)
+        type is(vector_${type[0]}$${kind}$)
             select type(vec_out)
-            type is(vector_${t1[0]}$${k1}$)
+            type is(vector_${type[0]}$${kind}$)
 
             vec_out%data = matmul(self%data, vec_in%data)
 
@@ -113,17 +114,17 @@ contains
         end select
 
         return
-    end subroutine sdp_matvec_${t1[0]}$${k1}$
+    end subroutine sdp_matvec_${type[0]}$${kind}$
     #:else
-    subroutine hermitian_matvec_${t1[0]}$${k1}$(self, vec_in, vec_out)
-        class(hermitian_linop_${t1[0]}$${k1}$), intent(in)  :: self
-        class(abstract_vector_${t1[0]}$${k1}$)       , intent(in)  :: vec_in
-        class(abstract_vector_${t1[0]}$${k1}$)       , intent(out) :: vec_out
+    subroutine hermitian_matvec_${type[0]}$${kind}$(self, vec_in, vec_out)
+        class(hermitian_linop_${type[0]}$${kind}$), intent(in)  :: self
+        class(abstract_vector_${type[0]}$${kind}$)       , intent(in)  :: vec_in
+        class(abstract_vector_${type[0]}$${kind}$)       , intent(out) :: vec_out
 
         select type(vec_in)
-        type is(vector_${t1[0]}$${k1}$)
+        type is(vector_${type[0]}$${kind}$)
             select type(vec_out)
-            type is(vector_${t1[0]}$${k1}$)
+            type is(vector_${type[0]}$${kind}$)
 
             vec_out%data = matmul(self%data, vec_in%data)
 
@@ -131,7 +132,7 @@ contains
         end select
 
         return
-    end subroutine hermitian_matvec_${t1[0]}$${k1}$
+    end subroutine hermitian_matvec_${type[0]}$${kind}$
    #:endif
 
     #:endfor
@@ -140,34 +141,34 @@ contains
     !-----     DEFINITIONS OF THE VARIOUS UNIT TESTS     -----
     !---------------------------------------------------------
 
-    #:for k1, t1 in RC_KINDS_TYPES
-    subroutine collect_linop_${t1[0]}$${k1}$_testsuite(testsuite)
+    #:for kind, type in RC_KINDS_TYPES
+    subroutine collect_linop_${type[0]}$${kind}$_testsuite(testsuite)
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-                    new_unittest("Matrix-vector product", test_matvec_${t1[0]}$${k1}$), &
-                    new_unittest("Tranpose Matrix-vector product", test_rmatvec_${t1[0]}$${k1}$),  &
-                    new_unittest("Adjoint Matrix-vector product", test_adjoint_matvec_${t1[0]}$${k1}$),  &
-                    new_unittest("Tranpose Adjoint Matrix-vector product", test_adjoint_rmatvec_${t1[0]}$${k1}$) &
+                    new_unittest("Matrix-vector product", test_matvec_${type[0]}$${kind}$), &
+                    new_unittest("Tranpose Matrix-vector product", test_rmatvec_${type[0]}$${kind}$),  &
+                    new_unittest("Adjoint Matrix-vector product", test_adjoint_matvec_${type[0]}$${kind}$),  &
+                    new_unittest("Tranpose Adjoint Matrix-vector product", test_adjoint_rmatvec_${type[0]}$${kind}$) &
                     ]
         return
-    end subroutine collect_linop_${t1[0]}$${k1}$_testsuite
+    end subroutine collect_linop_${type[0]}$${kind}$_testsuite
 
-    subroutine test_matvec_${t1[0]}$${k1}$(error)
+    subroutine test_matvec_${type[0]}$${kind}$(error)
         ! Error to be returned.
         type(error_type), allocatable, intent(out) :: error
         ! Test vectors.
-        type(vector_${t1[0]}$${k1}$), allocatable :: x, y
+        type(vector_${type[0]}$${kind}$), allocatable :: x, y
         ! Test LinOp.
-        type(linop_${t1[0]}$${k1}$), allocatable :: A
+        type(linop_${type[0]}$${kind}$), allocatable :: A
 
         ! Initialize vectors.
-        x = vector_${t1[0]}$${k1}$() ; call x%rand()
-        y = vector_${t1[0]}$${k1}$() ; call y%rand()
+        x = vector_${type[0]}$${kind}$() ; call x%rand()
+        y = vector_${type[0]}$${kind}$() ; call y%rand()
 
         ! Initialize matrix.
-        A = linop_${t1[0]}$${k1}$()
-        #:if t1[0] == "c"
+        A = linop_${type[0]}$${kind}$()
+        #:if type[0] == "c"
         call random_number(A%data%re) ; call random_number(A%data%im)
         #:else
         call random_number(A%data)
@@ -177,30 +178,30 @@ contains
         call A%matvec(x, y)
 
         ! Check result.
-        #:if t1[0] == "c"
-        call check(error, norm2(abs(y%data - matmul(A%data, x%data))) < rtol_${k1}$)
+        #:if type[0] == "c"
+        call check(error, norm2(abs(y%data - matmul(A%data, x%data))) < rtol_${kind}$)
         #:else
-        call check(error, norm2(y%data - matmul(A%data, x%data)) < rtol_${k1}$)
+        call check(error, norm2(y%data - matmul(A%data, x%data)) < rtol_${kind}$)
         #:endif
 
         return
-    end subroutine test_matvec_${t1[0]}$${k1}$
+    end subroutine test_matvec_${type[0]}$${kind}$
 
-    subroutine test_rmatvec_${t1[0]}$${k1}$(error)
+    subroutine test_rmatvec_${type[0]}$${kind}$(error)
         ! Error to be returned.
         type(error_type), allocatable, intent(out) :: error
         ! Test vectors.
-        type(vector_${t1[0]}$${k1}$), allocatable :: x, y
+        type(vector_${type[0]}$${kind}$), allocatable :: x, y
         ! Test LinOp.
-        type(linop_${t1[0]}$${k1}$), allocatable :: A
+        type(linop_${type[0]}$${kind}$), allocatable :: A
 
         ! Initialize vectors.
-        x = vector_${t1[0]}$${k1}$() ; call x%rand()
-        y = vector_${t1[0]}$${k1}$() ; call y%rand()
+        x = vector_${type[0]}$${kind}$() ; call x%rand()
+        y = vector_${type[0]}$${kind}$() ; call y%rand()
 
         ! Initialize matrix.
-        A = linop_${t1[0]}$${k1}$()
-        #:if t1[0] == "c"
+        A = linop_${type[0]}$${kind}$()
+        #:if type[0] == "c"
         call random_number(A%data%re) ; call random_number(A%data%im)
         #:else
         call random_number(A%data)
@@ -210,30 +211,30 @@ contains
         call A%rmatvec(x, y)
 
         ! Check result.
-        #:if t1[0] == "c"
-        call check(error, norm2(abs(y%data - matmul(transpose(conjg(A%data)), x%data))) < rtol_${k1}$)
+        #:if type[0] == "c"
+        call check(error, norm2(abs(y%data - matmul(transpose(conjg(A%data)), x%data))) < rtol_${kind}$)
         #:else
-        call check(error, norm2(y%data - matmul(transpose(A%data), x%data)) < rtol_${k1}$)
+        call check(error, norm2(y%data - matmul(transpose(A%data), x%data)) < rtol_${kind}$)
         #:endif
         
         return
-    end subroutine test_rmatvec_${t1[0]}$${k1}$
+    end subroutine test_rmatvec_${type[0]}$${kind}$
 
-    subroutine test_adjoint_matvec_${t1[0]}$${k1}$(error)
+    subroutine test_adjoint_matvec_${type[0]}$${kind}$(error)
         ! Error type to be returned.
         type(error_type), allocatable, intent(out) :: error
         ! Test vectors.
-        type(vector_${t1[0]}$${k1}$), allocatable :: x, y
+        type(vector_${type[0]}$${kind}$), allocatable :: x, y
         ! Test LinOp.
-        type(linop_${t1[0]}$${k1}$), allocatable :: A
-        type(adjoint_linop_${t1[0]}$${k1}$), allocatable :: B
+        type(linop_${type[0]}$${kind}$), allocatable :: A
+        type(adjoint_linop_${type[0]}$${kind}$), allocatable :: B
 
         ! Internal variable.
-        real(${k1}$) :: alpha
+        real(${kind}$) :: alpha
 
         ! Initialize matrix.
-        A = linop_${t1[0]}$${k1}$()
-        #:if t1[0] == "c"
+        A = linop_${type[0]}$${kind}$()
+        #:if type[0] == "c"
         call random_number(A%data%re) ; call random_number(A%data%im)
         #:else
         call random_number(A%data)
@@ -243,39 +244,39 @@ contains
         allocate(B) ; B%A = A
 
         ! Initialize vectors.
-        x = vector_${t1[0]}$${k1}$() ; call x%rand()
-        y = vector_${t1[0]}$${k1}$() ; call y%zero()
+        x = vector_${type[0]}$${kind}$() ; call x%rand()
+        y = vector_${type[0]}$${kind}$() ; call y%zero()
 
         ! Compute adjoint matrix-vector product
         call B%matvec(x, y)
 
         ! Check result.
-        #:if t1[0] == "c"
+        #:if type[0] == "c"
         alpha = norm2(abs(y%data - matmul(transpose(conjg(A%data)), x%data)))
         #:else
         alpha = norm2(y%data - matmul(transpose(A%data), x%data))
         #:endif
 
-        call check(error, alpha < rtol_${k1}$)
+        call check(error, alpha < rtol_${kind}$)
 
        return
-    end subroutine test_adjoint_matvec_${t1[0]}$${k1}$
+    end subroutine test_adjoint_matvec_${type[0]}$${kind}$
 
-    subroutine test_adjoint_rmatvec_${t1[0]}$${k1}$(error)
+    subroutine test_adjoint_rmatvec_${type[0]}$${kind}$(error)
         ! Error type to be returned.
         type(error_type), allocatable, intent(out) :: error
         ! Test vectors.
-        type(vector_${t1[0]}$${k1}$), allocatable :: x, y
+        type(vector_${type[0]}$${kind}$), allocatable :: x, y
         ! Test LinOp.
-        type(linop_${t1[0]}$${k1}$), allocatable :: A
-        type(adjoint_linop_${t1[0]}$${k1}$), allocatable :: B
+        type(linop_${type[0]}$${kind}$), allocatable :: A
+        type(adjoint_linop_${type[0]}$${kind}$), allocatable :: B
 
         ! Internal variable.
-        real(${k1}$) :: alpha
+        real(${kind}$) :: alpha
 
         ! Initialize matrix.
-        A = linop_${t1[0]}$${k1}$()
-        #:if t1[0] == "c"
+        A = linop_${type[0]}$${kind}$()
+        #:if type[0] == "c"
         call random_number(A%data%re) ; call random_number(A%data%im)
         #:else
         call random_number(A%data)
@@ -285,23 +286,23 @@ contains
         allocate(B) ; B%A = A
 
         ! Initialize vectors.
-        x = vector_${t1[0]}$${k1}$() ; call x%rand()
-        y = vector_${t1[0]}$${k1}$() ; call y%zero()
+        x = vector_${type[0]}$${kind}$() ; call x%rand()
+        y = vector_${type[0]}$${kind}$() ; call y%zero()
 
         ! Compute adjoint matrix-vector product
         call B%rmatvec(x, y)
 
         ! Check result.
-        #:if t1[0] == "c"
+        #:if type[0] == "c"
         alpha = norm2(abs(y%data - matmul(A%data, x%data)))
         #:else
         alpha = norm2(y%data - matmul(A%data, x%data))
         #:endif
 
-        call check(error, alpha < rtol_${k1}$)
+        call check(error, alpha < rtol_${kind}$)
 
        return
-    end subroutine test_adjoint_rmatvec_${t1[0]}$${k1}$
+    end subroutine test_adjoint_rmatvec_${type[0]}$${kind}$
 
 
     #:endfor

--- a/test/TestLinops.fypp
+++ b/test/TestLinops.fypp
@@ -12,7 +12,10 @@ module TestLinops
     use TestVectors
 
     implicit none
+    
     private
+
+    character*128, parameter, private :: this_module = 'LightKrylov_TestLinops'
 
     #:for k1, t1 in RC_KINDS_TYPES
     public :: collect_linop_${t1[0]}$${k1}$_testsuite

--- a/test/TestUtils.f90
+++ b/test/TestUtils.f90
@@ -1,6 +1,7 @@
 module TestUtils
     use stdlib_io_npy, only: save_npy
     use LightKrylov
+    use LightKrylov_Constants
     use TestVectors
     use TestLinops
     

--- a/test/TestUtils.f90
+++ b/test/TestUtils.f90
@@ -3,9 +3,12 @@ module TestUtils
     use LightKrylov
     use TestVectors
     use TestLinops
+    
     implicit none
     
     private
+
+    character*128, parameter, private :: this_module = 'LightKrylov_TestUtils'
 
     public :: get_data
     public :: put_data

--- a/test/TestUtils.fypp
+++ b/test/TestUtils.fypp
@@ -5,9 +5,12 @@ module TestUtils
     use LightKrylov
     use TestVectors
     use TestLinops
+    
     implicit none
     
     private
+
+    character*128, parameter, private :: this_module = 'LightKrylov_TestUtils'
 
     public :: get_data
     public :: put_data

--- a/test/TestUtils.fypp
+++ b/test/TestUtils.fypp
@@ -3,6 +3,7 @@
 module TestUtils
     use stdlib_io_npy, only: save_npy
     use LightKrylov
+    use LightKrylov_Constants
     use TestVectors
     use TestLinops
     
@@ -17,30 +18,30 @@ module TestUtils
     public :: init_rand
 
     interface get_data
-        #:for k1, t1 in RC_KINDS_TYPES
-        module procedure get_data_vec_${t1[0]}$${k1}$
-        module procedure get_data_vec_basis_${t1[0]}$${k1}$
-        module procedure get_data_linop_${t1[0]}$${k1}$
+        #:for kind, type in RC_KINDS_TYPES
+        module procedure get_data_vec_${type[0]}$${kind}$
+        module procedure get_data_vec_basis_${type[0]}$${kind}$
+        module procedure get_data_linop_${type[0]}$${kind}$
         #:endfor
     end interface
 
     interface put_data
-        #:for k1, t1 in RC_KINDS_TYPES
-        module procedure put_data_vec_${t1[0]}$${k1}$
-        module procedure put_data_vec_basis_${t1[0]}$${k1}$
-        module procedure put_data_linop_${t1[0]}$${k1}$
+        #:for kind, type in RC_KINDS_TYPES
+        module procedure put_data_vec_${type[0]}$${kind}$
+        module procedure put_data_vec_basis_${type[0]}$${kind}$
+        module procedure put_data_linop_${type[0]}$${kind}$
         #:endfor
     end interface
 
     interface init_rand
-        #:for k1, t1 in RC_KINDS_TYPES
-        module procedure init_rand_vec_${t1[0]}$${k1}$
-        module procedure init_rand_basis_${t1[0]}$${k1}$
-        module procedure init_rand_linop_${t1[0]}$${k1}$
-        #:if t1[0] == "r"
-        module procedure init_rand_spd_linop_${t1[0]}$${k1}$
+        #:for kind, type in RC_KINDS_TYPES
+        module procedure init_rand_vec_${type[0]}$${kind}$
+        module procedure init_rand_basis_${type[0]}$${kind}$
+        module procedure init_rand_linop_${type[0]}$${kind}$
+        #:if type[0] == "r"
+        module procedure init_rand_spd_linop_${type[0]}$${kind}$
         #:else
-        module procedure init_rand_hermitian_linop_${t1[0]}$${k1}$
+        module procedure init_rand_hermitian_linop_${type[0]}$${kind}$
         #:endif
         #:endfor
     end interface
@@ -51,19 +52,19 @@ contains
     !-----     EXTRACT DATA FROM ABSTRACT TYPES     -----
     !----------------------------------------------------
 
-    #:for k1, t1 in RC_KINDS_TYPES
-    subroutine get_data_vec_${t1[0]}$${k1}$(vec_out, vec_in)
-        ${t1}$, intent(out) :: vec_out(:)
-        type(vector_${t1[0]}$${k1}$), intent(in) :: vec_in
+    #:for kind, type in RC_KINDS_TYPES
+    subroutine get_data_vec_${type[0]}$${kind}$(vec_out, vec_in)
+        ${type}$, intent(out) :: vec_out(:)
+        type(vector_${type[0]}$${kind}$), intent(in) :: vec_in
         ! Internal variables.
         integer :: k, kdim
         vec_out = vec_in%data
         return
-    end subroutine get_data_vec_${t1[0]}$${k1}$
+    end subroutine get_data_vec_${type[0]}$${kind}$
 
-    subroutine get_data_vec_basis_${t1[0]}$${k1}$(basis_out, basis_in)
-        ${t1}$, intent(out) :: basis_out(:, :)
-        type(vector_${t1[0]}$${k1}$), intent(in) :: basis_in(:)
+    subroutine get_data_vec_basis_${type[0]}$${kind}$(basis_out, basis_in)
+        ${type}$, intent(out) :: basis_out(:, :)
+        type(vector_${type[0]}$${kind}$), intent(in) :: basis_in(:)
         ! Internal variables.
         integer :: k, kdim
         kdim = size(basis_in)
@@ -71,14 +72,14 @@ contains
             basis_out(:, k) = basis_in(k)%data
         enddo
         return
-    end subroutine get_data_vec_basis_${t1[0]}$${k1}$
+    end subroutine get_data_vec_basis_${type[0]}$${kind}$
 
-    subroutine get_data_linop_${t1[0]}$${k1}$(mat_out, linop_in)
-        ${t1}$, intent(out) :: mat_out(:, :)
-        type(linop_${t1[0]}$${k1}$), intent(in) :: linop_in
+    subroutine get_data_linop_${type[0]}$${kind}$(mat_out, linop_in)
+        ${type}$, intent(out) :: mat_out(:, :)
+        type(linop_${type[0]}$${kind}$), intent(in) :: linop_in
         mat_out = linop_in%data
         return
-    end subroutine get_data_linop_${t1[0]}$${k1}$
+    end subroutine get_data_linop_${type[0]}$${kind}$
 
     #:endfor
 
@@ -86,32 +87,32 @@ contains
     !-----     PUT DATA TO ABSTRACT TYPES     -----
     !----------------------------------------------
 
-    #:for k1, t1 in RC_KINDS_TYPES
-    subroutine put_data_vec_${t1[0]}$${k1}$(vec_out, vec_in)
-        type(vector_${t1[0]}$${k1}$), intent(out) :: vec_out
-        ${t1}$, intent(in) :: vec_in
+    #:for kind, type in RC_KINDS_TYPES
+    subroutine put_data_vec_${type[0]}$${kind}$(vec_out, vec_in)
+        type(vector_${type[0]}$${kind}$), intent(out) :: vec_out
+        ${type}$, intent(in) :: vec_in
         vec_out%data = vec_in
         return
-    end subroutine put_data_vec_${t1[0]}$${k1}$
+    end subroutine put_data_vec_${type[0]}$${kind}$
 
-    subroutine put_data_vec_basis_${t1[0]}$${k1}$(basis_out, basis_in)
-        type(vector_${t1[0]}$${k1}$), intent(out) :: basis_out(:)
-        ${t1}$, intent(in) :: basis_in(:, :)
+    subroutine put_data_vec_basis_${type[0]}$${kind}$(basis_out, basis_in)
+        type(vector_${type[0]}$${kind}$), intent(out) :: basis_out(:)
+        ${type}$, intent(in) :: basis_in(:, :)
         ! Internal variables.
         integer :: k
         do k = 1, size(basis_out)
             basis_out(k)%data = basis_in(:, k)
         enddo
         return
-    end subroutine put_data_vec_basis_${t1[0]}$${k1}$
+    end subroutine put_data_vec_basis_${type[0]}$${kind}$
 
-    subroutine put_data_linop_${t1[0]}$${k1}$(linop_out, mat_in)
-        type(linop_${t1[0]}$${k1}$), intent(out) :: linop_out
-        ${t1}$, intent(in) :: mat_in(:, :)
+    subroutine put_data_linop_${type[0]}$${kind}$(linop_out, mat_in)
+        type(linop_${type[0]}$${kind}$), intent(out) :: linop_out
+        ${type}$, intent(in) :: mat_in(:, :)
         ! Internal variables.
         linop_out%data = mat_in
         return
-    end subroutine put_data_linop_${t1[0]}$${k1}$
+    end subroutine put_data_linop_${type[0]}$${kind}$
 
     #:endfor
 
@@ -119,58 +120,58 @@ contains
     !-----     INITIALIZE ABSTRACT TYPES WITH RANDOM DATA     -----
     !--------------------------------------------------------------
 
-    #:for k1, t1 in RC_KINDS_TYPES
-    subroutine init_rand_vec_${t1[0]}$${k1}$(x)
-        type(vector_${t1[0]}$${k1}$), intent(inout) :: x
+    #:for kind, type in RC_KINDS_TYPES
+    subroutine init_rand_vec_${type[0]}$${kind}$(x)
+        type(vector_${type[0]}$${kind}$), intent(inout) :: x
         call x%rand()
         return
-    end subroutine init_rand_vec_${t1[0]}$${k1}$
+    end subroutine init_rand_vec_${type[0]}$${kind}$
 
-    subroutine init_rand_basis_${t1[0]}$${k1}$(X)
-        type(vector_${t1[0]}$${k1}$), intent(inout) :: X(:)
+    subroutine init_rand_basis_${type[0]}$${kind}$(X)
+        type(vector_${type[0]}$${kind}$), intent(inout) :: X(:)
         integer :: i
         do i = 1, size(X)
             call X(i)%rand()
         enddo
         return
-    end subroutine init_rand_basis_${t1[0]}$${k1}$
+    end subroutine init_rand_basis_${type[0]}$${kind}$
 
-    subroutine init_rand_linop_${t1[0]}$${k1}$(linop)
-        type(linop_${t1[0]}$${k1}$), intent(inout) :: linop
-        #:if t1[0] == "c"
-        real(${k1}$), dimension(test_size, test_size, 2) :: data
-        call random_number(data) ; data = data - 0.5_${k1}$
+    subroutine init_rand_linop_${type[0]}$${kind}$(linop)
+        type(linop_${type[0]}$${kind}$), intent(inout) :: linop
+        #:if type[0] == "c"
+        real(${kind}$), dimension(test_size, test_size, 2) :: data
+        call random_number(data) ; data = data - 0.5_${kind}$
         linop%data%re = data(:, :, 1)
         linop%data%im = data(:, :, 2)
         #:else
         call random_number(linop%data)
         #:endif
         return
-    end subroutine init_rand_linop_${t1[0]}$${k1}$
+    end subroutine init_rand_linop_${type[0]}$${kind}$
 
-    #:if t1[0] == "r"
-    subroutine init_rand_spd_linop_${t1[0]}$${k1}$(linop)
-        type(spd_linop_${t1[0]}$${k1}$), intent(inout) :: linop
-        ${t1}$, dimension(test_size, 2*test_size) :: data
+    #:if type[0] == "r"
+    subroutine init_rand_spd_linop_${type[0]}$${kind}$(linop)
+        type(spd_linop_${type[0]}$${kind}$), intent(inout) :: linop
+        ${type}$, dimension(test_size, 2*test_size) :: data
         integer :: i
-        call random_number(data) ; data = data - 0.5_${k1}$
+        call random_number(data) ; data = data - 0.5_${kind}$
         linop%data = matmul(data, transpose(data)) / 4
         return
-    end subroutine init_rand_spd_linop_${t1[0]}$${k1}$
+    end subroutine init_rand_spd_linop_${type[0]}$${kind}$
     #:else
-    subroutine init_rand_hermitian_linop_${t1[0]}$${k1}$(linop)
-        type(hermitian_linop_${t1[0]}$${k1}$), intent(inout) :: linop
-        real(${k1}$), dimension(test_size, 2*test_size, 2) :: data
-        ${t1}$, dimension(test_size, 2*test_size) :: data_c
-        ${t1}$, dimension(test_size, test_size) :: matrix
+    subroutine init_rand_hermitian_linop_${type[0]}$${kind}$(linop)
+        type(hermitian_linop_${type[0]}$${kind}$), intent(inout) :: linop
+        real(${kind}$), dimension(test_size, 2*test_size, 2) :: data
+        ${type}$, dimension(test_size, 2*test_size) :: data_c
+        ${type}$, dimension(test_size, test_size) :: matrix
         integer :: i
         call random_number(data)
-        data_c%re = data(:, :, 1) - 0.5_${k1}$
-        data_c%im = data(:, :, 2) - 0.5_${k1}$
+        data_c%re = data(:, :, 1) - 0.5_${kind}$
+        data_c%im = data(:, :, 2) - 0.5_${kind}$
         matrix = matmul(data_c, transpose(conjg(data_c))) / 4
         linop%data = matrix
         return
-    end subroutine init_rand_hermitian_linop_${t1[0]}$${k1}$
+    end subroutine init_rand_hermitian_linop_${type[0]}$${kind}$
     #:endif
 
     #:endfor

--- a/test/TestVectors.f90
+++ b/test/TestVectors.f90
@@ -3,8 +3,12 @@ module TestVectors
     use testdrive, only: new_unittest, unittest_type, error_type, check
     use stdlib_math, only: is_close, all_close
     use stdlib_optval, only: optval
+    
     implicit none
+    
     private
+
+    character*128, parameter, private :: this_module = 'LightKrylov_TestVectors'
 
     integer, parameter, public :: test_size = 128
 

--- a/test/TestVectors.fypp
+++ b/test/TestVectors.fypp
@@ -14,21 +14,21 @@ module TestVectors
 
     integer, parameter, public :: test_size = 128
 
-    #:for k1, t1 in RC_KINDS_TYPES
-    public :: collect_vector_${t1[0]}$${k1}$_testsuite
+    #:for kind, type in RC_KINDS_TYPES
+    public :: collect_vector_${type[0]}$${kind}$_testsuite
     #:endfor
 
-    #:for k1, t1 in RC_KINDS_TYPES
-    type, extends(abstract_vector_${t1[0]}$${k1}$), public :: vector_${t1[0]}$${k1}$
-        ${t1}$, dimension(test_size) :: data = 0.0_${k1}$
+    #:for kind, type in RC_KINDS_TYPES
+    type, extends(abstract_vector_${type[0]}$${kind}$), public :: vector_${type[0]}$${kind}$
+        ${type}$, dimension(test_size) :: data = 0.0_${kind}$
     contains
         private
-        procedure, pass(self), public :: zero => zero_${t1[0]}$${k1}$
-        procedure, pass(self), public :: dot => dot_${t1[0]}$${k1}$
-        procedure, pass(self), public :: scal => scal_${t1[0]}$${k1}$
-        procedure, pass(self), public :: axpby => axpby_${t1[0]}$${k1}$
-        procedure, pass(self), public :: rand => rand_${t1[0]}$${k1}$
-    end type vector_${t1[0]}$${k1}$
+        procedure, pass(self), public :: zero => zero_${type[0]}$${kind}$
+        procedure, pass(self), public :: dot => dot_${type[0]}$${kind}$
+        procedure, pass(self), public :: scal => scal_${type[0]}$${kind}$
+        procedure, pass(self), public :: axpby => axpby_${type[0]}$${kind}$
+        procedure, pass(self), public :: rand => rand_${type[0]}$${kind}$
+    end type vector_${type[0]}$${kind}$
 
     #:endfor
 contains
@@ -37,50 +37,50 @@ contains
     !-----     DEFINITIONS OF THE VARIOUS TYPE-BOUND PROCEDURES     -----
     !--------------------------------------------------------------------
 
-    #:for k1, t1 in RC_KINDS_TYPES
-    subroutine zero_${t1[0]}$${k1}$(self)
-        class(vector_${t1[0]}$${k1}$), intent(inout) :: self
-        self%data = 0.0_${k1}$
+    #:for kind, type in RC_KINDS_TYPES
+    subroutine zero_${type[0]}$${kind}$(self)
+        class(vector_${type[0]}$${kind}$), intent(inout) :: self
+        self%data = 0.0_${kind}$
         return
-    end subroutine zero_${t1[0]}$${k1}$
+    end subroutine zero_${type[0]}$${kind}$
 
-    function dot_${t1[0]}$${k1}$(self, vec) result(alpha)
-        class(vector_${t1[0]}$${k1}$), intent(in) :: self
-        class(abstract_vector_${t1[0]}$${k1}$), intent(in) :: vec
-        ${t1}$ :: alpha
+    function dot_${type[0]}$${kind}$(self, vec) result(alpha)
+        class(vector_${type[0]}$${kind}$), intent(in) :: self
+        class(abstract_vector_${type[0]}$${kind}$), intent(in) :: vec
+        ${type}$ :: alpha
 
         select type(vec)
-        type is(vector_${t1[0]}$${k1}$)
+        type is(vector_${type[0]}$${kind}$)
             alpha = dot_product(self%data, vec%data)
         end select
-    end function dot_${t1[0]}$${k1}$
+    end function dot_${type[0]}$${kind}$
 
-    subroutine scal_${t1[0]}$${k1}$(self, alpha)
-        class(vector_${t1[0]}$${k1}$), intent(inout) :: self
-        ${t1}$, intent(in) :: alpha
+    subroutine scal_${type[0]}$${kind}$(self, alpha)
+        class(vector_${type[0]}$${kind}$), intent(inout) :: self
+        ${type}$, intent(in) :: alpha
         self%data = alpha * self%data
         return
-    end subroutine scal_${t1[0]}$${k1}$
+    end subroutine scal_${type[0]}$${kind}$
 
-    subroutine axpby_${t1[0]}$${k1}$(self, alpha, vec, beta)
-        class(vector_${t1[0]}$${k1}$), intent(inout) :: self
-        class(abstract_vector_${t1[0]}$${k1}$), intent(in) :: vec
-        ${t1}$, intent(in) :: alpha, beta
+    subroutine axpby_${type[0]}$${kind}$(self, alpha, vec, beta)
+        class(vector_${type[0]}$${kind}$), intent(inout) :: self
+        class(abstract_vector_${type[0]}$${kind}$), intent(in) :: vec
+        ${type}$, intent(in) :: alpha, beta
 
         select type(vec)
-        type is(vector_${t1[0]}$${k1}$)
+        type is(vector_${type[0]}$${kind}$)
             self%data = alpha*self%data + beta*vec%data
         end select
         return
     end subroutine
 
-    subroutine rand_${t1[0]}$${k1}$(self, ifnorm)
-        class(vector_${t1[0]}$${k1}$), intent(inout) :: self
+    subroutine rand_${type[0]}$${kind}$(self, ifnorm)
+        class(vector_${type[0]}$${kind}$), intent(inout) :: self
         logical, optional, intent(in) :: ifnorm
         logical :: normalized
-        ${t1}$ :: alpha
-        #:if t1[0] == "c"
-        real(${k1}$), dimension(test_size, 2) :: data
+        ${type}$ :: alpha
+        #:if type[0] == "c"
+        real(${kind}$), dimension(test_size, 2) :: data
 
         call random_number(data)
         self%data%re = data(:, 1)
@@ -92,9 +92,9 @@ contains
         normalized = optval(ifnorm, .false.)
         if (normalized) then
             alpha = self%norm()
-            call self%scal(1.0_${k1}$/alpha)
+            call self%scal(1.0_${kind}$/alpha)
         endif
-    end subroutine rand_${t1[0]}$${k1}$
+    end subroutine rand_${type[0]}$${kind}$
 
     #:endfor
     
@@ -102,129 +102,129 @@ contains
     !-----     DEFINITIONS OF THE VARIOUS UNIT TESTS     -----
     !---------------------------------------------------------
 
-    #:for k1, t1 in RC_KINDS_TYPES
-    subroutine collect_vector_${t1[0]}$${k1}$_testsuite(testsuite)
+    #:for kind, type in RC_KINDS_TYPES
+    subroutine collect_vector_${type[0]}$${kind}$_testsuite(testsuite)
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-                    new_unittest("Vector norm", test_vector_${t1[0]}$${k1}$_norm)      , &
-                    new_unittest("Vector scale", test_vector_${t1[0]}$${k1}$_scal)     , &
-                    new_unittest("Vector addition", test_vector_${t1[0]}$${k1}$_add)   , &
-                    new_unittest("Vector subtraction", test_vector_${t1[0]}$${k1}$_sub), &
-                    new_unittest("Vector dot product", test_vector_${t1[0]}$${k1}$_dot)  &
+                    new_unittest("Vector norm", test_vector_${type[0]}$${kind}$_norm)      , &
+                    new_unittest("Vector scale", test_vector_${type[0]}$${kind}$_scal)     , &
+                    new_unittest("Vector addition", test_vector_${type[0]}$${kind}$_add)   , &
+                    new_unittest("Vector subtraction", test_vector_${type[0]}$${kind}$_sub), &
+                    new_unittest("Vector dot product", test_vector_${type[0]}$${kind}$_dot)  &
                     ]
         return
-    end subroutine collect_vector_${t1[0]}$${k1}$_testsuite
+    end subroutine collect_vector_${type[0]}$${kind}$_testsuite
 
-    subroutine test_vector_${t1[0]}$${k1}$_norm(error)
+    subroutine test_vector_${type[0]}$${kind}$_norm(error)
         ! Error type to be returned.
         type(error_type), allocatable, intent(out) :: error
         ! Test vector.
-        type(vector_${t1[0]}$${k1}$), allocatable :: x
-        real(${k1}$) :: alpha
+        type(vector_${type[0]}$${kind}$), allocatable :: x
+        real(${kind}$) :: alpha
 
         ! Initialize vector.
-        x = vector_${t1[0]}$${k1}$() ; call x%rand()
+        x = vector_${type[0]}$${kind}$() ; call x%rand()
         
         ! Compute its norm.
         alpha = x%norm()
 
         ! Check result.
-        #:if t1[0] == "c"
+        #:if type[0] == "c"
         call check(error, is_close(alpha, sqrt(sum(x%data%re**2 + x%data%im**2))))
         #:else
         call check(error, is_close(alpha, norm2(x%data)))
         #:endif
         
         return
-    end subroutine test_vector_${t1[0]}$${k1}$_norm
+    end subroutine test_vector_${type[0]}$${kind}$_norm
 
-    subroutine test_vector_${t1[0]}$${k1}$_add(error)
+    subroutine test_vector_${type[0]}$${kind}$_add(error)
         ! Error type to be returned.
         type(error_type), allocatable, intent(out) :: error
 
         ! Test vectors.
-        type(vector_${t1[0]}$${k1}$), allocatable :: x, y, z
+        type(vector_${type[0]}$${kind}$), allocatable :: x, y, z
 
         ! Initialize vectors.
-        x = vector_${t1[0]}$${k1}$() ; call x%rand()
-        y = vector_${t1[0]}$${k1}$() ; call y%rand()
+        x = vector_${type[0]}$${kind}$() ; call x%rand()
+        y = vector_${type[0]}$${kind}$() ; call y%rand()
         z = x
 
         ! Vector addition.
         call z%add(y)
 
         ! Check correctness.
-        #:if t1[0] == "c"
-        call check(error, sqrt(sum((z%data%re - x%data%re - y%data%re)**2 + (z%data%im - x%data%im - y%data%im)**2)) < rtol_${k1}$)
+        #:if type[0] == "c"
+        call check(error, sqrt(sum((z%data%re - x%data%re - y%data%re)**2 + (z%data%im - x%data%im - y%data%im)**2)) < rtol_${kind}$)
         #:else
-        call check(error, norm2(z%data - x%data - y%data) < rtol_${k1}$)
+        call check(error, norm2(z%data - x%data - y%data) < rtol_${kind}$)
         #:endif
 
         return
-    end subroutine test_vector_${t1[0]}$${k1}$_add
+    end subroutine test_vector_${type[0]}$${kind}$_add
  
-    subroutine test_vector_${t1[0]}$${k1}$_sub(error)
+    subroutine test_vector_${type[0]}$${kind}$_sub(error)
         ! Error type to be returned.
         type(error_type), allocatable, intent(out) :: error
 
         ! Test vectors.
-        type(vector_${t1[0]}$${k1}$), allocatable :: x, y, z
+        type(vector_${type[0]}$${kind}$), allocatable :: x, y, z
 
         ! Initialize vectors.
-        x = vector_${t1[0]}$${k1}$() ; call x%rand()
-        y = vector_${t1[0]}$${k1}$() ; call y%rand()
+        x = vector_${type[0]}$${kind}$() ; call x%rand()
+        y = vector_${type[0]}$${kind}$() ; call y%rand()
         z = x
 
         ! Vector addition.
         call z%sub(y)
 
         ! Check correctness.
-        #:if t1[0] == "c"
-        call check(error, sqrt(sum((z%data%re - x%data%re + y%data%re)**2 + (z%data%im - x%data%im + y%data%im)**2)) < rtol_${k1}$)
+        #:if type[0] == "c"
+        call check(error, sqrt(sum((z%data%re - x%data%re + y%data%re)**2 + (z%data%im - x%data%im + y%data%im)**2)) < rtol_${kind}$)
         #:else
-        call check(error, norm2(z%data - x%data + y%data) < rtol_${k1}$)
+        call check(error, norm2(z%data - x%data + y%data) < rtol_${kind}$)
         #:endif
 
         return
-    end subroutine test_vector_${t1[0]}$${k1}$_sub
+    end subroutine test_vector_${type[0]}$${kind}$_sub
 
-    subroutine test_vector_${t1[0]}$${k1}$_dot(error)
+    subroutine test_vector_${type[0]}$${kind}$_dot(error)
         ! Error type to be returned.
         type(error_type), allocatable, intent(out) :: error
 
         ! Test vectors.
-        type(vector_${t1[0]}$${k1}$), allocatable :: x, y
-        ${t1}$ :: alpha
+        type(vector_${type[0]}$${kind}$), allocatable :: x, y
+        ${type}$ :: alpha
 
         ! Initialize vectors.
-        x = vector_${t1[0]}$${k1}$() ; call x%rand()
-        y = vector_${t1[0]}$${k1}$() ; call y%rand()
+        x = vector_${type[0]}$${kind}$() ; call x%rand()
+        y = vector_${type[0]}$${kind}$() ; call y%rand()
 
         ! Compute inner-product.
         alpha = x%dot(y)
 
         ! Check correctness.
-        call check(error, abs(alpha - dot_product(x%data, y%data)) < rtol_${k1}$)
+        call check(error, abs(alpha - dot_product(x%data, y%data)) < rtol_${kind}$)
 
         return
-    end subroutine test_vector_${t1[0]}$${k1}$_dot
+    end subroutine test_vector_${type[0]}$${kind}$_dot
 
-    subroutine test_vector_${t1[0]}$${k1}$_scal(error)
+    subroutine test_vector_${type[0]}$${kind}$_scal(error)
         ! Error type to be returned.
         type(error_type), allocatable, intent(out) :: error
 
         ! Test vector.
-        type(vector_${t1[0]}$${k1}$), allocatable :: x, y
-        ${t1}$ :: alpha
-        #:if t1[0] == "c"
-        ${t1}$ :: tmp(test_size)
+        type(vector_${type[0]}$${kind}$), allocatable :: x, y
+        ${type}$ :: alpha
+        #:if type[0] == "c"
+        ${type}$ :: tmp(test_size)
         #:endif
 
         ! Initialize vector.
-        x = vector_${t1[0]}$${k1}$() ; call x%rand()
+        x = vector_${type[0]}$${kind}$() ; call x%rand()
         y = x
-        #:if t1[0] == "c"
+        #:if type[0] == "c"
         call random_number(alpha%re) ; call random_number(alpha%im)
         #:else
         call random_number(alpha)
@@ -234,15 +234,15 @@ contains
         call x%scal(alpha)
 
         ! Check correctness.
-        #:if t1[0] == "c"
+        #:if type[0] == "c"
         tmp = x%data - alpha*y%data
-        call check(error, sqrt(sum(tmp%re**2 + tmp%im**2)) < rtol_${k1}$)
+        call check(error, sqrt(sum(tmp%re**2 + tmp%im**2)) < rtol_${kind}$)
         #:else
-        call check(error, norm2(x%data - alpha*y%data) < rtol_${k1}$)
+        call check(error, norm2(x%data - alpha*y%data) < rtol_${kind}$)
         #:endif
 
         return
-    end subroutine test_vector_${t1[0]}$${k1}$_scal
+    end subroutine test_vector_${type[0]}$${kind}$_scal
 
     #:endfor
 

--- a/test/TestVectors.fypp
+++ b/test/TestVectors.fypp
@@ -5,8 +5,12 @@ module TestVectors
     use testdrive, only: new_unittest, unittest_type, error_type, check
     use stdlib_math, only: is_close, all_close
     use stdlib_optval, only: optval
+    
     implicit none
+    
     private
+
+    character*128, parameter, private :: this_module = 'LightKrylov_TestVectors'
 
     integer, parameter, public :: test_size = 128
 

--- a/test/Tests.f90
+++ b/test/Tests.f90
@@ -81,7 +81,7 @@ program Tester
                 new_testsuite("Real Arnoldi (dp) Test Suite", collect_arnoldi_rdp_testsuite), &
                 new_testsuite("Real Lanczos bidiagonalization (dp) Test Suite", collect_lanczos_bidiag_rdp_testsuite), &
                 new_testsuite("Real Lanczos tridiagonalization (dp) Test Suite", collect_lanczos_tridiag_rdp_testsuite), &
-                !new_testsuite("Real EVP (dp) Test Suite", collect_eig_rdp_testsuite), &
+                new_testsuite("Real EVP (dp) Test Suite", collect_eig_rdp_testsuite), &
                 new_testsuite("Real SVD (dp) Test Suite", collect_svd_rdp_testsuite), &
                 new_testsuite("Real GMRES (dp) Test Suite", collect_gmres_rdp_testsuite), &
                 new_testsuite("Real CG (dp) Test Suite", collect_cg_rdp_testsuite), &


### PR DESCRIPTION
- `innerprod`, deployed throughout
- `orthogonalize_against_basis`, deployed throughout the toolbox.
- `one_*`/`zero_*` -> `LightKrylov_Constants`
- Improved logging
- Streamlined testing to avoid multiple solver calls.
- Added test for eigen/singular values and associated vectors for iterative eigen/svd solvers
- Homogenization of the files.