### PR TITLE
Added default eigenvalue selection routine for `krylov_schur` in `eigs`

### DIFF
--- a/src/AbstractLinops.f90
+++ b/src/AbstractLinops.f90
@@ -3,8 +3,9 @@ module lightkrylov_AbstractLinops
     use lightkrylov_utils
     use lightkrylov_AbstractVectors
     implicit none
+    private
 
-    character*128, parameter, private :: this_module = 'Lightkrylov_AbstractLinops'
+    character*128, parameter :: this_module = 'Lightkrylov_AbstractLinops'
 
     type, abstract, public :: abstract_linop
     contains
@@ -12,10 +13,6 @@ module lightkrylov_AbstractLinops
         procedure, pass(from), public :: copy
         generic, public :: assignment(=) => copy
     end type abstract_linop
-
-
-
-
 
     !------------------------------------------------------------------------------
     !-----     Definition of an abstract real(sp) operator with kind=sp     -----

--- a/src/AbstractLinops.fypp
+++ b/src/AbstractLinops.fypp
@@ -5,8 +5,9 @@ module lightkrylov_AbstractLinops
     use lightkrylov_utils
     use lightkrylov_AbstractVectors
     implicit none
+    private
 
-    character*128, parameter, private :: this_module = 'Lightkrylov_AbstractLinops'
+    character*128, parameter :: this_module = 'Lightkrylov_AbstractLinops'
 
     type, abstract, public :: abstract_linop
     contains
@@ -14,10 +15,6 @@ module lightkrylov_AbstractLinops
         procedure, pass(from), public :: copy
         generic, public :: assignment(=) => copy
     end type abstract_linop
-
-
-
-
 
     #:for kind, type in RC_KINDS_TYPES
     !------------------------------------------------------------------------------

--- a/src/AbstractVectors.f90
+++ b/src/AbstractVectors.f90
@@ -2,8 +2,9 @@ module lightkrylov_AbstractVectors
     use lightkrylov_constants
     use lightkrylov_utils
     implicit none
+    private
 
-    character*128, parameter, private :: this_module = 'Lightkrylov_AbstractVectors'
+    character*128, parameter :: this_module = 'Lightkrylov_AbstractVectors'
 
     public :: innerprod
     public :: linear_combination

--- a/src/AbstractVectors.fypp
+++ b/src/AbstractVectors.fypp
@@ -4,8 +4,9 @@ module lightkrylov_AbstractVectors
     use lightkrylov_constants
     use lightkrylov_utils
     implicit none
+    private
 
-    character*128, parameter, private :: this_module = 'Lightkrylov_AbstractVectors'
+    character*128, parameter :: this_module = 'Lightkrylov_AbstractVectors'
 
     public :: innerprod
     public :: linear_combination

--- a/src/BaseKrylov.fypp
+++ b/src/BaseKrylov.fypp
@@ -10,8 +10,9 @@ module lightkrylov_BaseKrylov
     use LightKrylov_AbstractVectors
     use LightKrylov_AbstractLinops
     implicit none
+    private
     
-    character*128, parameter, private :: this_module = 'LightKrylov_BaseKrylov'
+    character*128, parameter :: this_module = 'LightKrylov_BaseKrylov'
 
     public :: qr
     public :: apply_permutation_matrix
@@ -22,6 +23,10 @@ module lightkrylov_BaseKrylov
     public :: lanczos_bidiagonalization
     public :: lanczos_tridiagonalization
     public :: krylov_schur
+    public :: double_gram_schmidt_step
+    #:for kind in REAL_KINDS
+    public :: eigvals_select_${kind}$
+    #:endfor
 
     interface qr
         #:for kind, type in RC_KINDS_TYPES
@@ -94,6 +99,20 @@ module lightkrylov_BaseKrylov
         #:endfor
     end interface
 
+    !----------------------------------------------------------
+    !-----     ABSTRACT EIGENVALUE SELECTOR INTERFACE     -----
+    !----------------------------------------------------------
+
+    abstract interface
+        #:for kind in REAL_KINDS
+        function eigvals_select_${kind}$(lambda) result(selected)
+            import ${kind}$
+            complex(${kind}$), intent(in) :: lambda(:)
+            logical                       :: selected(size(lambda))
+        end function eigvals_select_${kind}$
+        #:endfor
+    end interface
+
 contains
 
     !-------------------------------------
