### PR TITLE
Fixed the tests so that single precision no longer fails.

### DIFF
--- a/src/BaseKrylov.f90
+++ b/src/BaseKrylov.f90
@@ -2907,7 +2907,7 @@ contains
         enddo
 
         ! Full re-orthogonalization against existing basis
-        call orthogonalize_against_basis(X(k+1), X(1:k), info, if_chk_orthonormal=.false.)
+        call double_gram_schmidt_step(X(k+1), X(:k), info, if_chk_orthonormal=.true.)
         call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='update_tridiag_matrix_rsp')
 
         return
@@ -2977,7 +2977,7 @@ contains
         enddo
 
         ! Full re-orthogonalization against existing basis
-        call orthogonalize_against_basis(X(k+1), X(1:k), info, if_chk_orthonormal=.false.)
+        call double_gram_schmidt_step(X(k+1), X(:k), info, if_chk_orthonormal=.true.)
         call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='update_tridiag_matrix_rdp')
 
         return
@@ -3047,7 +3047,7 @@ contains
         enddo
 
         ! Full re-orthogonalization against existing basis
-        call orthogonalize_against_basis(X(k+1), X(1:k), info, if_chk_orthonormal=.false.)
+        call double_gram_schmidt_step(X(k+1), X(:k), info, if_chk_orthonormal=.true.)
         call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='update_tridiag_matrix_csp')
 
         return
@@ -3117,7 +3117,7 @@ contains
         enddo
 
         ! Full re-orthogonalization against existing basis
-        call orthogonalize_against_basis(X(k+1), X(1:k), info, if_chk_orthonormal=.false.)
+        call double_gram_schmidt_step(X(k+1), X(:k), info, if_chk_orthonormal=.true.)
         call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='update_tridiag_matrix_cdp')
 
         return

--- a/src/BaseKrylov.f90
+++ b/src/BaseKrylov.f90
@@ -2549,7 +2549,7 @@ contains
             ! Full re-orthogonalization of the right Krylov subspace.
             if (k > 1 ) then
             
-                call double_gram_schmidt_step(V(k), V(:k-1), info, if_chk_orthonormal=.true.)
+                call double_gram_schmidt_step(V(k), V(:k-1), info, if_chk_orthonormal=.false.)
                 call check_info(info, 'double_gram_schmidt_step', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_rsp, first pass')
             end if
@@ -2567,7 +2567,7 @@ contains
             call A%matvec(V(k), U(k+1))
 
             ! Full re-orthogonalization of the left Krylov subspace.
-            call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.true.)
+            call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.false.)
             call check_info(info, 'orthogonalize_against_basis', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_rsp, second pass')
 
@@ -2633,7 +2633,7 @@ contains
             ! Full re-orthogonalization of the right Krylov subspace.
             if (k > 1 ) then
             
-                call double_gram_schmidt_step(V(k), V(:k-1), info, if_chk_orthonormal=.true.)
+                call double_gram_schmidt_step(V(k), V(:k-1), info, if_chk_orthonormal=.false.)
                 call check_info(info, 'double_gram_schmidt_step', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_rdp, first pass')
             end if
@@ -2651,7 +2651,7 @@ contains
             call A%matvec(V(k), U(k+1))
 
             ! Full re-orthogonalization of the left Krylov subspace.
-            call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.true.)
+            call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.false.)
             call check_info(info, 'orthogonalize_against_basis', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_rdp, second pass')
 
@@ -2717,7 +2717,7 @@ contains
             ! Full re-orthogonalization of the right Krylov subspace.
             if (k > 1 ) then
             
-                call double_gram_schmidt_step(V(k), V(:k-1), info, if_chk_orthonormal=.true.)
+                call double_gram_schmidt_step(V(k), V(:k-1), info, if_chk_orthonormal=.false.)
                 call check_info(info, 'double_gram_schmidt_step', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_csp, first pass')
             end if
@@ -2735,7 +2735,7 @@ contains
             call A%matvec(V(k), U(k+1))
 
             ! Full re-orthogonalization of the left Krylov subspace.
-            call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.true.)
+            call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.false.)
             call check_info(info, 'orthogonalize_against_basis', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_csp, second pass')
 
@@ -2801,7 +2801,7 @@ contains
             ! Full re-orthogonalization of the right Krylov subspace.
             if (k > 1 ) then
             
-                call double_gram_schmidt_step(V(k), V(:k-1), info, if_chk_orthonormal=.true.)
+                call double_gram_schmidt_step(V(k), V(:k-1), info, if_chk_orthonormal=.false.)
                 call check_info(info, 'double_gram_schmidt_step', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_cdp, first pass')
             end if
@@ -2819,7 +2819,7 @@ contains
             call A%matvec(V(k), U(k+1))
 
             ! Full re-orthogonalization of the left Krylov subspace.
-            call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.true.)
+            call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.false.)
             call check_info(info, 'orthogonalize_against_basis', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_cdp, second pass')
 
@@ -2907,7 +2907,7 @@ contains
         enddo
 
         ! Full re-orthogonalization against existing basis
-        call double_gram_schmidt_step(X(k+1), X(:k), info, if_chk_orthonormal=.true.)
+        call double_gram_schmidt_step(X(k+1), X(:k), info, if_chk_orthonormal=.false.)
         call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='update_tridiag_matrix_rsp')
 
         return
@@ -2977,7 +2977,7 @@ contains
         enddo
 
         ! Full re-orthogonalization against existing basis
-        call double_gram_schmidt_step(X(k+1), X(:k), info, if_chk_orthonormal=.true.)
+        call double_gram_schmidt_step(X(k+1), X(:k), info, if_chk_orthonormal=.false.)
         call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='update_tridiag_matrix_rdp')
 
         return
@@ -3047,7 +3047,7 @@ contains
         enddo
 
         ! Full re-orthogonalization against existing basis
-        call double_gram_schmidt_step(X(k+1), X(:k), info, if_chk_orthonormal=.true.)
+        call double_gram_schmidt_step(X(k+1), X(:k), info, if_chk_orthonormal=.false.)
         call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='update_tridiag_matrix_csp')
 
         return
@@ -3117,7 +3117,7 @@ contains
         enddo
 
         ! Full re-orthogonalization against existing basis
-        call double_gram_schmidt_step(X(k+1), X(:k), info, if_chk_orthonormal=.true.)
+        call double_gram_schmidt_step(X(k+1), X(:k), info, if_chk_orthonormal=.false.)
         call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='update_tridiag_matrix_cdp')
 
         return

--- a/src/BaseKrylov.f90
+++ b/src/BaseKrylov.f90
@@ -2866,6 +2866,7 @@ contains
         k_end = optval(kend, kdim)
         verbose = optval(verbosity, .false.)
         tolerance = optval(tol, atol_sp)
+        info = 0
 
         ! Lanczos tridiagonalization.
         lanczos: do k = k_start, k_end
@@ -2936,6 +2937,7 @@ contains
         k_end = optval(kend, kdim)
         verbose = optval(verbosity, .false.)
         tolerance = optval(tol, atol_dp)
+        info = 0
 
         ! Lanczos tridiagonalization.
         lanczos: do k = k_start, k_end
@@ -3006,6 +3008,7 @@ contains
         k_end = optval(kend, kdim)
         verbose = optval(verbosity, .false.)
         tolerance = optval(tol, atol_sp)
+        info = 0
 
         ! Lanczos tridiagonalization.
         lanczos: do k = k_start, k_end
@@ -3076,6 +3079,7 @@ contains
         k_end = optval(kend, kdim)
         verbose = optval(verbosity, .false.)
         tolerance = optval(tol, atol_dp)
+        info = 0
 
         ! Lanczos tridiagonalization.
         lanczos: do k = k_start, k_end

--- a/src/BaseKrylov.f90
+++ b/src/BaseKrylov.f90
@@ -2548,8 +2548,9 @@ contains
 
             ! Full re-orthogonalization of the right Krylov subspace.
             if (k > 1 ) then
