### PR TITLE
Switch to `stdlib_svd`  + minor typo corrections.

### DIFF
--- a/src/Constants.f90
+++ b/src/Constants.f90
@@ -11,7 +11,7 @@ module lightkrylov_constants
 
     integer , parameter, public :: dp = selected_real_kind(15, 307)
     !! Definition of the double precision data type.
-    real(dp), parameter, public :: atol_dp = 10.0_sp ** -precision(1.0_dp)
+    real(dp), parameter, public :: atol_dp = 10.0_dp ** -precision(1.0_dp)
     !! Definition of the absolute tolerance for double precision computations.
     real(dp), parameter, public :: rtol_dp = sqrt(atol_dp)
     !! Definition of the relative tolerance for double precision computations.

--- a/src/IterativeSolvers.f90
+++ b/src/IterativeSolvers.f90
@@ -1230,17 +1230,14 @@ contains
             call lanczos_bidiagonalization(A, Uwrk, Vwrk, B, info, kstart=k, kend=k, verbosity=verbosity, tol=tol)
             call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='svds_rsp')
 
-            ! SVD of the k x k bidiagonal matrix.
+            ! SVD of the k x k bidiagonal matrix and residual computation.
             svdvals_wrk = 0.0_sp ; umat = 0.0_sp ; vmat = 0.0_sp
+
             if (k > 1) then
                 call svd(B(:k, :k), svdvals_wrk(:k), umat(:k, :k), vmat(:k, :k))
                 vmat(:k, :k) = transpose(vmat(:k, :k))
-            endif
 
-            ! Compute residuals.
-            beta = B(k+1, k)
-            if ( k > 1) then
-                residuals_wrk(:k) = compute_residual_rsp(beta, vmat(k, :k))
+                residuals_wrk(:k) = compute_residual_rsp(B(k+1, k), vmat(k, :k))
 
                 ! Check for convergence.
                 conv = count(residuals_wrk(:k) < tol)
@@ -1330,17 +1327,14 @@ contains
             call lanczos_bidiagonalization(A, Uwrk, Vwrk, B, info, kstart=k, kend=k, verbosity=verbosity, tol=tol)
             call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='svds_rdp')
 
-            ! SVD of the k x k bidiagonal matrix.
+            ! SVD of the k x k bidiagonal matrix and residual computation.
             svdvals_wrk = 0.0_dp ; umat = 0.0_dp ; vmat = 0.0_dp
+
             if (k > 1) then
                 call svd(B(:k, :k), svdvals_wrk(:k), umat(:k, :k), vmat(:k, :k))
                 vmat(:k, :k) = transpose(vmat(:k, :k))
-            endif
 
-            ! Compute residuals.
-            beta = B(k+1, k)
-            if ( k > 1) then
-                residuals_wrk(:k) = compute_residual_rdp(beta, vmat(k, :k))
+                residuals_wrk(:k) = compute_residual_rdp(B(k+1, k), vmat(k, :k))
 
                 ! Check for convergence.
                 conv = count(residuals_wrk(:k) < tol)
@@ -1430,17 +1424,14 @@ contains
             call lanczos_bidiagonalization(A, Uwrk, Vwrk, B, info, kstart=k, kend=k, verbosity=verbosity, tol=tol)
             call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='svds_csp')
 
-            ! SVD of the k x k bidiagonal matrix.
+            ! SVD of the k x k bidiagonal matrix and residual computation.
             svdvals_wrk = 0.0_sp ; umat = 0.0_sp ; vmat = 0.0_sp
+
             if (k > 1) then
                 call svd(B(:k, :k), svdvals_wrk(:k), umat(:k, :k), vmat(:k, :k))
                 vmat(:k, :k) = conjg(transpose(vmat(:k, :k)))
-            endif
 
-            ! Compute residuals.
-            beta = B(k+1, k)
-            if ( k > 1) then
-                residuals_wrk(:k) = compute_residual_csp(beta, vmat(k, :k))
+                residuals_wrk(:k) = compute_residual_csp(B(k+1, k), vmat(k, :k))
 
                 ! Check for convergence.
                 conv = count(residuals_wrk(:k) < tol)
@@ -1530,17 +1521,14 @@ contains
             call lanczos_bidiagonalization(A, Uwrk, Vwrk, B, info, kstart=k, kend=k, verbosity=verbosity, tol=tol)
             call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='svds_cdp')
 
-            ! SVD of the k x k bidiagonal matrix.
+            ! SVD of the k x k bidiagonal matrix and residual computation.
             svdvals_wrk = 0.0_dp ; umat = 0.0_dp ; vmat = 0.0_dp