@@ -112,9 +131,7 @@ contains
         integer :: i, p, info
 
         ! Zero-out X.
-        do i = 1, size(X)
-            call X(i)%zero()
-        enddo
+        call zero_basis(X)
 
         ! Deals with optional args.
         if(present(X0)) then
@@ -128,8 +145,8 @@ contains
             enddo
     
             ! Orthonormalize.
-            allocate(R(1:p, 1:p)) ; R = zero_r${kind}$
-            allocate(perm(1:p)) ; perm = 0
+            allocate(R(p, p)) ; R = zero_r${kind}$
+            allocate(perm(p)) ; perm = 0
             call qr(Q, R, perm, info)
             do i = 1, p
                 call X(i)%add(Q(i))
@@ -889,14 +906,7 @@ contains
         !! Krylov basis.
         ${type}$, intent(inout) :: H(:, :)
         !! Upper Hessenberg matrix.
-        interface
-            function selector(lambda) result(out)
-                import ${kind}$
-                complex(${kind}$), intent(in) :: lambda(:)
-                logical                       :: out(size(lambda))
-            end function selector
-        end interface
-        procedure(selector) :: select_eigs
+        procedure(eigvals_select_${kind}$) :: select_eigs
         !! Procedure to select the eigenvalues to move in the upper left-block.
 
         !--------------------------------------
@@ -940,9 +950,7 @@ contains
 
         call X(n+1)%axpby(zero_${type[0]}$${kind}$, X(kdim+1), one_${type[0]}$${kind}$)
 
-        do i = n+2, size(X)
-            call X(i)%zero()
-        enddo
+        call zero_basis(X(n+2:))
 
         ! Update the Hessenberg matrix.
         b = matmul(H(kdim+1, :), Z)

--- a/src/Constants.f90
+++ b/src/Constants.f90
@@ -4,14 +4,14 @@ module lightkrylov_constants
 
     integer , parameter, public :: sp = selected_real_kind(6, 37)
     !! Definition of the single precision data type.
-    real(sp), parameter, public :: atol_sp = 10*epsilon(1.0_sp)
+    real(sp), parameter, public :: atol_sp = 10.0_sp ** -precision(1.0_sp)
     !! Definition of the absolute tolerance for single precision computations.
     real(sp), parameter, public :: rtol_sp = sqrt(atol_sp)
     !! Definition of the relative tolerance for single precision computations.
 
     integer , parameter, public :: dp = selected_real_kind(15, 307)
     !! Definition of the double precision data type.
-    real(dp), parameter, public :: atol_dp = epsilon(1.0_dp)
+    real(dp), parameter, public :: atol_dp = 10.0_sp ** -precision(1.0_dp)
     !! Definition of the absolute tolerance for double precision computations.
     real(dp), parameter, public :: rtol_dp = sqrt(atol_dp)
     !! Definition of the relative tolerance for double precision computations.

--- a/src/IterativeSolvers.fypp
+++ b/src/IterativeSolvers.fypp
@@ -8,6 +8,7 @@ module lightkrylov_IterativeSolvers
     use stdlib_optval, only: optval
     use stdlib_io_npy, only: save_npy
     use stdlib_linalg, only: lstsq
+    use stdlib_stats, only: median
 
     use lightkrylov_constants
     Use LightKrylov_Logger
@@ -17,8 +18,9 @@ module lightkrylov_IterativeSolvers
     use lightkrylov_BaseKrylov
 
     implicit none
+    private
 
-    character*128, parameter, private :: this_module = 'LightKrylov_IterativeSolvers'
+    character*128, parameter :: this_module = 'LightKrylov_IterativeSolvers'
 
     public :: save_eigenspectrum
     public :: eigs
@@ -129,6 +131,13 @@ contains
         return
     end subroutine save_eigenspectrum_${kind}$
 
+    function median_eigvals_selector_${kind}$(lambda) result(selected)
+        complex(${kind}$), intent(in) :: lambda(:)
+        logical :: selected(size(lambda))
+        selected = abs(lambda) > median(abs(lambda))
+        return
+    end function median_eigvals_selector_${kind}$
+
     #:endfor
 
     !---------------------------------------------------