-               call orthogonalize_against_basis(V(k), V(1:k-1), info, if_chk_orthonormal=.false.)
-               call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+            
+                call double_gram_schmidt_step(V(k), V(:k-1), info, if_chk_orthonormal=.true.)
+                call check_info(info, 'double_gram_schmidt_step', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_rsp, first pass')
             end if
 
@@ -2566,7 +2567,7 @@ contains
             call A%matvec(V(k), U(k+1))
 
             ! Full re-orthogonalization of the left Krylov subspace.
-            call orthogonalize_against_basis(U(k+1), U(1:k), info, if_chk_orthonormal=.false.)
+            call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.true.)
             call check_info(info, 'orthogonalize_against_basis', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_rsp, second pass')
 
@@ -2631,8 +2632,9 @@ contains
 
             ! Full re-orthogonalization of the right Krylov subspace.
             if (k > 1 ) then
-               call orthogonalize_against_basis(V(k), V(1:k-1), info, if_chk_orthonormal=.false.)
-               call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+            
+                call double_gram_schmidt_step(V(k), V(:k-1), info, if_chk_orthonormal=.true.)
+                call check_info(info, 'double_gram_schmidt_step', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_rdp, first pass')
             end if
 
@@ -2649,7 +2651,7 @@ contains
             call A%matvec(V(k), U(k+1))
 
             ! Full re-orthogonalization of the left Krylov subspace.
-            call orthogonalize_against_basis(U(k+1), U(1:k), info, if_chk_orthonormal=.false.)
+            call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.true.)
             call check_info(info, 'orthogonalize_against_basis', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_rdp, second pass')
 
@@ -2714,8 +2716,9 @@ contains
 
             ! Full re-orthogonalization of the right Krylov subspace.
             if (k > 1 ) then
-               call orthogonalize_against_basis(V(k), V(1:k-1), info, if_chk_orthonormal=.false.)
-               call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+            
+                call double_gram_schmidt_step(V(k), V(:k-1), info, if_chk_orthonormal=.true.)
+                call check_info(info, 'double_gram_schmidt_step', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_csp, first pass')
             end if
 
@@ -2732,7 +2735,7 @@ contains
             call A%matvec(V(k), U(k+1))
 
             ! Full re-orthogonalization of the left Krylov subspace.
-            call orthogonalize_against_basis(U(k+1), U(1:k), info, if_chk_orthonormal=.false.)
+            call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.true.)
             call check_info(info, 'orthogonalize_against_basis', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_csp, second pass')
 
@@ -2797,8 +2800,9 @@ contains
 
             ! Full re-orthogonalization of the right Krylov subspace.
             if (k > 1 ) then
-               call orthogonalize_against_basis(V(k), V(1:k-1), info, if_chk_orthonormal=.false.)
-               call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+            
+                call double_gram_schmidt_step(V(k), V(:k-1), info, if_chk_orthonormal=.true.)
+                call check_info(info, 'double_gram_schmidt_step', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_cdp, first pass')
             end if
 
@@ -2815,7 +2819,7 @@ contains
             call A%matvec(V(k), U(k+1))
 
             ! Full re-orthogonalization of the left Krylov subspace.
-            call orthogonalize_against_basis(U(k+1), U(1:k), info, if_chk_orthonormal=.false.)
+            call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.true.)
             call check_info(info, 'orthogonalize_against_basis', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_cdp, second pass')
 

--- a/src/BaseKrylov.fypp
+++ b/src/BaseKrylov.fypp
@@ -774,7 +774,7 @@ contains
             ! Full re-orthogonalization of the right Krylov subspace.
             if (k > 1 ) then
             
-                call double_gram_schmidt_step(V(k), V(:k-1), info, if_chk_orthonormal=.true.)
+                call double_gram_schmidt_step(V(k), V(:k-1), info, if_chk_orthonormal=.false.)
                 call check_info(info, 'double_gram_schmidt_step', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_${type[0]}$${kind}$, first pass')
             end if
@@ -792,7 +792,7 @@ contains
             call A%matvec(V(k), U(k+1))
 
             ! Full re-orthogonalization of the left Krylov subspace.
-            call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.true.)
+            call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.false.)
             call check_info(info, 'orthogonalize_against_basis', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_${type[0]}$${kind}$, second pass')
 
@@ -886,7 +886,7 @@ contains
         enddo
 
         ! Full re-orthogonalization against existing basis
-        call double_gram_schmidt_step(X(k+1), X(:k), info, if_chk_orthonormal=.true.)
+        call double_gram_schmidt_step(X(k+1), X(:k), info, if_chk_orthonormal=.false.)
         call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='update_tridiag_matrix_${type[0]}$${kind}$')
 
         return

--- a/src/BaseKrylov.fypp
+++ b/src/BaseKrylov.fypp
@@ -845,6 +845,7 @@ contains
         k_end = optval(kend, kdim)
         verbose = optval(verbosity, .false.)
         tolerance = optval(tol, atol_${kind}$)
+        info = 0
 
         ! Lanczos tridiagonalization.
         lanczos: do k = k_start, k_end

--- a/src/BaseKrylov.fypp
+++ b/src/BaseKrylov.fypp
@@ -886,7 +886,7 @@ contains
         enddo
 
         ! Full re-orthogonalization against existing basis
-        call orthogonalize_against_basis(X(k+1), X(1:k), info, if_chk_orthonormal=.false.)
+        call double_gram_schmidt_step(X(k+1), X(:k), info, if_chk_orthonormal=.true.)
         call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='update_tridiag_matrix_${type[0]}$${kind}$')
 
         return

--- a/src/BaseKrylov.fypp
+++ b/src/BaseKrylov.fypp
@@ -773,8 +773,9 @@ contains
 
             ! Full re-orthogonalization of the right Krylov subspace.
             if (k > 1 ) then
-               call orthogonalize_against_basis(V(k), V(1:k-1), info, if_chk_orthonormal=.false.)
-               call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+            
+                call double_gram_schmidt_step(V(k), V(:k-1), info, if_chk_orthonormal=.true.)
+                call check_info(info, 'double_gram_schmidt_step', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_${type[0]}$${kind}$, first pass')
             end if
 
@@ -791,7 +792,7 @@ contains
             call A%matvec(V(k), U(k+1))
 
             ! Full re-orthogonalization of the left Krylov subspace.
-            call orthogonalize_against_basis(U(k+1), U(1:k), info, if_chk_orthonormal=.false.)
+            call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.true.)
             call check_info(info, 'orthogonalize_against_basis', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_${type[0]}$${kind}$, second pass')
 

--- a/test/TestIterativeSolvers.f90
+++ b/test/TestIterativeSolvers.f90
@@ -99,7 +99,7 @@ contains
         enddo
 
         ! Compute spectral decomposition.
-        call eigs(A, X, eigvals, residuals, info)
+        call eigs(A, X, eigvals, residuals, info, tolerance=atol_sp)
         call check_info(info, 'eigs', module=this_module, procedure='test_ks_evp_rsp')
 
         ! Analytical eigenvalues.
@@ -111,7 +111,12 @@ contains
         enddo
 
         ! check eigenvalues
-        call check(error, norm2(abs(eigvals - true_eigvals(:nev))) < rtol_sp)
+        call check(error, maxval(abs(eigvals - true_eigvals(:nev))) < rtol_sp)
+            write(output_unit, *) "True eigenvalues / Computed eigenvalues / Difference"
+            do i = 1, nev
+                write(output_unit, *) "    -", true_eigvals(i), eigvals(i), abs(eigvals(i) - true_eigvals(i)), rtol_sp, atol_sp
+            enddo
+            write(output_unit, *) "|| err ||_inf :",  maxval(abs(eigvals - true_eigvals(:nev))) 
         !if (allocated(error)) return
         !! check eigenvectors
         !allocate(AX(nev))
@@ -319,7 +324,7 @@ contains
         enddo
 
         ! Compute spectral decomposition.
-        call eigs(A, X, eigvals, residuals, info)
+        call eigs(A, X, eigvals, residuals, info, tolerance=atol_dp)
         call check_info(info, 'eigs', module=this_module, procedure='test_ks_evp_rdp')
 
         ! Analytical eigenvalues.
@@ -331,7 +336,12 @@ contains
         enddo
 
         ! check eigenvalues
-        call check(error, norm2(abs(eigvals - true_eigvals(:nev))) < rtol_dp)
+        call check(error, maxval(abs(eigvals - true_eigvals(:nev))) < rtol_dp)
+            write(output_unit, *) "True eigenvalues / Computed eigenvalues / Difference"
+            do i = 1, nev
+                write(output_unit, *) "    -", true_eigvals(i), eigvals(i), abs(eigvals(i) - true_eigvals(i)), rtol_dp, atol_dp
+            enddo
+            write(output_unit, *) "|| err ||_inf :",  maxval(abs(eigvals - true_eigvals(:nev))) 
         !if (allocated(error)) return
         !! check eigenvectors
         !allocate(AX(nev))
@@ -882,6 +892,9 @@ contains
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_sp)
+        if (allocated(error)) then
+            write(output_unit, *) norm2(abs(matmul(A%data, x%data) - b%data)),  b%norm() * rtol_sp
+        endif
 
         return
     end subroutine test_gmres_rsp
@@ -907,8 +920,6 @@ contains
         opts = gmres_sp_opts(kdim=test_size, verbose=.false.)
         call gmres(A, b, x, info, options=opts)
         call check_info(info, 'gmres', module=this_module, procedure='test_gmres_spd_rsp')
-
-        write(output_unit, *) norm2(abs(matmul(A%data, x%data) - b%data)), b%norm()*rtol_sp
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_sp)
@@ -949,6 +960,9 @@ contains
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_dp)
+        if (allocated(error)) then
+            write(output_unit, *) norm2(abs(matmul(A%data, x%data) - b%data)),  b%norm() * rtol_dp
+        endif
 
         return
     end subroutine test_gmres_rdp
@@ -974,8 +988,6 @@ contains
         opts = gmres_dp_opts(kdim=test_size, verbose=.false.)
         call gmres(A, b, x, info, options=opts)
         call check_info(info, 'gmres', module=this_module, procedure='test_gmres_spd_rdp')
-
-        write(output_unit, *) norm2(abs(matmul(A%data, x%data) - b%data)), b%norm()*rtol_dp
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_dp)
@@ -1016,6 +1028,9 @@ contains
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_sp)
+        if (allocated(error)) then
+            write(output_unit, *) norm2(abs(matmul(A%data, x%data) - b%data)),  b%norm() * rtol_sp
+        endif
 
         return
     end subroutine test_gmres_csp
@@ -1041,8 +1056,6 @@ contains
         opts = gmres_sp_opts(kdim=test_size, verbose=.false.)
         call gmres(A, b, x, info, options=opts)
         call check_info(info, 'gmres', module=this_module, procedure='test_gmres_spd_csp')
-
-        write(output_unit, *) norm2(abs(matmul(A%data, x%data) - b%data)), b%norm()*rtol_sp
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_sp)
@@ -1083,6 +1096,9 @@ contains
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_dp)
+        if (allocated(error)) then
+            write(output_unit, *) norm2(abs(matmul(A%data, x%data) - b%data)),  b%norm() * rtol_dp
+        endif
 
         return
     end subroutine test_gmres_cdp
@@ -1108,8 +1124,6 @@ contains
         opts = gmres_dp_opts(kdim=test_size, verbose=.false.)
         call gmres(A, b, x, info, options=opts)
         call check_info(info, 'gmres', module=this_module, procedure='test_gmres_spd_cdp')
-
-        write(output_unit, *) norm2(abs(matmul(A%data, x%data) - b%data)), b%norm()*rtol_dp
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_dp)

--- a/test/TestIterativeSolvers.f90
+++ b/test/TestIterativeSolvers.f90
@@ -112,11 +112,6 @@ contains
 
         ! check eigenvalues
         call check(error, maxval(abs(eigvals - true_eigvals(:nev))) < rtol_sp)