+
             if (k > 1) then
                 call svd(B(:k, :k), svdvals_wrk(:k), umat(:k, :k), vmat(:k, :k))
                 vmat(:k, :k) = conjg(transpose(vmat(:k, :k)))
-            endif
 
-            ! Compute residuals.
-            beta = B(k+1, k)
-            if ( k > 1) then
-                residuals_wrk(:k) = compute_residual_cdp(beta, vmat(k, :k))
+                residuals_wrk(:k) = compute_residual_cdp(B(k+1, k), vmat(k, :k))
 
                 ! Check for convergence.
                 conv = count(residuals_wrk(:k) < tol)

--- a/src/IterativeSolvers.f90
+++ b/src/IterativeSolvers.f90
@@ -5,7 +5,7 @@ module lightkrylov_IterativeSolvers
     use stdlib_sorting, only: sort_index
     use stdlib_optval, only: optval
     use stdlib_io_npy, only: save_npy
-    use stdlib_linalg, only: lstsq
+    use stdlib_linalg, only: lstsq, svd
     use stdlib_stats, only: median
 
     use lightkrylov_constants
@@ -1232,15 +1232,20 @@ contains
 
             ! SVD of the k x k bidiagonal matrix.
             svdvals_wrk = 0.0_sp ; umat = 0.0_sp ; vmat = 0.0_sp
-            call svd(B(:k, :k), umat(:k, :k), svdvals_wrk(:k), vmat(:k, :k))
+            if (k > 1) then
+                call svd(B(:k, :k), svdvals_wrk(:k), umat(:k, :k), vmat(:k, :k))
+                vmat(:k, :k) = transpose(vmat(:k, :k))
+            endif
 
             ! Compute residuals.
             beta = B(k+1, k)
-            residuals_wrk(:k) = compute_residual_rsp(beta, vmat(k, :k))
+            if ( k > 1) then
+                residuals_wrk(:k) = compute_residual_rsp(beta, vmat(k, :k))
 
-            ! Check for convergence.
-            conv = count(residuals_wrk(:k) < tol)
-            if (conv >= nsv) exit lanczos
+                ! Check for convergence.
+                conv = count(residuals_wrk(:k) < tol)
+                if (conv >= nsv) exit lanczos
+            endif
         enddo lanczos
 
         !--------------------------------
@@ -1327,15 +1332,20 @@ contains
 
             ! SVD of the k x k bidiagonal matrix.
             svdvals_wrk = 0.0_dp ; umat = 0.0_dp ; vmat = 0.0_dp
-            call svd(B(:k, :k), umat(:k, :k), svdvals_wrk(:k), vmat(:k, :k))
+            if (k > 1) then
+                call svd(B(:k, :k), svdvals_wrk(:k), umat(:k, :k), vmat(:k, :k))
+                vmat(:k, :k) = transpose(vmat(:k, :k))
+            endif
 
             ! Compute residuals.
             beta = B(k+1, k)
-            residuals_wrk(:k) = compute_residual_rdp(beta, vmat(k, :k))
+            if ( k > 1) then
+                residuals_wrk(:k) = compute_residual_rdp(beta, vmat(k, :k))
 
-            ! Check for convergence.
-            conv = count(residuals_wrk(:k) < tol)
-            if (conv >= nsv) exit lanczos
+                ! Check for convergence.
+                conv = count(residuals_wrk(:k) < tol)
+                if (conv >= nsv) exit lanczos
+            endif
         enddo lanczos
 
         !--------------------------------
@@ -1422,15 +1432,20 @@ contains
 
             ! SVD of the k x k bidiagonal matrix.
             svdvals_wrk = 0.0_sp ; umat = 0.0_sp ; vmat = 0.0_sp
-            call svd(B(:k, :k), umat(:k, :k), svdvals_wrk(:k), vmat(:k, :k))
+            if (k > 1) then
+                call svd(B(:k, :k), svdvals_wrk(:k), umat(:k, :k), vmat(:k, :k))
+                vmat(:k, :k) = conjg(transpose(vmat(:k, :k)))
+            endif
 
             ! Compute residuals.
             beta = B(k+1, k)
-            residuals_wrk(:k) = compute_residual_csp(beta, vmat(k, :k))
+            if ( k > 1) then
+                residuals_wrk(:k) = compute_residual_csp(beta, vmat(k, :k))
 