@@ -148,14 +157,7 @@ contains
         integer, intent(out) :: info
         !! Information flag.
         integer, optional, intent(in) :: kdim
-        interface
-            function selector(lambda) result(out) 
-                import ${kind}$
-                complex(${kind}$), intent(in) :: lambda(:)
-                logical                       :: out(size(lambda))
-            end function selector
-        end interface
-        procedure(selector), optional :: select
+        procedure(eigvals_select_${kind}$), optional :: select
         !! Desired number of eigenpairs.
         real(${kind}$), optional, intent(in) :: tolerance
         !! Tolerance.
@@ -190,12 +192,20 @@ contains
         #:if type[0] == "r"
         ${type}$ :: alpha
         #:endif
+        ! Eigenvalue selection.
+        procedure(eigvals_select_${kind}$), pointer :: select_
 
         ! Deals with optional parameters.
         nev = size(X)
         kdim_   = optval(kdim, 4*nev)
         verbose = optval(verbosity, .false.)
         tol     = optval(tolerance, rtol_${kind}$)
+
+        if (present(select)) then
+            select_ => select
+        else
+            select_ => median_eigvals_selector_${kind}$
+        endif
 
         ! Allocate eigenvalues.
         allocate(eigvals(nev)) ; eigvals = 0.0_${kind}$
@@ -245,13 +255,7 @@ contains
             enddo arnoldi_factorization
 
             ! Krylov-Schur restarting procedure.
-            if (present(select)) then
-                call krylov_schur(kstart, Xwrk, H, select)
-                kstart = kstart + 1
-            else
-                exit krylovschur
-            endif
-
+            call krylov_schur(kstart, Xwrk, H, select_) ; kstart = kstart + 1
         end do krylovschur
 
         !--------------------------------

--- a/src/Logger.f90
+++ b/src/Logger.f90
@@ -4,8 +4,12 @@ module LightKrylov_Logger
    use stdlib_logger, only: logger => global_logger
    use stdlib_ascii, only : to_lower
    implicit none
+   private
 
    logical, parameter :: exit_on_error = .true.
+
+   public :: check_info
+   public :: logger
 
 contains
 

--- a/src/Utils.f90
+++ b/src/Utils.f90
@@ -21,8 +21,9 @@ module lightkrylov_utils
     use LightKrylov_Constants
 
     implicit none
+    private
 
-    character*128, parameter, private :: this_module = 'LightKrylov_Utils'
+    character*128, parameter :: this_module = 'LightKrylov_Utils'
 
     public :: stop_error
     public :: assert_shape

--- a/src/Utils.fypp
+++ b/src/Utils.fypp
@@ -23,8 +23,9 @@ module lightkrylov_utils
     use LightKrylov_Constants
 
     implicit none
+    private
 
-    character*128, parameter, private :: this_module = 'LightKrylov_Utils'
+    character*128, parameter :: this_module = 'LightKrylov_Utils'
 
     public :: stop_error
     public :: assert_shape

--- a/test/TestIterativeSolvers.f90
+++ b/test/TestIterativeSolvers.f90
@@ -2,7 +2,7 @@ module TestIterativeSolvers
     ! Fortran Standard library.
     use iso_fortran_env
     use stdlib_math, only: is_close, all_close
-    use stdlib_linalg, only: eye
+    use stdlib_linalg, only: eye, diag
     use stdlib_stats, only : median
 
     ! LightKrylov
@@ -98,7 +98,7 @@ contains
         enddo
 
         ! Compute spectral decomposition.
-        call eigs(A, X, eigvals, residuals, info, select=select_eigs)
+        call eigs(A, X, eigvals, residuals, info)
         call check_info(info, 'eigs', module=this_module, procedure='test_ks_evp_rsp')
 
         ! Analytical eigenvalues.
@@ -123,14 +123,6 @@ contains
         !call check(error, norm2(abs(eigvec_residuals)) < rtol_sp)
 
         return