-            write(output_unit, *) "True eigenvalues / Computed eigenvalues / Difference"
-            do i = 1, nev
-                write(output_unit, *) "    -", true_eigvals(i), eigvals(i), abs(eigvals(i) - true_eigvals(i)), rtol_sp, atol_sp
-            enddo
-            write(output_unit, *) "|| err ||_inf :",  maxval(abs(eigvals - true_eigvals(:nev))) 
         !if (allocated(error)) return
         !! check eigenvectors
         !allocate(AX(nev))
@@ -170,7 +165,7 @@ contains
         enddo
 
         ! Compute spectral decomposition.
-        call eigs(A, X, eigvals, residuals, info)
+        call eigs(A, X, eigvals, residuals, info, tolerance=atol_sp)
         call check_info(info, 'eigs', module=this_module, procedure='test_evp_rsp')
 
         ! Analytical eigenvalues.
@@ -181,7 +176,7 @@ contains
             k = k+1
         enddo
 
-        call check(error, norm2(abs(eigvals - true_eigvals)) < rtol_sp)
+        call check(error, maxval(abs(eigvals - true_eigvals)) < rtol_sp)
 !        if (allocated(error)) return
 !
 !        ! check eigenvectors
@@ -238,7 +233,7 @@ contains
         allocate(X(test_size)) ; call zero_basis(X)
 
         ! Spectral decomposition.
-        call eighs(A, X, evals, residuals, info, kdim=test_size)
+        call eighs(A, X, evals, residuals, info, kdim=test_size, tolerance=atol_sp)
         call check_info(info, 'eighs', module=this_module, procedure='test_sym_evp_rsp')
 
         ! Analytical eigenvalues.
@@ -248,7 +243,7 @@ contains
         enddo
 
         ! Check error.
-        call check(error, all_close(evals, true_evals, rtol_sp, atol_sp))
+        call check(error, maxval(abs(true_evals - evals)) < rtol_sp)
         if (allocated(error)) return
 
         ! check eigenvectors
@@ -268,7 +263,7 @@ contains
 
         ! Check orthonormality of the eigenvectors.
         Id = eye(test_size)
-        call check(error, norm2(abs(G - Id)) < rtol_sp)
+        call check(error, maxval(abs(G - Id)) < rtol_sp)
 
         return
     end subroutine test_sym_evp_rsp
@@ -337,11 +332,6 @@ contains
 
         ! check eigenvalues
         call check(error, maxval(abs(eigvals - true_eigvals(:nev))) < rtol_dp)
-            write(output_unit, *) "True eigenvalues / Computed eigenvalues / Difference"
-            do i = 1, nev
-                write(output_unit, *) "    -", true_eigvals(i), eigvals(i), abs(eigvals(i) - true_eigvals(i)), rtol_dp, atol_dp
-            enddo
-            write(output_unit, *) "|| err ||_inf :",  maxval(abs(eigvals - true_eigvals(:nev))) 
         !if (allocated(error)) return
         !! check eigenvectors
         !allocate(AX(nev))
@@ -395,7 +385,7 @@ contains
         enddo
 
         ! Compute spectral decomposition.
-        call eigs(A, X, eigvals, residuals, info)
+        call eigs(A, X, eigvals, residuals, info, tolerance=atol_dp)
         call check_info(info, 'eigs', module=this_module, procedure='test_evp_rdp')
 
         ! Analytical eigenvalues.
@@ -406,7 +396,7 @@ contains
             k = k+1
         enddo
 
-        call check(error, norm2(abs(eigvals - true_eigvals)) < rtol_dp)
+        call check(error, maxval(abs(eigvals - true_eigvals)) < rtol_dp)
 !        if (allocated(error)) return
 !
 !        ! check eigenvectors
@@ -463,7 +453,7 @@ contains
         allocate(X(test_size)) ; call zero_basis(X)
 
         ! Spectral decomposition.
-        call eighs(A, X, evals, residuals, info, kdim=test_size)
+        call eighs(A, X, evals, residuals, info, kdim=test_size, tolerance=atol_dp)
         call check_info(info, 'eighs', module=this_module, procedure='test_sym_evp_rdp')
 
         ! Analytical eigenvalues.
@@ -473,7 +463,7 @@ contains
         enddo
 
         ! Check error.
-        call check(error, all_close(evals, true_evals, rtol_dp, atol_dp))
+        call check(error, maxval(abs(true_evals - evals)) < rtol_dp)
         if (allocated(error)) return
 
         ! check eigenvectors
@@ -493,7 +483,7 @@ contains
 
         ! Check orthonormality of the eigenvectors.
         Id = eye(test_size)
-        call check(error, norm2(abs(G - Id)) < rtol_dp)
+        call check(error, maxval(abs(G - Id)) < rtol_dp)
 
         return
     end subroutine test_sym_evp_rdp
@@ -676,7 +666,7 @@ contains
             true_svdvals(i) = 2.0_sp * (1.0_sp + cos(i*pi/(test_size+1)))
         enddo
 
-        call check(error, norm2(s - true_svdvals)**2 < rtol_sp)
+        call check(error, maxval(s - true_svdvals) < rtol_sp)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the Krylov basis of the left singular vectors.
@@ -685,7 +675,7 @@ contains
 
         ! Check orthonormality of the left singular vectors
         Id = eye(test_size)
-        call check(error, norm2(abs(G - Id)) < rtol_sp)
+        call check(error, maxval(abs(G - Id)) < rtol_sp)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the Krylov basis of the right singular vectors.
@@ -693,7 +683,7 @@ contains
         call innerprod(G, V(1:test_size), V(1:test_size))
 
         ! Check orthonormality of the right singular vectors
-        call check(error, norm2(abs(G - Id)) < rtol_sp)
+        call check(error, maxval(abs(G - Id)) < rtol_sp)
         if (allocated(error)) return
 
         ! Check correctness of full factorization.
@@ -760,7 +750,7 @@ contains
             true_svdvals(i) = 2.0_dp * (1.0_dp + cos(i*pi/(test_size+1)))
         enddo
 
-        call check(error, norm2(s - true_svdvals)**2 < rtol_dp)
+        call check(error, maxval(s - true_svdvals) < rtol_dp)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the Krylov basis of the left singular vectors.
@@ -769,7 +759,7 @@ contains
 
         ! Check orthonormality of the left singular vectors
         Id = eye(test_size)
-        call check(error, norm2(abs(G - Id)) < rtol_dp)
+        call check(error, maxval(abs(G - Id)) < rtol_dp)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the Krylov basis of the right singular vectors.
@@ -777,7 +767,7 @@ contains
         call innerprod(G, V(1:test_size), V(1:test_size))
 
         ! Check orthonormality of the right singular vectors
-        call check(error, norm2(abs(G - Id)) < rtol_dp)
+        call check(error, maxval(abs(G - Id)) < rtol_dp)
         if (allocated(error)) return
 
         ! Check correctness of full factorization.
@@ -892,9 +882,6 @@ contains
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_sp)
-        if (allocated(error)) then
-            write(output_unit, *) norm2(abs(matmul(A%data, x%data) - b%data)),  b%norm() * rtol_sp
-        endif
 
         return
     end subroutine test_gmres_rsp
@@ -917,7 +904,7 @@ contains
         x = vector_rsp() ; call x%zero()
 
         ! GMRES solver.
-        opts = gmres_sp_opts(kdim=test_size, verbose=.false.)
+        opts = gmres_sp_opts(kdim=test_size, verbose=.false., rtol=rtol_sp, atol=atol_sp)
         call gmres(A, b, x, info, options=opts)
         call check_info(info, 'gmres', module=this_module, procedure='test_gmres_spd_rsp')
 
@@ -960,9 +947,6 @@ contains
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_dp)
-        if (allocated(error)) then
-            write(output_unit, *) norm2(abs(matmul(A%data, x%data) - b%data)),  b%norm() * rtol_dp
-        endif
 
         return
     end subroutine test_gmres_rdp
@@ -985,7 +969,7 @@ contains
         x = vector_rdp() ; call x%zero()
 
         ! GMRES solver.
-        opts = gmres_dp_opts(kdim=test_size, verbose=.false.)
+        opts = gmres_dp_opts(kdim=test_size, verbose=.false., rtol=rtol_dp, atol=atol_dp)
         call gmres(A, b, x, info, options=opts)
         call check_info(info, 'gmres', module=this_module, procedure='test_gmres_spd_rdp')
 
@@ -1028,9 +1012,6 @@ contains
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_sp)
-        if (allocated(error)) then
-            write(output_unit, *) norm2(abs(matmul(A%data, x%data) - b%data)),  b%norm() * rtol_sp
-        endif
 
         return
     end subroutine test_gmres_csp
@@ -1053,7 +1034,7 @@ contains
         x = vector_csp() ; call x%zero()
 
         ! GMRES solver.
-        opts = gmres_sp_opts(kdim=test_size, verbose=.false.)
+        opts = gmres_sp_opts(kdim=test_size, verbose=.false., rtol=rtol_sp, atol=atol_sp)
         call gmres(A, b, x, info, options=opts)
         call check_info(info, 'gmres', module=this_module, procedure='test_gmres_spd_csp')
 
@@ -1096,9 +1077,6 @@ contains
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_dp)
-        if (allocated(error)) then
-            write(output_unit, *) norm2(abs(matmul(A%data, x%data) - b%data)),  b%norm() * rtol_dp
-        endif
 
         return
     end subroutine test_gmres_cdp
@@ -1121,7 +1099,7 @@ contains
         x = vector_cdp() ; call x%zero()
 
         ! GMRES solver.
-        opts = gmres_dp_opts(kdim=test_size, verbose=.false.)
+        opts = gmres_dp_opts(kdim=test_size, verbose=.false., rtol=rtol_dp, atol=atol_dp)
         call gmres(A, b, x, info, options=opts)
         call check_info(info, 'gmres', module=this_module, procedure='test_gmres_spd_cdp')
 
@@ -1161,11 +1139,9 @@ contains
         x = vector_rsp() ; call x%zero()
 
         ! CG solver.