-            ! Check for convergence.
-            conv = count(residuals_wrk(:k) < tol)
-            if (conv >= nsv) exit lanczos
+                ! Check for convergence.
+                conv = count(residuals_wrk(:k) < tol)
+                if (conv >= nsv) exit lanczos
+            endif
         enddo lanczos
 
         !--------------------------------
@@ -1517,15 +1532,20 @@ contains
 
             ! SVD of the k x k bidiagonal matrix.
             svdvals_wrk = 0.0_dp ; umat = 0.0_dp ; vmat = 0.0_dp
-            call svd(B(:k, :k), umat(:k, :k), svdvals_wrk(:k), vmat(:k, :k))
+            if (k > 1) then
+                call svd(B(:k, :k), svdvals_wrk(:k), umat(:k, :k), vmat(:k, :k))
+                vmat(:k, :k) = conjg(transpose(vmat(:k, :k)))
+            endif
 
             ! Compute residuals.
             beta = B(k+1, k)
-            residuals_wrk(:k) = compute_residual_cdp(beta, vmat(k, :k))
+            if ( k > 1) then
+                residuals_wrk(:k) = compute_residual_cdp(beta, vmat(k, :k))
 
-            ! Check for convergence.
-            conv = count(residuals_wrk(:k) < tol)
-            if (conv >= nsv) exit lanczos
+                ! Check for convergence.
+                conv = count(residuals_wrk(:k) < tol)
+                if (conv >= nsv) exit lanczos
+            endif
         enddo lanczos
 
         !--------------------------------

--- a/src/IterativeSolvers.fypp
+++ b/src/IterativeSolvers.fypp
@@ -7,7 +7,7 @@ module lightkrylov_IterativeSolvers
     use stdlib_sorting, only: sort_index
     use stdlib_optval, only: optval
     use stdlib_io_npy, only: save_npy
-    use stdlib_linalg, only: lstsq
+    use stdlib_linalg, only: lstsq, svd
     use stdlib_stats, only: median
 
     use lightkrylov_constants
@@ -468,15 +468,24 @@ contains
 
             ! SVD of the k x k bidiagonal matrix.
             svdvals_wrk = 0.0_${kind}$ ; umat = 0.0_${kind}$ ; vmat = 0.0_${kind}$
-            call svd(B(:k, :k), umat(:k, :k), svdvals_wrk(:k), vmat(:k, :k))
+            if (k > 1) then
+                call svd(B(:k, :k), svdvals_wrk(:k), umat(:k, :k), vmat(:k, :k))
+                #:if type[0] == "r"
+                vmat(:k, :k) = transpose(vmat(:k, :k))
+                #:else
+                vmat(:k, :k) = conjg(transpose(vmat(:k, :k)))
+                #:endif
+            endif
 
             ! Compute residuals.
             beta = B(k+1, k)
-            residuals_wrk(:k) = compute_residual_${type[0]}$${kind}$(beta, vmat(k, :k))
+            if ( k > 1) then
+                residuals_wrk(:k) = compute_residual_${type[0]}$${kind}$(beta, vmat(k, :k))
 
-            ! Check for convergence.
-            conv = count(residuals_wrk(:k) < tol)
-            if (conv >= nsv) exit lanczos
+                ! Check for convergence.
+                conv = count(residuals_wrk(:k) < tol)
+                if (conv >= nsv) exit lanczos
+            endif
         enddo lanczos
 
         !--------------------------------

--- a/src/IterativeSolvers.fypp
+++ b/src/IterativeSolvers.fypp
@@ -466,8 +466,9 @@ contains
             call lanczos_bidiagonalization(A, Uwrk, Vwrk, B, info, kstart=k, kend=k, verbosity=verbosity, tol=tol)
             call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='svds_${type[0]}$${kind}$')
 
-            ! SVD of the k x k bidiagonal matrix.
+            ! SVD of the k x k bidiagonal matrix and residual computation.
             svdvals_wrk = 0.0_${kind}$ ; umat = 0.0_${kind}$ ; vmat = 0.0_${kind}$
+
             if (k > 1) then
                 call svd(B(:k, :k), svdvals_wrk(:k), umat(:k, :k), vmat(:k, :k))
                 #:if type[0] == "r"
@@ -475,12 +476,8 @@ contains
                 #:else
                 vmat(:k, :k) = conjg(transpose(vmat(:k, :k)))
                 #:endif
-            endif
 
-            ! Compute residuals.
-            beta = B(k+1, k)
-            if ( k > 1) then
-                residuals_wrk(:k) = compute_residual_${type[0]}$${kind}$(beta, vmat(k, :k))
+                residuals_wrk(:k) = compute_residual_${type[0]}$${kind}$(B(k+1, k), vmat(k, :k))
 
                 ! Check for convergence.
                 conv = count(residuals_wrk(:k) < tol)