-        contains
-        function select_eigs(lambda) result(selected)
-            complex(sp), intent(in) :: lambda(:)
-            logical :: selected(size(lambda))
-
-            selected = abs(lambda) > median(abs(lambda))
-            return
-        end function select_eigs
     end subroutine test_ks_evp_rsp
 
    subroutine test_evp_rsp(error)
@@ -326,7 +318,7 @@ contains
         enddo
 
         ! Compute spectral decomposition.
-        call eigs(A, X, eigvals, residuals, info, select=select_eigs)
+        call eigs(A, X, eigvals, residuals, info)
         call check_info(info, 'eigs', module=this_module, procedure='test_ks_evp_rdp')
 
         ! Analytical eigenvalues.
@@ -351,14 +343,6 @@ contains
         !call check(error, norm2(abs(eigvec_residuals)) < rtol_dp)
 
         return
-        contains
-        function select_eigs(lambda) result(selected)
-            complex(dp), intent(in) :: lambda(:)
-            logical :: selected(size(lambda))
-
-            selected = abs(lambda) > median(abs(lambda))
-            return
-        end function select_eigs
     end subroutine test_ks_evp_rdp
 
    subroutine test_evp_rdp(error)
@@ -535,14 +519,6 @@ contains
         real(sp) :: pi = 4.0_sp * atan(1.0_sp)
 
         return
-        contains
-        function select_eigs(lambda) result(selected)
-            complex(sp), intent(in) :: lambda(:)
-            logical :: selected(size(lambda))
-
-            selected = abs(lambda) > median(abs(lambda))
-            return
-        end function select_eigs
     end subroutine test_ks_evp_csp
 
    subroutine test_evp_csp(error)
@@ -601,14 +577,6 @@ contains
         real(dp) :: pi = 4.0_dp * atan(1.0_dp)
 
         return
-        contains
-        function select_eigs(lambda) result(selected)
-            complex(dp), intent(in) :: lambda(:)
-            logical :: selected(size(lambda))
-
-            selected = abs(lambda) > median(abs(lambda))
-            return
-        end function select_eigs
     end subroutine test_ks_evp_cdp
 
    subroutine test_evp_cdp(error)

--- a/test/TestIterativeSolvers.fypp
+++ b/test/TestIterativeSolvers.fypp
@@ -4,7 +4,7 @@ module TestIterativeSolvers
     ! Fortran Standard library.
     use iso_fortran_env
     use stdlib_math, only: is_close, all_close
-    use stdlib_linalg, only: eye
+    use stdlib_linalg, only: eye, diag
     use stdlib_stats, only : median
 
     ! LightKrylov
@@ -94,7 +94,7 @@ contains
         enddo
 
         ! Compute spectral decomposition.
-        call eigs(A, X, eigvals, residuals, info, select=select_eigs)
+        call eigs(A, X, eigvals, residuals, info)
         call check_info(info, 'eigs', module=this_module, procedure='test_ks_evp_${type[0]}$${kind}$')
 
         ! Analytical eigenvalues.
@@ -120,14 +120,6 @@ contains
         #:endif
 
         return
-        contains
-        function select_eigs(lambda) result(selected)
-            complex(${kind}$), intent(in) :: lambda(:)
-            logical :: selected(size(lambda))
-
-            selected = abs(lambda) > median(abs(lambda))
-            return
-        end function select_eigs
     end subroutine test_ks_evp_${type[0]}$${kind}$
 
    subroutine test_evp_${type[0]}$${kind}$(error)

--- a/test/Tests.f90
+++ b/test/Tests.f90
@@ -1,6 +1,7 @@
 program Tester
    ! Fortran best practice.
    use, intrinsic :: iso_fortran_env, only: error_unit, output_unit
+   use stdlib_logger, only: error_level
    ! Unit-test utility.
    use testdrive, only: run_testsuite, new_testsuite, testsuite_type
    ! Abstract implementation of Krylov-based techniques.


### PR DESCRIPTION
This pull request includes:
- default eigenvalue selection routine for krylov-schur restart in `eigs`. By default, it selects half of the computed Ritz eigenvalues based on the median of `abs(lambda)`.
- Replaced `initialize_krylov_subspace` with `zero_basis` wherever appropriate (not yet in the tests).
- Makes all the modules `private` by default.
- Minor cosmetic changes.