-        opts = cg_sp_opts()
+        opts = cg_sp_opts(rtol=rtol_sp, atol=atol_sp)
         call cg(A, b, x, info, options=opts)
         call check_info(info, 'cg', module=this_module, procedure='test_cg_rsp')
-
-        write(*, *) norm2(abs(matmul(A%data, x%data) - b%data)), b%norm() * rtol_sp 
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_sp)
@@ -1198,11 +1174,9 @@ contains
         x = vector_rdp() ; call x%zero()
 
         ! CG solver.
-        opts = cg_dp_opts()
+        opts = cg_dp_opts(rtol=rtol_dp, atol=atol_dp)
         call cg(A, b, x, info, options=opts)
         call check_info(info, 'cg', module=this_module, procedure='test_cg_rdp')
-
-        write(*, *) norm2(abs(matmul(A%data, x%data) - b%data)), b%norm() * rtol_dp 
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_dp)
@@ -1235,11 +1209,9 @@ contains
         x = vector_csp() ; call x%zero()
 
         ! CG solver.
-        opts = cg_sp_opts()
+        opts = cg_sp_opts(rtol=rtol_sp, atol=atol_sp)
         call cg(A, b, x, info, options=opts)
         call check_info(info, 'cg', module=this_module, procedure='test_cg_csp')
-
-        write(*, *) norm2(abs(matmul(A%data, x%data) - b%data)), b%norm() * rtol_sp 
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_sp)
@@ -1272,11 +1244,9 @@ contains
         x = vector_cdp() ; call x%zero()
 
         ! CG solver.
-        opts = cg_dp_opts()
+        opts = cg_dp_opts(rtol=rtol_dp, atol=atol_dp)
         call cg(A, b, x, info, options=opts)
         call check_info(info, 'cg', module=this_module, procedure='test_cg_cdp')
-
-        write(*, *) norm2(abs(matmul(A%data, x%data) - b%data)), b%norm() * rtol_dp 
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_dp)

--- a/test/TestIterativeSolvers.f90
+++ b/test/TestIterativeSolvers.f90
@@ -853,7 +853,7 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
         testsuite = [ &
                     new_unittest("Full GMRES", test_gmres_rsp), &
-                    new_unittest("Full (SPD) GMRES", test_gmres_rsp) &
+                    new_unittest("Full (SPD) GMRES", test_gmres_spd_rsp) &
                     ]
         return
     end subroutine collect_gmres_rsp_testsuite
@@ -908,6 +908,8 @@ contains
         call gmres(A, b, x, info, options=opts)
         call check_info(info, 'gmres', module=this_module, procedure='test_gmres_spd_rsp')
 
+        write(output_unit, *) norm2(abs(matmul(A%data, x%data) - b%data)), b%norm()*rtol_sp
+
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_sp)
 
@@ -918,7 +920,7 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
         testsuite = [ &
                     new_unittest("Full GMRES", test_gmres_rdp), &
-                    new_unittest("Full (SPD) GMRES", test_gmres_rdp) &
+                    new_unittest("Full (SPD) GMRES", test_gmres_spd_rdp) &
                     ]
         return
     end subroutine collect_gmres_rdp_testsuite
@@ -973,6 +975,8 @@ contains
         call gmres(A, b, x, info, options=opts)
         call check_info(info, 'gmres', module=this_module, procedure='test_gmres_spd_rdp')
 
+        write(output_unit, *) norm2(abs(matmul(A%data, x%data) - b%data)), b%norm()*rtol_dp
+
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_dp)
 
@@ -983,7 +987,7 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
         testsuite = [ &
                     new_unittest("Full GMRES", test_gmres_csp), &
-                    new_unittest("Full (SPD) GMRES", test_gmres_csp) &
+                    new_unittest("Full (SPD) GMRES", test_gmres_spd_csp) &
                     ]
         return
     end subroutine collect_gmres_csp_testsuite
@@ -1038,6 +1042,8 @@ contains
         call gmres(A, b, x, info, options=opts)
         call check_info(info, 'gmres', module=this_module, procedure='test_gmres_spd_csp')
 
+        write(output_unit, *) norm2(abs(matmul(A%data, x%data) - b%data)), b%norm()*rtol_sp
+
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_sp)
 
@@ -1048,7 +1054,7 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
         testsuite = [ &
                     new_unittest("Full GMRES", test_gmres_cdp), &
-                    new_unittest("Full (SPD) GMRES", test_gmres_cdp) &
+                    new_unittest("Full (SPD) GMRES", test_gmres_spd_cdp) &
                     ]
         return
     end subroutine collect_gmres_cdp_testsuite
@@ -1102,6 +1108,8 @@ contains
         opts = gmres_dp_opts(kdim=test_size, verbose=.false.)
         call gmres(A, b, x, info, options=opts)
         call check_info(info, 'gmres', module=this_module, procedure='test_gmres_spd_cdp')
+
+        write(output_unit, *) norm2(abs(matmul(A%data, x%data) - b%data)), b%norm()*rtol_dp
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_dp)

--- a/test/TestIterativeSolvers.fypp
+++ b/test/TestIterativeSolvers.fypp
@@ -163,7 +163,7 @@ contains
         enddo
 
         ! Compute spectral decomposition.
-        call eigs(A, X, eigvals, residuals, info)
+        call eigs(A, X, eigvals, residuals, info, tolerance=atol_${kind}$)
         call check_info(info, 'eigs', module=this_module, procedure='test_evp_${type[0]}$${kind}$')
 
         ! Analytical eigenvalues.
@@ -174,7 +174,7 @@ contains
             k = k+1
         enddo
 
-        call check(error, norm2(abs(eigvals - true_eigvals)) < rtol_${kind}$)
+        call check(error, maxval(abs(eigvals - true_eigvals)) < rtol_${kind}$)
 !        if (allocated(error)) return
 !
 !        ! check eigenvectors
@@ -233,7 +233,7 @@ contains
         allocate(X(test_size)) ; call zero_basis(X)
 
         ! Spectral decomposition.
-        call eighs(A, X, evals, residuals, info, kdim=test_size)
+        call eighs(A, X, evals, residuals, info, kdim=test_size, tolerance=atol_${kind}$)
         call check_info(info, 'eighs', module=this_module, procedure='test_sym_evp_${type[0]}$${kind}$')
 
         ! Analytical eigenvalues.
@@ -243,7 +243,7 @@ contains
         enddo
 
         ! Check error.
-        call check(error, all_close(evals, true_evals, rtol_${kind}$, atol_${kind}$))
+        call check(error, maxval(abs(true_evals - evals)) < rtol_${kind}$)
         if (allocated(error)) return
 
         ! check eigenvectors
@@ -263,7 +263,7 @@ contains
 
         ! Check orthonormality of the eigenvectors.
         Id = eye(test_size)
-        call check(error, norm2(abs(G - Id)) < rtol_${kind}$)
+        call check(error, maxval(abs(G - Id)) < rtol_${kind}$)
 
         return
     end subroutine test_sym_evp_${type[0]}$${kind}$
@@ -333,7 +333,7 @@ contains
             true_svdvals(i) = 2.0_${kind}$ * (1.0_${kind}$ + cos(i*pi/(test_size+1)))
         enddo
 
-        call check(error, norm2(s - true_svdvals)**2 < rtol_${kind}$)
+        call check(error, maxval(s - true_svdvals) < rtol_${kind}$)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the Krylov basis of the left singular vectors.
@@ -342,7 +342,7 @@ contains
 
         ! Check orthonormality of the left singular vectors
         Id = eye(test_size)
-        call check(error, norm2(abs(G - Id)) < rtol_${kind}$)
+        call check(error, maxval(abs(G - Id)) < rtol_${kind}$)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the Krylov basis of the right singular vectors.
@@ -350,7 +350,7 @@ contains
         call innerprod(G, V(1:test_size), V(1:test_size))
 
         ! Check orthonormality of the right singular vectors
-        call check(error, norm2(abs(G - Id)) < rtol_${kind}$)
+        call check(error, maxval(abs(G - Id)) < rtol_${kind}$)
         if (allocated(error)) return
 
         ! Check correctness of full factorization.
@@ -432,7 +432,7 @@ contains
         x = vector_${type[0]}$${kind}$() ; call x%zero()
 
         ! GMRES solver.
-        opts = gmres_${kind}$_opts(kdim=test_size, verbose=.false.)
+        opts = gmres_${kind}$_opts(kdim=test_size, verbose=.false., rtol=rtol_${kind}$, atol=atol_${kind}$)
         call gmres(A, b, x, info, options=opts)
         call check_info(info, 'gmres', module=this_module, procedure='test_gmres_spd_${type[0]}$${kind}$')
 
@@ -482,11 +482,9 @@ contains
         x = vector_${type[0]}$${kind}$() ; call x%zero()
 
         ! CG solver.
-        opts = cg_${kind}$_opts()
+        opts = cg_${kind}$_opts(rtol=rtol_${kind}$, atol=atol_${kind}$)
         call cg(A, b, x, info, options=opts)
         call check_info(info, 'cg', module=this_module, procedure='test_cg_${type[0]}$${kind}$')
-
-        write(*, *) norm2(abs(matmul(A%data, x%data) - b%data)), b%norm() * rtol_${kind}$ 
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_${kind}$)

--- a/test/TestIterativeSolvers.fypp
+++ b/test/TestIterativeSolvers.fypp
@@ -373,7 +373,7 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
         testsuite = [ &
                     new_unittest("Full GMRES", test_gmres_${type[0]}$${kind}$), &
-                    new_unittest("Full (SPD) GMRES", test_gmres_${type[0]}$${kind}$) &
+                    new_unittest("Full (SPD) GMRES", test_gmres_spd_${type[0]}$${kind}$) &
                     ]
         return
     end subroutine collect_gmres_${type[0]}$${kind}$_testsuite

--- a/test/TestIterativeSolvers.fypp
+++ b/test/TestIterativeSolvers.fypp
@@ -95,7 +95,7 @@ contains
         enddo
 
         ! Compute spectral decomposition.