--- a/src/Logger.f90
+++ b/src/Logger.f90
@@ -139,20 +139,7 @@ contains
                call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
-         else if (trim(to_lower(origin)) == 'gesvd') then
-            ! GESVD
-            if (info < 0) then
-               write(msg, *) "The ", -info, "-th argument has illegal value."
-               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
-               ierr = -1
-            else
-               write(msg, *) "The QR alg. did not converge. ", info, &
-                           & "superdiagonals of an intermediate bidiagonal form B ", &
-                           & "did not converge to zero."
-               call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
-               ierr = -1
-            end if
-         !
+        !
          !   LightKrylov_Utils
          !
          else if (trim(to_lower(origin)) == 'sqrtm') then

--- a/src/Utils.fypp
+++ b/src/Utils.fypp
@@ -31,8 +31,6 @@ module lightkrylov_utils
     public :: assert_shape
     ! Compute B = inv(A) in-place for dense matrices.
     public :: inv
-    ! Compute USV^T = svd(A) for dense matrices.
-    public :: svd
     ! Compute AX = XD for general dense matrices.
     public :: eig
     ! Compute AX = XD for symmetric/hermitian matrices.
@@ -67,12 +65,6 @@ module lightkrylov_utils
     interface inv
         #:for kind, type in RC_KINDS_TYPES
         module procedure inv_${type[0]}$${kind}$
-        #:endfor
-    end interface
-
-    interface svd
-        #:for kind, type in RC_KINDS_TYPES
-        module procedure svd_${type[0]}$${kind}$
         #:endfor
     end interface
 
@@ -223,50 +215,6 @@ contains
 
         return
     end subroutine inv_${type[0]}$${kind}$
-
-    subroutine svd_${type[0]}$${kind}$(A, U, S, V)
-        !! Singular value decomposition of a dense matrix.
-        ${type}$, intent(in) :: A(:, :)
-        !! Matrix to be factorized.
-        ${type}$, intent(out) :: U(:, :)
-        !! Left singular vectors.
-        real(${kind}$), intent(out) :: S(:)
-        !! Singular values.
-        ${type}$, intent(out) :: V(:, :)
-        !! Right singular vectors.
-
-        ! Internal variables.
-        character :: jobu = "S", jobvt = "S"
-        integer :: m, n, lda, ldu, ldvt, lwork, info
-        ${type}$, allocatable :: work(:)
-        ${type}$ :: A_tilde(size(A, 1), size(A, 2)), Vt(min(size(A, 1), size(A, 2)), size(A, 2))
-        #:if type[0] == "c"
-        real(${kind}$), allocatable :: rwork(:)
-        #:endif
-
-        ! Setup variables.
-        m = size(A, 1) ; n = size(A, 2)
-        lda = m ; ldu = m ; ldvt = n
-        lwork = max(1, 3*min(m, n) + max(m, n), 5*min(m, n)) ; allocate(work(lwork))
-
-        ! Shape assertion.
-        call assert_shape(U, [m, m], "svd", "U")
-        call assert_shape(V, [n, n], "svd", "V")
-
-        ! SVD computation.
-        A_tilde = A
-        #:if type[0] == "c"
-        allocate(rwork(5*min(m, n)))
-        call gesvd(jobu, jobvt, m, n, A_tilde, lda, S, U, ldu, Vt, ldvt, work, lwork, rwork, info)
-        v = transpose(conjg(vt))
-        #:else
-        call gesvd(jobu, jobvt, m, n, A_tilde, lda, S, U, ldu, Vt, ldvt, work, lwork, info)
-        v = transpose(vt)
-        #:endif
-        call check_info(info, 'GESVD', module=this_module, procedure='svd_${type[0]}$${kind}$')
-
-        return
-    end subroutine svd_${type[0]}$${kind}$
 
     subroutine eig_${type[0]}$${kind}$(A, vecs, vals)
         !! Eigenvalue decomposition of a dense matrix using LAPACK.


### PR DESCRIPTION
`LightKrylov` now makes use of `stdlib_svd` rather than our own wrapper.
Minor issue is that it doesn't work if `A` is of size ` 1 x 1`. See [here](https://github.com/fortran-lang/stdlib/issues/835) for more details. It's not big deal, we simply need a couple of `if (k>1)` here and there. That will do for the moment, hoping that this LAPACK issue (not stdlib) is resolved at some point.