-        call eigs(A, X, eigvals, residuals, info)
+        call eigs(A, X, eigvals, residuals, info, tolerance=atol_${kind}$)
         call check_info(info, 'eigs', module=this_module, procedure='test_ks_evp_${type[0]}$${kind}$')
 
         ! Analytical eigenvalues.
@@ -107,7 +107,7 @@ contains
         enddo
 
         ! check eigenvalues
-        call check(error, norm2(abs(eigvals - true_eigvals(:nev))) < rtol_${kind}$)
+        call check(error, maxval(abs(eigvals - true_eigvals(:nev))) < rtol_${kind}$)
         !if (allocated(error)) return
         !! check eigenvectors
         !allocate(AX(nev))

--- a/test/TestIterativeSolvers.fypp
+++ b/test/TestIterativeSolvers.fypp
@@ -3,6 +3,7 @@
 module TestIterativeSolvers
     ! Fortran Standard library.
     use iso_fortran_env
+    use stdlib_io_npy, only: save_npy
     use stdlib_math, only: is_close, all_close
     use stdlib_linalg, only: eye, diag
     use stdlib_stats, only : median
@@ -77,7 +78,7 @@ contains
         ${type}$ :: a_, b_
 
         ! Allocate eigenvectors.
-        allocate(X(nev)) ; call initialize_krylov_subspace(X)
+        allocate(X(nev)) ; call zero_basis(X)
         
         ! Initialize linear operator with random tridiagonal Toeplitz matrix.
         A = linop_${type[0]}$${kind}$() ; A%data = 0.0_${kind}$ ; n = size(A%data, 1)
@@ -145,7 +146,7 @@ contains
         ${type}$ :: a_, b_
 
         ! Allocate eigenvectors.
-        allocate(X(test_size)) ; call initialize_krylov_subspace(X)
+        allocate(X(test_size)) ; call zero_basis(X)
         
         ! Initialize linear operator with random tridiagonal Toeplitz matrix.
         A = linop_${type[0]}$${kind}$() ; A%data = 0.0_${kind}$ ; n = size(A%data, 1)
@@ -229,7 +230,7 @@ contains
 
         ! Allocations.
         A = spd_linop_${type[0]}$${kind}$(T)
-        allocate(X(test_size)) ; call initialize_krylov_subspace(X)
+        allocate(X(test_size)) ; call zero_basis(X)
 
         ! Spectral decomposition.
         call eighs(A, X, evals, residuals, info, kdim=test_size)
@@ -307,8 +308,8 @@ contains
         #:if type[0] == "r"
 
         ! Allocate eigenvectors.
-        allocate(U(test_size)) ; call initialize_krylov_subspace(U)
-        allocate(V(test_size)) ; call initialize_krylov_subspace(V)
+        allocate(U(test_size)) ; call zero_basis(U)
+        allocate(V(test_size)) ; call zero_basis(V)
         
         ! Initialize linear operator with the Strang matrix.
         A = linop_${type[0]}$${kind}$() ; A%data = 0.0_${kind}$ ; n = size(A%data, 1)
@@ -324,7 +325,7 @@ contains
         enddo
 
         ! Compute spectral decomposition.
-        call svds(A, U, S, V, residuals, info)
+        call svds(A, U, S, V, residuals, info, tolerance=atol_${kind}$)
         call check_info(info, 'svds', module=this_module, procedure='test_svd_${type[0]}$${kind}$')
 
         ! Analytical singular values.
@@ -395,7 +396,7 @@ contains
         x = vector_${type[0]}$${kind}$() ; call x%zero()
 
         ! GMRES solver.
-        opts = gmres_${kind}$_opts(kdim=test_size, verbose=.false.)
+        opts = gmres_${kind}$_opts(kdim=test_size, verbose=.false., rtol=rtol_${kind}$, atol=atol_${kind}$)
         call gmres(A, b, x, info, options=opts)
         call check_info(info, 'gmres', module=this_module, procedure='test_gmres_${type[0]}$${kind}$')
 

--- a/test/TestKrylov.f90
+++ b/test/TestKrylov.f90
@@ -82,7 +82,7 @@ contains
         call get_data(Adata, A)
 
         ! In-place QR factorization.
-        call qr(A, R, info)
+        call qr(A, R, info, tol=atol_sp)
         call check_info(info, 'qr', module=this_module, procedure='test_qr_factorization_rsp')
 
         ! Get data.
@@ -148,7 +148,7 @@ contains
         call get_data(Adata, A)
 
         ! In-place QR factorization.
-        call qr(A, R, perm, info)
+        call qr(A, R, perm, info, tol=atol_sp)
         call check_info(info, 'qr_pivot', module=this_module, procedure='test_pivoting_qr_exact_rank_deficiency_rsp')
 
         ! Extract data
@@ -202,7 +202,7 @@ contains
         call get_data(Adata, A)
 
         ! In-place QR factorization.
-        call qr(A, R, info)
+        call qr(A, R, info, tol=atol_dp)
         call check_info(info, 'qr', module=this_module, procedure='test_qr_factorization_rdp')
 
         ! Get data.
@@ -268,7 +268,7 @@ contains
         call get_data(Adata, A)
 
         ! In-place QR factorization.
-        call qr(A, R, perm, info)
+        call qr(A, R, perm, info, tol=atol_dp)
         call check_info(info, 'qr_pivot', module=this_module, procedure='test_pivoting_qr_exact_rank_deficiency_rdp')
 
         ! Extract data
@@ -322,7 +322,7 @@ contains
         call get_data(Adata, A)
 
         ! In-place QR factorization.
-        call qr(A, R, info)
+        call qr(A, R, info, tol=atol_sp)
         call check_info(info, 'qr', module=this_module, procedure='test_qr_factorization_csp')
 
         ! Get data.
@@ -388,7 +388,7 @@ contains
         call get_data(Adata, A)
 
         ! In-place QR factorization.
-        call qr(A, R, perm, info)
+        call qr(A, R, perm, info, tol=atol_sp)
         call check_info(info, 'qr_pivot', module=this_module, procedure='test_pivoting_qr_exact_rank_deficiency_csp')
 
         ! Extract data
@@ -442,7 +442,7 @@ contains
         call get_data(Adata, A)
 
         ! In-place QR factorization.
-        call qr(A, R, info)
+        call qr(A, R, info, tol=atol_dp)
         call check_info(info, 'qr', module=this_module, procedure='test_qr_factorization_cdp')
 
         ! Get data.
@@ -508,7 +508,7 @@ contains
         call get_data(Adata, A)
 
         ! In-place QR factorization.
-        call qr(A, R, perm, info)
+        call qr(A, R, perm, info, tol=atol_dp)
         call check_info(info, 'qr_pivot', module=this_module, procedure='test_pivoting_qr_exact_rank_deficiency_cdp')
 
         ! Extract data
@@ -570,7 +570,7 @@ contains
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
         H = zero_rsp
         ! Arnoldi factorization.
-        call arnoldi(A, X, H, info)
+        call arnoldi(A, X, H, info, tol=atol_sp)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_arnoldi_factorization_rsp')
 
         ! Check correctness of full factorization.
@@ -584,7 +584,7 @@ contains
 
         ! Check orthonormality of the computed basis.
         Id = eye(kdim)
-        call check(error, norm2(abs(G - Id)) < rtol_sp)
+        call check(error, maxval(abs(G - Id)) < rtol_sp)
 
         return
     end subroutine test_arnoldi_factorization_rsp
@@ -617,7 +617,7 @@ contains
         H = zero_rsp
 
         ! Arnoldi factorization.
-        call arnoldi(A, X, H, info, blksize=p)
+        call arnoldi(A, X, H, info, blksize=p, tol=atol_sp)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_block_arnoldi_factorization_rsp')
 
         ! Check correctness of full factorization.
@@ -631,7 +631,7 @@ contains
 
         ! Check orthonormality of the computed basis.
         Id = eye(p*kdim)
-        call check(error, norm2(abs(G - Id)) < rtol_sp)
+        call check(error, maxval(abs(G - Id)) < rtol_sp)
 
         return
     end subroutine test_block_arnoldi_factorization_rsp
@@ -665,7 +665,7 @@ contains
         H = zero_rsp
 
         ! Arnoldi factorization.
-        call arnoldi(A, X, H, info)
+        call arnoldi(A, X, H, info, tol=atol_sp)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_krylov_schur_rsp')
 
         ! Krylov-Schur condensation.
@@ -722,7 +722,7 @@ contains
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
         H = zero_rdp
         ! Arnoldi factorization.
-        call arnoldi(A, X, H, info)
+        call arnoldi(A, X, H, info, tol=atol_dp)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_arnoldi_factorization_rdp')
 
         ! Check correctness of full factorization.
@@ -736,7 +736,7 @@ contains
 
         ! Check orthonormality of the computed basis.
         Id = eye(kdim)
-        call check(error, norm2(abs(G - Id)) < rtol_dp)
+        call check(error, maxval(abs(G - Id)) < rtol_dp)
 
         return
     end subroutine test_arnoldi_factorization_rdp
@@ -769,7 +769,7 @@ contains
         H = zero_rdp
 
         ! Arnoldi factorization.
-        call arnoldi(A, X, H, info, blksize=p)
+        call arnoldi(A, X, H, info, blksize=p, tol=atol_dp)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_block_arnoldi_factorization_rdp')
 
         ! Check correctness of full factorization.
@@ -783,7 +783,7 @@ contains
 
         ! Check orthonormality of the computed basis.
         Id = eye(p*kdim)
-        call check(error, norm2(abs(G - Id)) < rtol_dp)
+        call check(error, maxval(abs(G - Id)) < rtol_dp)
 
         return
     end subroutine test_block_arnoldi_factorization_rdp
@@ -817,7 +817,7 @@ contains
         H = zero_rdp
 
         ! Arnoldi factorization.
-        call arnoldi(A, X, H, info)
+        call arnoldi(A, X, H, info, tol=atol_dp)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_krylov_schur_rdp')
 
         ! Krylov-Schur condensation.
@@ -874,7 +874,7 @@ contains
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
         H = zero_csp
         ! Arnoldi factorization.
-        call arnoldi(A, X, H, info)
+        call arnoldi(A, X, H, info, tol=atol_sp)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_arnoldi_factorization_csp')
 
         ! Check correctness of full factorization.
@@ -888,7 +888,7 @@ contains
 
         ! Check orthonormality of the computed basis.
         Id = eye(kdim)
-        call check(error, norm2(abs(G - Id)) < rtol_sp)
+        call check(error, maxval(abs(G - Id)) < rtol_sp)
 
         return
     end subroutine test_arnoldi_factorization_csp
@@ -921,7 +921,7 @@ contains
         H = zero_csp
 
         ! Arnoldi factorization.
-        call arnoldi(A, X, H, info, blksize=p)
+        call arnoldi(A, X, H, info, blksize=p, tol=atol_sp)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_block_arnoldi_factorization_csp')
 
         ! Check correctness of full factorization.
@@ -935,7 +935,7 @@ contains
 
         ! Check orthonormality of the computed basis.
         Id = eye(p*kdim)
-        call check(error, norm2(abs(G - Id)) < rtol_sp)
+        call check(error, maxval(abs(G - Id)) < rtol_sp)
 
         return
     end subroutine test_block_arnoldi_factorization_csp
@@ -969,7 +969,7 @@ contains
         H = zero_csp
 
         ! Arnoldi factorization.
-        call arnoldi(A, X, H, info)
+        call arnoldi(A, X, H, info, tol=atol_sp)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_krylov_schur_csp')
 
         ! Krylov-Schur condensation.
@@ -1026,7 +1026,7 @@ contains
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
         H = zero_cdp
         ! Arnoldi factorization.
-        call arnoldi(A, X, H, info)
+        call arnoldi(A, X, H, info, tol=atol_dp)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_arnoldi_factorization_cdp')
 
         ! Check correctness of full factorization.
@@ -1040,7 +1040,7 @@ contains
 
         ! Check orthonormality of the computed basis.
         Id = eye(kdim)
-        call check(error, norm2(abs(G - Id)) < rtol_dp)
+        call check(error, maxval(abs(G - Id)) < rtol_dp)
 
         return
     end subroutine test_arnoldi_factorization_cdp
@@ -1073,7 +1073,7 @@ contains
         H = zero_cdp
 
         ! Arnoldi factorization.
-        call arnoldi(A, X, H, info, blksize=p)
+        call arnoldi(A, X, H, info, blksize=p, tol=atol_dp)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_block_arnoldi_factorization_cdp')
 
         ! Check correctness of full factorization.
@@ -1087,7 +1087,7 @@ contains
 
         ! Check orthonormality of the computed basis.
         Id = eye(p*kdim)
-        call check(error, norm2(abs(G - Id)) < rtol_dp)
+        call check(error, maxval(abs(G - Id)) < rtol_dp)
 
         return
     end subroutine test_block_arnoldi_factorization_cdp
@@ -1121,7 +1121,7 @@ contains
         H = zero_cdp
 
         ! Arnoldi factorization.
-        call arnoldi(A, X, H, info)
+        call arnoldi(A, X, H, info, tol=atol_dp)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_krylov_schur_cdp')
 
         ! Krylov-Schur condensation.
@@ -1186,7 +1186,7 @@ contains
         call initialize_krylov_subspace(V) ; B = zero_rsp
 
         ! Lanczos bidiagonalization.
-        call lanczos_bidiagonalization(A, U, V, B, info)
+        call lanczos_bidiagonalization(A, U, V, B, info, tol=atol_sp)
         call check_info(info, 'lanczos_bidiagonalization', module=this_module, &
                         & procedure='test_lanczos_bidiag_factorization_rsp')
 
@@ -1204,7 +1204,7 @@ contains
 
         ! Check orthonormality of the left basis.
         Id = eye(kdim)
-        call check(error, norm2(abs(G - Id)) < rtol_sp)
+        call check(error, maxval(abs(G - Id)) < rtol_sp)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the right Krylov basis.
@@ -1212,7 +1212,7 @@ contains
         call innerprod(G, V(1:kdim), V(1:kdim))
 
         ! Check orthonormality of the right basis.
-        call check(error, norm2(abs(G - Id)) < rtol_sp)
+        call check(error, maxval(abs(G - Id)) < rtol_sp)
 
         return
     end subroutine test_lanczos_bidiag_factorization_rsp
@@ -1255,7 +1255,7 @@ contains
         call initialize_krylov_subspace(V) ; B = zero_rdp
 
         ! Lanczos bidiagonalization.
-        call lanczos_bidiagonalization(A, U, V, B, info)
+        call lanczos_bidiagonalization(A, U, V, B, info, tol=atol_dp)
         call check_info(info, 'lanczos_bidiagonalization', module=this_module, &
                         & procedure='test_lanczos_bidiag_factorization_rdp')
 
@@ -1273,7 +1273,7 @@ contains
 
         ! Check orthonormality of the left basis.
         Id = eye(kdim)
-        call check(error, norm2(abs(G - Id)) < rtol_dp)
+        call check(error, maxval(abs(G - Id)) < rtol_dp)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the right Krylov basis.
@@ -1281,7 +1281,7 @@ contains
         call innerprod(G, V(1:kdim), V(1:kdim))
 
         ! Check orthonormality of the right basis.
-        call check(error, norm2(abs(G - Id)) < rtol_dp)
+        call check(error, maxval(abs(G - Id)) < rtol_dp)
 
         return
     end subroutine test_lanczos_bidiag_factorization_rdp
@@ -1324,7 +1324,7 @@ contains
         call initialize_krylov_subspace(V) ; B = zero_csp
 
         ! Lanczos bidiagonalization.
-        call lanczos_bidiagonalization(A, U, V, B, info)
+        call lanczos_bidiagonalization(A, U, V, B, info, tol=atol_sp)
         call check_info(info, 'lanczos_bidiagonalization', module=this_module, &
                         & procedure='test_lanczos_bidiag_factorization_csp')
 
@@ -1342,7 +1342,7 @@ contains
 
         ! Check orthonormality of the left basis.
         Id = eye(kdim)
-        call check(error, norm2(abs(G - Id)) < rtol_sp)
+        call check(error, maxval(abs(G - Id)) < rtol_sp)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the right Krylov basis.
@@ -1350,7 +1350,7 @@ contains
         call innerprod(G, V(1:kdim), V(1:kdim))
 
         ! Check orthonormality of the right basis.
-        call check(error, norm2(abs(G - Id)) < rtol_sp)
+        call check(error, maxval(abs(G - Id)) < rtol_sp)
 
         return
     end subroutine test_lanczos_bidiag_factorization_csp
@@ -1393,7 +1393,7 @@ contains
         call initialize_krylov_subspace(V) ; B = zero_cdp
 
         ! Lanczos bidiagonalization.
-        call lanczos_bidiagonalization(A, U, V, B, info)
+        call lanczos_bidiagonalization(A, U, V, B, info, tol=atol_dp)
         call check_info(info, 'lanczos_bidiagonalization', module=this_module, &
                         & procedure='test_lanczos_bidiag_factorization_cdp')
 
@@ -1411,7 +1411,7 @@ contains
 
         ! Check orthonormality of the left basis.
         Id = eye(kdim)
-        call check(error, norm2(abs(G - Id)) < rtol_dp)
+        call check(error, maxval(abs(G - Id)) < rtol_dp)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the right Krylov basis.
@@ -1419,7 +1419,7 @@ contains
         call innerprod(G, V(1:kdim), V(1:kdim))
 
         ! Check orthonormality of the right basis.
-        call check(error, norm2(abs(G - Id)) < rtol_dp)
+        call check(error, maxval(abs(G - Id)) < rtol_dp)
 
         return
     end subroutine test_lanczos_bidiag_factorization_cdp
@@ -1472,7 +1472,7 @@ contains
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
 
         ! Lanczos factorization.
-        call lanczos_tridiagonalization(A, X, T, info)
+        call lanczos_tridiagonalization(A, X, T, info, tol=atol_sp)
         call check_info(info, 'lanczos_tridiagonalization', module=this_module, & 
                         & procedure='test_lanczos_tridiag_full_factorization_rsp')
 
@@ -1490,7 +1490,7 @@ contains
 
         ! Check orthonormality of the Krylov basis.
         Id = eye(kdim)
-        call check(error, norm2(abs(G - Id)) < rtol_sp)
+        call check(error, maxval(abs(G - Id)) < rtol_sp)
 
         return
     end subroutine test_lanczos_tridiag_factorization_rsp
@@ -1538,7 +1538,7 @@ contains
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
 
         ! Lanczos factorization.
-        call lanczos_tridiagonalization(A, X, T, info)
+        call lanczos_tridiagonalization(A, X, T, info, tol=atol_dp)
         call check_info(info, 'lanczos_tridiagonalization', module=this_module, & 
                         & procedure='test_lanczos_tridiag_full_factorization_rdp')
 
@@ -1556,7 +1556,7 @@ contains
 
         ! Check orthonormality of the Krylov basis.
         Id = eye(kdim)
-        call check(error, norm2(abs(G - Id)) < rtol_dp)
+        call check(error, maxval(abs(G - Id)) < rtol_dp)
 
         return
     end subroutine test_lanczos_tridiag_factorization_rdp
@@ -1604,7 +1604,7 @@ contains
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
 
         ! Lanczos factorization.
-        call lanczos_tridiagonalization(A, X, T, info)
+        call lanczos_tridiagonalization(A, X, T, info, tol=atol_sp)
         call check_info(info, 'lanczos_tridiagonalization', module=this_module, & 
                         & procedure='test_lanczos_tridiag_full_factorization_csp')
 
@@ -1622,7 +1622,7 @@ contains
 
         ! Check orthonormality of the Krylov basis.
         Id = eye(kdim)
-        call check(error, norm2(abs(G - Id)) < rtol_sp)
+        call check(error, maxval(abs(G - Id)) < rtol_sp)
 
         return
     end subroutine test_lanczos_tridiag_factorization_csp
@@ -1670,7 +1670,7 @@ contains
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
 
         ! Lanczos factorization.
-        call lanczos_tridiagonalization(A, X, T, info)
+        call lanczos_tridiagonalization(A, X, T, info, tol=atol_dp)
         call check_info(info, 'lanczos_tridiagonalization', module=this_module, & 
                         & procedure='test_lanczos_tridiag_full_factorization_cdp')
 
@@ -1688,7 +1688,7 @@ contains
 
         ! Check orthonormality of the Krylov basis.
         Id = eye(kdim)
-        call check(error, norm2(abs(G - Id)) < rtol_dp)
+        call check(error, maxval(abs(G - Id)) < rtol_dp)
 
         return
     end subroutine test_lanczos_tridiag_factorization_cdp

--- a/test/TestKrylov.fypp
+++ b/test/TestKrylov.fypp
@@ -71,7 +71,7 @@ contains
         call get_data(Adata, A)
 
         ! In-place QR factorization.
-        call qr(A, R, info)
+        call qr(A, R, info, tol=atol_${kind}$)
         call check_info(info, 'qr', module=this_module, procedure='test_qr_factorization_${type[0]}$${kind}$')
 
         ! Get data.
@@ -137,7 +137,7 @@ contains
         call get_data(Adata, A)
 
         ! In-place QR factorization.
-        call qr(A, R, perm, info)
+        call qr(A, R, perm, info, tol=atol_${kind}$)
         call check_info(info, 'qr_pivot', module=this_module, procedure='test_pivoting_qr_exact_rank_deficiency_${type[0]}$${kind}$')
 
         ! Extract data
@@ -201,7 +201,7 @@ contains
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
         H = zero_${type[0]}$${kind}$
         ! Arnoldi factorization.
-        call arnoldi(A, X, H, info)
+        call arnoldi(A, X, H, info, tol=atol_${kind}$)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_arnoldi_factorization_${type[0]}$${kind}$')
 
         ! Check correctness of full factorization.
@@ -215,7 +215,7 @@ contains
 
         ! Check orthonormality of the computed basis.
         Id = eye(kdim)
-        call check(error, norm2(abs(G - Id)) < rtol_${kind}$)
+        call check(error, maxval(abs(G - Id)) < rtol_${kind}$)
 
         return
     end subroutine test_arnoldi_factorization_${type[0]}$${kind}$
@@ -248,7 +248,7 @@ contains
         H = zero_${type[0]}$${kind}$
 
         ! Arnoldi factorization.
-        call arnoldi(A, X, H, info, blksize=p)
+        call arnoldi(A, X, H, info, blksize=p, tol=atol_${kind}$)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_block_arnoldi_factorization_${type[0]}$${kind}$')
 
         ! Check correctness of full factorization.
@@ -262,7 +262,7 @@ contains
 
         ! Check orthonormality of the computed basis.
         Id = eye(p*kdim)
-        call check(error, norm2(abs(G - Id)) < rtol_${kind}$)
+        call check(error, maxval(abs(G - Id)) < rtol_${kind}$)
 
         return
     end subroutine test_block_arnoldi_factorization_${type[0]}$${kind}$
@@ -296,7 +296,7 @@ contains
         H = zero_${type[0]}$${kind}$
 
         ! Arnoldi factorization.
-        call arnoldi(A, X, H, info)
+        call arnoldi(A, X, H, info, tol=atol_${kind}$)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_krylov_schur_${type[0]}$${kind}$')
 
         ! Krylov-Schur condensation.
@@ -362,7 +362,7 @@ contains
         call initialize_krylov_subspace(V) ; B = zero_${type[0]}$${kind}$
 
         ! Lanczos bidiagonalization.
-        call lanczos_bidiagonalization(A, U, V, B, info)
+        call lanczos_bidiagonalization(A, U, V, B, info, tol=atol_${kind}$)
         call check_info(info, 'lanczos_bidiagonalization', module=this_module, &
                         & procedure='test_lanczos_bidiag_factorization_${type[0]}$${kind}$')
 
@@ -380,7 +380,7 @@ contains
 
         ! Check orthonormality of the left basis.
         Id = eye(kdim)
-        call check(error, norm2(abs(G - Id)) < rtol_${kind}$)
+        call check(error, maxval(abs(G - Id)) < rtol_${kind}$)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the right Krylov basis.
@@ -388,7 +388,7 @@ contains
         call innerprod(G, V(1:kdim), V(1:kdim))
 
         ! Check orthonormality of the right basis.
-        call check(error, norm2(abs(G - Id)) < rtol_${kind}$)
+        call check(error, maxval(abs(G - Id)) < rtol_${kind}$)
 
         return
     end subroutine test_lanczos_bidiag_factorization_${type[0]}$${kind}$
@@ -451,7 +451,7 @@ contains
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
 
         ! Lanczos factorization.
-        call lanczos_tridiagonalization(A, X, T, info)
+        call lanczos_tridiagonalization(A, X, T, info, tol=atol_${kind}$)
         call check_info(info, 'lanczos_tridiagonalization', module=this_module, & 
                         & procedure='test_lanczos_tridiag_full_factorization_${type[0]}$${kind}$')
 
@@ -469,7 +469,7 @@ contains
 
         ! Check orthonormality of the Krylov basis.
         Id = eye(kdim)
-        call check(error, norm2(abs(G - Id)) < rtol_${kind}$)
+        call check(error, maxval(abs(G - Id)) < rtol_${kind}$)
 
         return
     end subroutine test_lanczos_tridiag_factorization_${type[0]}$${kind}$

--- a/test/Tests.f90
+++ b/test/Tests.f90
@@ -39,13 +39,16 @@ program Tester
                 new_testsuite("Real Linops (sp) Test Suite", collect_linop_rsp_testsuite), &
                 new_testsuite("Real QR (sp) Test Suite", collect_qr_rsp_testsuite), &
                 new_testsuite("Real Arnoldi (sp) Test Suite", collect_arnoldi_rsp_testsuite), &
-                ! new_testsuite("Real Lanczos bidiagonalization (sp) Test Suite", collect_lanczos_bidiag_rsp_testsuite), &
+                new_testsuite("Real Lanczos bidiagonalization (sp) Test Suite", collect_lanczos_bidiag_rsp_testsuite), &
                 new_testsuite("Real Lanczos tridiagonalization (sp) Test Suite", collect_lanczos_tridiag_rsp_testsuite), &
-                new_testsuite("Real EVP (sp) Test Suite", collect_eig_rsp_testsuite), & 
+                new_testsuite("Real EVP (sp) Test Suite", collect_eig_rsp_testsuite), &
                 new_testsuite("Real SVD (sp) Test Suite", collect_svd_rsp_testsuite), &
                 new_testsuite("Real GMRES (sp) Test Suite", collect_gmres_rsp_testsuite), &
-                new_testsuite("Real CG (sp) Test Suite", collect_cg_rsp_testsuite) &
+                new_testsuite("Real CG (sp) Test Suite", collect_cg_rsp_testsuite), &
+                ! new_testsuite("Real Expm (sp) Test Suite", collect_expm_rsp_testsuite), &
+                new_testsuite("Real Sqrtm (sp) Test Suite", collect_sqrtm_rsp_testsuite) &
                 ]
+
 
    write(output_unit, *) "----------------------------------------------------------------"
    write(output_unit, *) "-----                                                      -----"
@@ -119,14 +122,16 @@ program Tester
    !-----------------------------------------------------
 
    testsuites = [ &
-                new_testsuite("Complex Vector (sp) Test Suite", collect_vector_csp_testsuite), &
-                new_testsuite("Complex Linops (sp) Test Suite", collect_linop_csp_testsuite), &
+                new_testsuite("Complex Vector (sp) Test Suite", collect_vector_csp_testsuite),  &
+                new_testsuite("Complex Linops (sp) Test Suite", collect_linop_csp_testsuite),  &
                 new_testsuite("Complex QR (sp) Test Suite", collect_qr_csp_testsuite), &
                 new_testsuite("Complex Arnoldi (sp) Test Suite", collect_arnoldi_csp_testsuite), &
                 ! new_testsuite("Complex Lanczos bidiagonalization (sp) Test Suite", collect_lanczos_bidiag_csp_testsuite), &
                 new_testsuite("Complex Lanczos tridiagonalization (sp) Test Suite", collect_lanczos_tridiag_csp_testsuite), &
                 new_testsuite("Complex GMRES (sp) Test Suite", collect_gmres_csp_testsuite), &
-                new_testsuite("Complex CG (sp) Test Suite", collect_cg_csp_testsuite) &
+                new_testsuite("Complex CG (sp) Test Suite", collect_cg_csp_testsuite), &
+                new_testsuite("Complex Expm. (sp) Test Suite", collect_expm_csp_testsuite), &
+                new_testsuite("Complex Sqrtm (sp) Test Suite", collect_sqrtm_csp_testsuite) &
                 ]
 
    write(output_unit, *) "-------------------------------------------------------------------"
@@ -161,7 +166,7 @@ program Tester
                 new_testsuite("Complex Vector (dp) Test Suite", collect_vector_cdp_testsuite),  &
                 new_testsuite("Complex Linops (dp) Test Suite", collect_linop_cdp_testsuite),  &
                 new_testsuite("Complex QR (dp) Test Suite", collect_qr_cdp_testsuite), &
-                new_testsuite("Complex QR (dp) Test Suite", collect_arnoldi_cdp_testsuite), &
+                new_testsuite("Complex Arnoldi (dp) Test Suite", collect_arnoldi_cdp_testsuite), &
                 ! new_testsuite("Complex Lanczos bidiagonalization (dp) Test Suite", collect_lanczos_bidiag_cdp_testsuite), &
                 new_testsuite("Complex Lanczos tridiagonalization (dp) Test Suite", collect_lanczos_tridiag_cdp_testsuite), &
                 new_testsuite("Complex GMRES (dp) Test Suite", collect_gmres_cdp_testsuite), &

--- a/test/Tests.f90
+++ b/test/Tests.f90
@@ -30,46 +30,46 @@ program Tester
 
    status = 0
 
-   ! !----------------------------------------------------
-   ! !-----     REAL SINGLE-PRECISION TEST SUITE     -----
-   ! !----------------------------------------------------
-   !
-   ! testsuites = [ &
-   !              new_testsuite("Real Vector (sp) Test Suite", collect_vector_rsp_testsuite), &
-   !              new_testsuite("Real Linops (sp) Test Suite", collect_linop_rsp_testsuite), &
-   !              new_testsuite("Real QR (sp) Test Suite", collect_qr_rsp_testsuite), &
-   !              new_testsuite("Real Arnoldi (sp) Test Suite", collect_arnoldi_rsp_testsuite), &
-   !              ! new_testsuite("Real Lanczos bidiagonalization (sp) Test Suite", collect_lanczos_bidiag_rsp_testsuite), &
-   !              new_testsuite("Real Lanczos tridiagonalization (sp) Test Suite", collect_lanczos_tridiag_rsp_testsuite), &
-   !              new_testsuite("Real EVP (sp) Test Suite", collect_eig_rsp_testsuite), & 
-   !              new_testsuite("Real SVD (sp) Test Suite", collect_svd_rsp_testsuite), &
-   !              new_testsuite("Real GMRES (sp) Test Suite", collect_gmres_rsp_testsuite), &
-   !              new_testsuite("Real CG (sp) Test Suite", collect_cg_rsp_testsuite) &
-   !              ]
-   !
-   ! write(output_unit, *) "----------------------------------------------------------------"
-   ! write(output_unit, *) "-----                                                      -----"
-   ! write(output_unit, *) "-----     RUNNING THE REAL SINGLE-PRECISION TEST SUITE     -----"
-   ! write(output_unit, *) "-----                                                      -----"
-   ! write(output_unit, *) "----------------------------------------------------------------"
-   ! write(output_unit, *)
-   !
-   ! do is = 1, size(testsuites)
-   !    write (*, *) "-------------------------------"
-   !    write (error_unit, fmt) "Testing :", testsuites(is)%name
-   !    write (*, *) "-------------------------------"
-   !    write (*, *)
-   !    call run_testsuite(testsuites(is)%collect, error_unit, status)
-   !    write (*, *)
-   ! end do
-   !
-   ! if (status > 0) then
-   !    write (error_unit, '(i0, 1x, a)') status, "test(s) failed!"
-   !    error stop
-   ! else if (status == 0) then
-   !    write (*, *) "All tests successfully passed!"
-   !    write (*, *)
-   ! end if
+   !----------------------------------------------------
+   !-----     REAL SINGLE-PRECISION TEST SUITE     -----
+   !----------------------------------------------------
+
+   testsuites = [ &
+                new_testsuite("Real Vector (sp) Test Suite", collect_vector_rsp_testsuite), &
+                new_testsuite("Real Linops (sp) Test Suite", collect_linop_rsp_testsuite), &
+                new_testsuite("Real QR (sp) Test Suite", collect_qr_rsp_testsuite), &
+                new_testsuite("Real Arnoldi (sp) Test Suite", collect_arnoldi_rsp_testsuite), &
+                ! new_testsuite("Real Lanczos bidiagonalization (sp) Test Suite", collect_lanczos_bidiag_rsp_testsuite), &
+                new_testsuite("Real Lanczos tridiagonalization (sp) Test Suite", collect_lanczos_tridiag_rsp_testsuite), &
+                new_testsuite("Real EVP (sp) Test Suite", collect_eig_rsp_testsuite), & 
+                new_testsuite("Real SVD (sp) Test Suite", collect_svd_rsp_testsuite), &
+                new_testsuite("Real GMRES (sp) Test Suite", collect_gmres_rsp_testsuite), &
+                new_testsuite("Real CG (sp) Test Suite", collect_cg_rsp_testsuite) &
+                ]
+
+   write(output_unit, *) "----------------------------------------------------------------"
+   write(output_unit, *) "-----                                                      -----"
+   write(output_unit, *) "-----     RUNNING THE REAL SINGLE-PRECISION TEST SUITE     -----"
+   write(output_unit, *) "-----                                                      -----"
+   write(output_unit, *) "----------------------------------------------------------------"
+   write(output_unit, *)
+
+   do is = 1, size(testsuites)
+      write (*, *) "-------------------------------"
+      write (error_unit, fmt) "Testing :", testsuites(is)%name
+      write (*, *) "-------------------------------"
+      write (*, *)
+      call run_testsuite(testsuites(is)%collect, error_unit, status)
+      write (*, *)
+   end do
+
+   if (status > 0) then
+      write (error_unit, '(i0, 1x, a)') status, "test(s) failed!"
+      error stop
+   else if (status == 0) then
+      write (*, *) "All tests successfully passed!"
+      write (*, *)
+   end if
 
    !----------------------------------------------------
    !-----     REAL DOUBLE-PRECISION TEST SUITE     -----
@@ -114,44 +114,44 @@ program Tester
       write (*, *)
    end if
 
-   ! !-----------------------------------------------------
-   ! !-----     COMPLEX SING-PRECISION TEST SUITE     -----
-   ! !-----------------------------------------------------
-   !
-   ! testsuites = [ &
-   !              new_testsuite("Complex Vector (sp) Test Suite", collect_vector_csp_testsuite), &
-   !              new_testsuite("Complex Linops (sp) Test Suite", collect_linop_csp_testsuite), &
-   !              new_testsuite("Complex QR (sp) Test Suite", collect_qr_csp_testsuite), &
-   !              new_testsuite("Complex Arnoldi (sp) Test Suite", collect_arnoldi_csp_testsuite), &
-   !              ! new_testsuite("Complex Lanczos bidiagonalization (sp) Test Suite", collect_lanczos_bidiag_csp_testsuite), &
-   !              new_testsuite("Complex Lanczos tridiagonalization (sp) Test Suite", collect_lanczos_tridiag_csp_testsuite), &
-   !              new_testsuite("Complex GMRES (sp) Test Suite", collect_gmres_csp_testsuite), &
-   !              new_testsuite("Complex CG (sp) Test Suite", collect_cg_csp_testsuite) &
-   !              ]
-   !
-   ! write(output_unit, *) "-------------------------------------------------------------------"
-   ! write(output_unit, *) "-----                                                         -----"
-   ! write(output_unit, *) "-----     RUNNING THE COMPLEX SINGLE-PRECISION TEST SUITE     -----"
-   ! write(output_unit, *) "-----                                                         -----"
-   ! write(output_unit, *) "-------------------------------------------------------------------"
-   ! write(output_unit, *)
-   !
-   ! do is = 1, size(testsuites)
-   !    write (*, *) "-------------------------------"
-   !    write (error_unit, fmt) "Testing :", testsuites(is)%name
-   !    write (*, *) "-------------------------------"
-   !    write (*, *)
-   !    call run_testsuite(testsuites(is)%collect, error_unit, status)
-   !    write (*, *)
-   ! end do
-   !
-   ! if (status > 0) then
-   !    write (error_unit, '(i0, 1x, a)') status, "test(s) failed!"
-   !    error stop
-   ! else if (status == 0) then
-   !    write (*, *) "All tests successfully passed!"
-   !    write (*, *)
-   ! end if
+   !-----------------------------------------------------
+   !-----     COMPLEX SING-PRECISION TEST SUITE     -----
+   !-----------------------------------------------------
+
+   testsuites = [ &
+                new_testsuite("Complex Vector (sp) Test Suite", collect_vector_csp_testsuite), &
+                new_testsuite("Complex Linops (sp) Test Suite", collect_linop_csp_testsuite), &
+                new_testsuite("Complex QR (sp) Test Suite", collect_qr_csp_testsuite), &
+                new_testsuite("Complex Arnoldi (sp) Test Suite", collect_arnoldi_csp_testsuite), &
+                ! new_testsuite("Complex Lanczos bidiagonalization (sp) Test Suite", collect_lanczos_bidiag_csp_testsuite), &
+                new_testsuite("Complex Lanczos tridiagonalization (sp) Test Suite", collect_lanczos_tridiag_csp_testsuite), &
+                new_testsuite("Complex GMRES (sp) Test Suite", collect_gmres_csp_testsuite), &
+                new_testsuite("Complex CG (sp) Test Suite", collect_cg_csp_testsuite) &
+                ]
+
+   write(output_unit, *) "-------------------------------------------------------------------"
+   write(output_unit, *) "-----                                                         -----"
+   write(output_unit, *) "-----     RUNNING THE COMPLEX SINGLE-PRECISION TEST SUITE     -----"
+   write(output_unit, *) "-----                                                         -----"
+   write(output_unit, *) "-------------------------------------------------------------------"
+   write(output_unit, *)
+
+   do is = 1, size(testsuites)
+      write (*, *) "-------------------------------"
+      write (error_unit, fmt) "Testing :", testsuites(is)%name
+      write (*, *) "-------------------------------"
+      write (*, *)
+      call run_testsuite(testsuites(is)%collect, error_unit, status)
+      write (*, *)
+   end do
+
+   if (status > 0) then
+      write (error_unit, '(i0, 1x, a)') status, "test(s) failed!"
+      error stop
+   else if (status == 0) then
+      write (*, *) "All tests successfully passed!"
+      write (*, *)
+   end if
 
    !-------------------------------------------------------
    !-----     COMPLEX DOUBLE-PRECISION TEST SUITE     -----


### PR DESCRIPTION
This PR includes a handful of small bug fixes + turns on the single precision tests again. For most tests, the norm used to assess the error is set to the infinity norm wherever appropriate. I ran the tests close to 100 times on my laptop with both `gfortran` and `ifort` (both debug and optimized modes) and I no longer get failures.