### PR TITLE
Add get_size

### DIFF
--- a/example/ginzburg_landau/Ginzburg_Landau.f90
+++ b/example/ginzburg_landau/Ginzburg_Landau.f90
@@ -44,6 +44,7 @@ module Ginzburg_Landau
      procedure, pass(self), public :: scal
      procedure, pass(self), public :: axpby
      procedure, pass(self), public :: rand
+     procedure, pass(self), public :: get_size
   end type state_vector
 
   !------------------------------------------
@@ -292,6 +293,12 @@ contains
     end select
     return
   end subroutine axpby
+
+  integer function get_size(self) result(N)
+    class(state_vector), intent(in) :: self
+    N = nx
+    return
+  end function get_size
 
   subroutine rand(self, ifnorm)
     class(state_vector), intent(inout) :: self

--- a/fpm.toml
+++ b/fpm.toml
@@ -26,6 +26,7 @@ stdlib = "*"
 [dev-dependencies]
 test-drive.git = "https://github.com/fortran-lang/test-drive"
 test-drive.tag = "v0.4.0"
+FACE = {git="https://github.com/szaghi/FACE.git"}
 
 [[example]]
 

--- a/fpm.toml
+++ b/fpm.toml
@@ -24,8 +24,7 @@ source-form = "free"
 stdlib = "*"
 
 [dev-dependencies]
-test-drive.git = "https://github.com/fortran-lang/test-drive"
-test-drive.tag = "v0.4.0"
+test-drive.git = "https://github.com/nekStab/test-drive.git"
 FACE = {git="https://github.com/szaghi/FACE.git"}
 
 [[example]]

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,13 @@
+# Gfortran.
+python deployment.py
+
+fpm test --compiler "gfortran" --flag "-O0 -g3 -fbacktrace -Wall -Wextra -fcheck=all -pedantic -Wconversion -fbounds-check -ffpe-trap=zero,overflow,underflow" --verbose
+#fpm test --compiler "gfortran" --flag "-O3 -march=native -mtune=native"
+
+# Ifort
+#fpm test --compiler "ifort"
+#fpm test --compiler "ifort" --flag "-O3 -xhost"
+
+# Ifx
+#fpm test --compiler "ifx"
+#fpm test --compiler "ifx" --flag "-O3 -xhost"

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,8 +1,8 @@
 # Gfortran.
 python deployment.py
 
-fpm test --compiler "gfortran" --flag "-O0 -g3 -fbacktrace -Wall -Wextra -fcheck=all -pedantic -Wconversion -fbounds-check -ffpe-trap=zero,overflow,underflow" --verbose
-#fpm test --compiler "gfortran" --flag "-O3 -march=native -mtune=native"
+fpm test --compiler "gfortran" --flag "-O0 -g3 -fbacktrace -Wall -Wextra -fcheck=all -pedantic -Wconversion -fbounds-check -ffpe-trap=zero,overflow" --verbose
+fpm test --compiler "gfortran" --flag "-O3 -march=native -mtune=native"
 
 # Ifort
 #fpm test --compiler "ifort"

--- a/src/AbstractVectors.f90
+++ b/src/AbstractVectors.f90
@@ -1,6 +1,7 @@
 module lightkrylov_AbstractVectors
     use lightkrylov_constants
     use lightkrylov_utils
+    use LightKrylov_Logger
     implicit none
     private
 
@@ -518,7 +519,8 @@ contains
 
         ! Check sizes.
         if (size(X) /= size(v)) then
-            call stop_error("linear_combination: Krylov basis X and low-dimensional vector v have different sizes.")
+            call stop_error("Krylov basis X and low-dimensional vector v have different sizes.", &
+                              & module=this_module, procedure='linear_combination_vector_rsp')
         endif
 
         ! Initialize output vector.
@@ -546,7 +548,8 @@ contains
     
         ! Check sizes.
         if (size(X) /= size(B, 1)) then
-            call stop_error("linear_combination: Krylov basis X and combination matrix B have incompatible sizes.")
+            call stop_error("Krylov basis X and combination matrix B have incompatible sizes.", &
+                              & module=this_module, procedure='linear_combination_matrix_rsp')
         endif
 
         ! Initialize output basis.
@@ -554,7 +557,8 @@ contains
             allocate(Y(size(B, 2)), source=X(1))
         else
             if (size(Y) /= size(B, 2)) then
-                call stop_error("linear_combination: Krylov basis Y and combination matrix B have incompatible sizes.")
+                call stop_error("Krylov basis Y and combination matrix B have incompatible sizes.", &
+                              & module=this_module, procedure='linear_combination_matrix_rsp')
             endif
         endif
 
@@ -624,7 +628,8 @@ contains
 
         ! Check size.
         if (size(X) /= size(Y)) then
-            call stop_error("add_basis: X and Y have incompatible dimensions.")
+            call stop_error("X and Y have incompatible dimensions.", &
+                              & module=this_module, procedure='axpby_basis_rsp')
         endif
 
         ! Add basis.
@@ -653,7 +658,8 @@ contains
 
         ! Check size.
         if (size(out) /= size(from)) then
-            call stop_error("copy: from and out have incompatible dimensions.")
+            call stop_error("from and out have incompatible dimensions.", &
+                              & module=this_module, procedure='copy_basis_rsp')
         endif
 
         ! Copy array.
@@ -681,7 +687,8 @@ contains
 
         ! Check sizes.
         if (size(X) /= size(v)) then
-            call stop_error("linear_combination: Krylov basis X and low-dimensional vector v have different sizes.")
+            call stop_error("Krylov basis X and low-dimensional vector v have different sizes.", &
+                              & module=this_module, procedure='linear_combination_vector_rdp')
         endif
 
         ! Initialize output vector.
@@ -709,7 +716,8 @@ contains
     
         ! Check sizes.
         if (size(X) /= size(B, 1)) then
-            call stop_error("linear_combination: Krylov basis X and combination matrix B have incompatible sizes.")
+            call stop_error("Krylov basis X and combination matrix B have incompatible sizes.", &
+                              & module=this_module, procedure='linear_combination_matrix_rdp')
         endif
 
         ! Initialize output basis.
@@ -717,7 +725,8 @@ contains
             allocate(Y(size(B, 2)), source=X(1))
         else
             if (size(Y) /= size(B, 2)) then
-                call stop_error("linear_combination: Krylov basis Y and combination matrix B have incompatible sizes.")
+                call stop_error("Krylov basis Y and combination matrix B have incompatible sizes.", &
+                              & module=this_module, procedure='linear_combination_matrix_rdp')
             endif
         endif
 
@@ -787,7 +796,8 @@ contains
 
         ! Check size.
         if (size(X) /= size(Y)) then
-            call stop_error("add_basis: X and Y have incompatible dimensions.")
+            call stop_error("X and Y have incompatible dimensions.", &
+                              & module=this_module, procedure='axpby_basis_rdp')
         endif
 
         ! Add basis.
@@ -816,7 +826,8 @@ contains
 
         ! Check size.
         if (size(out) /= size(from)) then
-            call stop_error("copy: from and out have incompatible dimensions.")
+            call stop_error("from and out have incompatible dimensions.", &
+                              & module=this_module, procedure='copy_basis_rdp')
         endif
 
         ! Copy array.
@@ -844,7 +855,8 @@ contains
 
         ! Check sizes.
         if (size(X) /= size(v)) then
-            call stop_error("linear_combination: Krylov basis X and low-dimensional vector v have different sizes.")
+            call stop_error("Krylov basis X and low-dimensional vector v have different sizes.", &
+                              & module=this_module, procedure='linear_combination_vector_csp')
         endif
 
         ! Initialize output vector.
@@ -872,7 +884,8 @@ contains
     
         ! Check sizes.
         if (size(X) /= size(B, 1)) then
-            call stop_error("linear_combination: Krylov basis X and combination matrix B have incompatible sizes.")
+            call stop_error("Krylov basis X and combination matrix B have incompatible sizes.", &
+                              & module=this_module, procedure='linear_combination_matrix_csp')
         endif
 
         ! Initialize output basis.
@@ -880,7 +893,8 @@ contains
             allocate(Y(size(B, 2)), source=X(1))
         else
             if (size(Y) /= size(B, 2)) then
-                call stop_error("linear_combination: Krylov basis Y and combination matrix B have incompatible sizes.")
+                call stop_error("Krylov basis Y and combination matrix B have incompatible sizes.", &
+                              & module=this_module, procedure='linear_combination_matrix_csp')
             endif
         endif
 
@@ -950,7 +964,8 @@ contains
 
         ! Check size.
         if (size(X) /= size(Y)) then
-            call stop_error("add_basis: X and Y have incompatible dimensions.")
+            call stop_error("X and Y have incompatible dimensions.", &
+                              & module=this_module, procedure='axpby_basis_csp')
         endif
 
         ! Add basis.
@@ -979,7 +994,8 @@ contains
 
         ! Check size.
         if (size(out) /= size(from)) then
-            call stop_error("copy: from and out have incompatible dimensions.")
+            call stop_error("from and out have incompatible dimensions.", &
+                              & module=this_module, procedure='copy_basis_csp')
         endif
 
         ! Copy array.
@@ -1007,7 +1023,8 @@ contains
 
         ! Check sizes.
         if (size(X) /= size(v)) then
-            call stop_error("linear_combination: Krylov basis X and low-dimensional vector v have different sizes.")
+            call stop_error("Krylov basis X and low-dimensional vector v have different sizes.", &
+                              & module=this_module, procedure='linear_combination_vector_cdp')
         endif
 
         ! Initialize output vector.
@@ -1035,7 +1052,8 @@ contains
     
         ! Check sizes.
         if (size(X) /= size(B, 1)) then
-            call stop_error("linear_combination: Krylov basis X and combination matrix B have incompatible sizes.")
+            call stop_error("Krylov basis X and combination matrix B have incompatible sizes.", &
+                              & module=this_module, procedure='linear_combination_matrix_cdp')
         endif
 
         ! Initialize output basis.
@@ -1043,7 +1061,8 @@ contains
             allocate(Y(size(B, 2)), source=X(1))
         else
             if (size(Y) /= size(B, 2)) then
-                call stop_error("linear_combination: Krylov basis Y and combination matrix B have incompatible sizes.")
+                call stop_error("Krylov basis Y and combination matrix B have incompatible sizes.", &
+                              & module=this_module, procedure='linear_combination_matrix_cdp')
             endif
         endif
 
@@ -1113,7 +1132,8 @@ contains
 
         ! Check size.
         if (size(X) /= size(Y)) then
-            call stop_error("add_basis: X and Y have incompatible dimensions.")
+            call stop_error("X and Y have incompatible dimensions.", &
+                              & module=this_module, procedure='axpby_basis_cdp')
         endif
 
         ! Add basis.
@@ -1142,7 +1162,8 @@ contains
 
         ! Check size.
         if (size(out) /= size(from)) then
-            call stop_error("copy: from and out have incompatible dimensions.")
+            call stop_error("from and out have incompatible dimensions.", &
+                              & module=this_module, procedure='copy_basis_cdp')
         endif
 
         ! Copy array.

--- a/src/AbstractVectors.f90
+++ b/src/AbstractVectors.f90
@@ -80,6 +80,8 @@ module lightkrylov_AbstractVectors
         !! In-place computation of \( \mathbf{x} = \alpha \mathbf{x} + \beta \mathbf{y} \).
         procedure(abstract_dot_rsp), pass(self), deferred, public :: dot
         !! Computes the dot product between two `abstract_vector_rsp`.
+        procedure(abstract_get_size_rsp), pass(self), deferred, public :: get_size
+        !! Return size of specific abstract vector
         procedure, pass(self), public :: norm => norm_rsp
         !! Computes the norm of the `abstract_vector`.
         procedure, pass(self), public :: add => add_rsp
@@ -92,14 +94,14 @@ module lightkrylov_AbstractVectors
     abstract interface
         subroutine abstract_zero_rsp(self)
             !! Abstract interface to zero-out a vector in-place.
-            import abstract_vector_rsp, sp
+            import abstract_vector_rsp
             class(abstract_vector_rsp), intent(inout) :: self
             !! Vector to be zeroed-out.
         end subroutine abstract_zero_rsp
 
         subroutine abstract_rand_rsp(self, ifnorm)
             !! Abstract interface to generate a random (normalized) vector.
-            import abstract_vector_rsp, sp
+            import abstract_vector_rsp
             class(abstract_vector_rsp), intent(inout) :: self
             logical, optional, intent(in) :: ifnorm
         end subroutine abstract_rand_rsp
@@ -131,11 +133,17 @@ module lightkrylov_AbstractVectors
             real(sp) :: alpha
             !! Result of the dot product.
         end function abstract_dot_rsp
+
+        function abstract_get_size_rsp(self) result(N)
+            !! Abstract interface to return the size of the specific abstract vector.
+            import abstract_vector_rsp
+            class(abstract_vector_rsp), intent(in) :: self
+            !! Vectors whose dot product will be computed.
+            integer :: N
+            !! Size of the vector
+        end function abstract_get_size_rsp
+
     end interface
-
-
-
-
 
     !----------------------------------------------------------------------------
     !-----     Definition of an abstract real(dp) vector with kind=dp     -----
@@ -154,6 +162,8 @@ module lightkrylov_AbstractVectors
         !! In-place computation of \( \mathbf{x} = \alpha \mathbf{x} + \beta \mathbf{y} \).
         procedure(abstract_dot_rdp), pass(self), deferred, public :: dot
         !! Computes the dot product between two `abstract_vector_rdp`.
+        procedure(abstract_get_size_rdp), pass(self), deferred, public :: get_size
+        !! Return size of specific abstract vector
         procedure, pass(self), public :: norm => norm_rdp
         !! Computes the norm of the `abstract_vector`.
         procedure, pass(self), public :: add => add_rdp
@@ -166,14 +176,14 @@ module lightkrylov_AbstractVectors
     abstract interface
         subroutine abstract_zero_rdp(self)
             !! Abstract interface to zero-out a vector in-place.
-            import abstract_vector_rdp, dp
+            import abstract_vector_rdp
             class(abstract_vector_rdp), intent(inout) :: self
             !! Vector to be zeroed-out.
         end subroutine abstract_zero_rdp
 
         subroutine abstract_rand_rdp(self, ifnorm)
             !! Abstract interface to generate a random (normalized) vector.
-            import abstract_vector_rdp, dp
+            import abstract_vector_rdp
             class(abstract_vector_rdp), intent(inout) :: self
             logical, optional, intent(in) :: ifnorm
         end subroutine abstract_rand_rdp
@@ -205,11 +215,17 @@ module lightkrylov_AbstractVectors
             real(dp) :: alpha
             !! Result of the dot product.
         end function abstract_dot_rdp
+
+        function abstract_get_size_rdp(self) result(N)
+            !! Abstract interface to return the size of the specific abstract vector.
+            import abstract_vector_rdp
+            class(abstract_vector_rdp), intent(in) :: self
+            !! Vectors whose dot product will be computed.
+            integer :: N
+            !! Size of the vector
+        end function abstract_get_size_rdp
+
     end interface
-
-
-
-
 
     !----------------------------------------------------------------------------
     !-----     Definition of an abstract complex(sp) vector with kind=sp     -----
@@ -228,6 +244,8 @@ module lightkrylov_AbstractVectors
         !! In-place computation of \( \mathbf{x} = \alpha \mathbf{x} + \beta \mathbf{y} \).
         procedure(abstract_dot_csp), pass(self), deferred, public :: dot
         !! Computes the dot product between two `abstract_vector_csp`.
+        procedure(abstract_get_size_csp), pass(self), deferred, public :: get_size
+        !! Return size of specific abstract vector
         procedure, pass(self), public :: norm => norm_csp
         !! Computes the norm of the `abstract_vector`.
         procedure, pass(self), public :: add => add_csp
@@ -240,14 +258,14 @@ module lightkrylov_AbstractVectors
     abstract interface
         subroutine abstract_zero_csp(self)
             !! Abstract interface to zero-out a vector in-place.
-            import abstract_vector_csp, sp
+            import abstract_vector_csp
             class(abstract_vector_csp), intent(inout) :: self
             !! Vector to be zeroed-out.
         end subroutine abstract_zero_csp
 
         subroutine abstract_rand_csp(self, ifnorm)
             !! Abstract interface to generate a random (normalized) vector.
-            import abstract_vector_csp, sp
+            import abstract_vector_csp
             class(abstract_vector_csp), intent(inout) :: self
             logical, optional, intent(in) :: ifnorm
         end subroutine abstract_rand_csp
@@ -279,11 +297,17 @@ module lightkrylov_AbstractVectors
             complex(sp) :: alpha
             !! Result of the dot product.
         end function abstract_dot_csp
+
+        function abstract_get_size_csp(self) result(N)
+            !! Abstract interface to return the size of the specific abstract vector.
+            import abstract_vector_csp
+            class(abstract_vector_csp), intent(in) :: self
+            !! Vectors whose dot product will be computed.
+            integer :: N
+            !! Size of the vector
+        end function abstract_get_size_csp
+
     end interface
-
-
-
-
 
     !----------------------------------------------------------------------------
     !-----     Definition of an abstract complex(dp) vector with kind=dp     -----
@@ -302,6 +326,8 @@ module lightkrylov_AbstractVectors
         !! In-place computation of \( \mathbf{x} = \alpha \mathbf{x} + \beta \mathbf{y} \).
         procedure(abstract_dot_cdp), pass(self), deferred, public :: dot
         !! Computes the dot product between two `abstract_vector_cdp`.
+        procedure(abstract_get_size_cdp), pass(self), deferred, public :: get_size
+        !! Return size of specific abstract vector
         procedure, pass(self), public :: norm => norm_cdp
         !! Computes the norm of the `abstract_vector`.
         procedure, pass(self), public :: add => add_cdp
@@ -314,14 +340,14 @@ module lightkrylov_AbstractVectors
     abstract interface
         subroutine abstract_zero_cdp(self)
             !! Abstract interface to zero-out a vector in-place.
-            import abstract_vector_cdp, dp
+            import abstract_vector_cdp
             class(abstract_vector_cdp), intent(inout) :: self
             !! Vector to be zeroed-out.
         end subroutine abstract_zero_cdp
 
         subroutine abstract_rand_cdp(self, ifnorm)
             !! Abstract interface to generate a random (normalized) vector.
-            import abstract_vector_cdp, dp
+            import abstract_vector_cdp
             class(abstract_vector_cdp), intent(inout) :: self
             logical, optional, intent(in) :: ifnorm
         end subroutine abstract_rand_cdp
@@ -353,11 +379,17 @@ module lightkrylov_AbstractVectors
             complex(dp) :: alpha
             !! Result of the dot product.
         end function abstract_dot_cdp
+
+        function abstract_get_size_cdp(self) result(N)
+            !! Abstract interface to return the size of the specific abstract vector.
+            import abstract_vector_cdp
+            class(abstract_vector_cdp), intent(in) :: self
+            !! Vectors whose dot product will be computed.
+            integer :: N
+            !! Size of the vector
+        end function abstract_get_size_cdp
+
     end interface
-
-
-
-
 
 contains
 

--- a/src/AbstractVectors.f90
+++ b/src/AbstractVectors.f90
@@ -5,7 +5,7 @@ module lightkrylov_AbstractVectors
     implicit none
     private
 
-    character*128, parameter :: this_module = 'Lightkrylov_AbstractVectors'
+    character(len=128), parameter :: this_module = 'Lightkrylov_AbstractVectors'
 
     public :: innerprod
     public :: linear_combination

--- a/src/AbstractVectors.fypp
+++ b/src/AbstractVectors.fypp
@@ -72,6 +72,8 @@ module lightkrylov_AbstractVectors
         !! In-place computation of \( \mathbf{x} = \alpha \mathbf{x} + \beta \mathbf{y} \).
         procedure(abstract_dot_${type[0]}$${kind}$), pass(self), deferred, public :: dot
         !! Computes the dot product between two `abstract_vector_${type[0]}$${kind}$`.
+        procedure(abstract_get_size_${type[0]}$${kind}$), pass(self), deferred, public :: get_size
+        !! Return size of specific abstract vector
         procedure, pass(self), public :: norm => norm_${type[0]}$${kind}$
         !! Computes the norm of the `abstract_vector`.
         procedure, pass(self), public :: add => add_${type[0]}$${kind}$
@@ -84,14 +86,14 @@ module lightkrylov_AbstractVectors
     abstract interface
         subroutine abstract_zero_${type[0]}$${kind}$(self)
             !! Abstract interface to zero-out a vector in-place.
-            import abstract_vector_${type[0]}$${kind}$, ${kind}$
+            import abstract_vector_${type[0]}$${kind}$
             class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: self
             !! Vector to be zeroed-out.
         end subroutine abstract_zero_${type[0]}$${kind}$
 
         subroutine abstract_rand_${type[0]}$${kind}$(self, ifnorm)
             !! Abstract interface to generate a random (normalized) vector.
-            import abstract_vector_${type[0]}$${kind}$, ${kind}$
+            import abstract_vector_${type[0]}$${kind}$
             class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: self
             logical, optional, intent(in) :: ifnorm
         end subroutine abstract_rand_${type[0]}$${kind}$
@@ -123,11 +125,17 @@ module lightkrylov_AbstractVectors
             ${type}$ :: alpha
             !! Result of the dot product.
         end function abstract_dot_${type[0]}$${kind}$
+
+        function abstract_get_size_${type[0]}$${kind}$(self) result(N)
+            !! Abstract interface to return the size of the specific abstract vector.
+            import abstract_vector_${type[0]}$${kind}$
+            class(abstract_vector_${type[0]}$${kind}$), intent(in) :: self
+            !! Vectors whose dot product will be computed.
+            integer :: N
+            !! Size of the vector
+        end function abstract_get_size_${type[0]}$${kind}$
+
     end interface
-
-
-
-
 
     #:endfor
 contains

--- a/src/AbstractVectors.fypp
+++ b/src/AbstractVectors.fypp
@@ -3,6 +3,7 @@
 module lightkrylov_AbstractVectors
     use lightkrylov_constants
     use lightkrylov_utils
+    use LightKrylov_Logger
     implicit none
     private
 
@@ -202,7 +203,8 @@ contains
 
         ! Check sizes.
         if (size(X) /= size(v)) then
-            call stop_error("linear_combination: Krylov basis X and low-dimensional vector v have different sizes.")
+            call stop_error("Krylov basis X and low-dimensional vector v have different sizes.", &
+                              & module=this_module, procedure='linear_combination_vector_${type[0]}$${kind}$')
         endif
 
         ! Initialize output vector.
@@ -230,7 +232,8 @@ contains
     
         ! Check sizes.
         if (size(X) /= size(B, 1)) then
-            call stop_error("linear_combination: Krylov basis X and combination matrix B have incompatible sizes.")
+            call stop_error("Krylov basis X and combination matrix B have incompatible sizes.", &
+                              & module=this_module, procedure='linear_combination_matrix_${type[0]}$${kind}$')
         endif
 
         ! Initialize output basis.
@@ -238,7 +241,8 @@ contains
             allocate(Y(size(B, 2)), source=X(1))
         else
             if (size(Y) /= size(B, 2)) then
-                call stop_error("linear_combination: Krylov basis Y and combination matrix B have incompatible sizes.")
+                call stop_error("Krylov basis Y and combination matrix B have incompatible sizes.", &
+                              & module=this_module, procedure='linear_combination_matrix_${type[0]}$${kind}$')
             endif
         endif
 
@@ -308,7 +312,8 @@ contains
 
         ! Check size.
         if (size(X) /= size(Y)) then
-            call stop_error("add_basis: X and Y have incompatible dimensions.")
+            call stop_error("X and Y have incompatible dimensions.", &
+                              & module=this_module, procedure='axpby_basis_${type[0]}$${kind}$')
         endif
 
         ! Add basis.
@@ -337,7 +342,8 @@ contains
 
         ! Check size.
         if (size(out) /= size(from)) then
-            call stop_error("copy: from and out have incompatible dimensions.")
+            call stop_error("from and out have incompatible dimensions.", &
+                              & module=this_module, procedure='copy_basis_${type[0]}$${kind}$')
         endif
 
         ! Copy array.

--- a/src/AbstractVectors.fypp
+++ b/src/AbstractVectors.fypp
@@ -7,7 +7,7 @@ module lightkrylov_AbstractVectors
     implicit none
     private
 
-    character*128, parameter :: this_module = 'Lightkrylov_AbstractVectors'
+    character(len=128), parameter :: this_module = 'Lightkrylov_AbstractVectors'
 
     public :: innerprod
     public :: linear_combination

--- a/src/BaseKrylov.f90
+++ b/src/BaseKrylov.f90
@@ -10,7 +10,7 @@ module lightkrylov_BaseKrylov
     implicit none
     private
     
-    character*128, parameter :: this_module = 'LightKrylov_BaseKrylov'
+    character(len=128), parameter :: this_module = 'LightKrylov_BaseKrylov'
 
     public :: qr
     public :: apply_permutation_matrix
@@ -1127,7 +1127,7 @@ contains
         ! Internal variables.
         real(sp) :: alpha
         real(sp) :: beta(size(Q))
-        integer :: idx, j, kdim, iwrk
+        integer :: j
 
         ! Deals with the optional args.
         verbose   = optval(verbosity, .false.)
@@ -1179,7 +1179,7 @@ contains
 
         ! Internal variables
         real(sp) :: beta
-        integer :: idx, i, j, kdim, iwrk
+        integer :: idx, i, j, kdim
         integer :: idxv(1)
         real(sp)  :: Rii(size(Q))
 
@@ -1332,7 +1332,7 @@ contains
         integer :: i
         real(sp), allocatable :: Qwrk(:, :)
 
-        Qwrk = Q
+        allocate(Qwrk, source=Q)
         do i = 1, size(perm)
             Q(:, i) = Qwrk(:, perm(i))
         enddo
@@ -1351,7 +1351,7 @@ contains
         integer :: inv_perm(size(perm))
         real(sp), allocatable :: Qwrk(:, :)
 
-        Qwrk = Q ; inv_perm = 0
+        allocate(Qwrk, source=Q) ; inv_perm = 0
 
         ! Inverse permutation vector.
         do i = 1, size(perm)
@@ -1384,7 +1384,7 @@ contains
         ! Internal variables.
         real(dp) :: alpha
         real(dp) :: beta(size(Q))
-        integer :: idx, j, kdim, iwrk
+        integer :: j
 
         ! Deals with the optional args.
         verbose   = optval(verbosity, .false.)
@@ -1436,7 +1436,7 @@ contains
 
         ! Internal variables
         real(dp) :: beta
-        integer :: idx, i, j, kdim, iwrk
+        integer :: idx, i, j, kdim
         integer :: idxv(1)
         real(dp)  :: Rii(size(Q))
 
@@ -1589,7 +1589,7 @@ contains
         integer :: i
         real(dp), allocatable :: Qwrk(:, :)
 
-        Qwrk = Q
+        allocate(Qwrk, source=Q)
         do i = 1, size(perm)
             Q(:, i) = Qwrk(:, perm(i))
         enddo
@@ -1608,7 +1608,7 @@ contains
         integer :: inv_perm(size(perm))
         real(dp), allocatable :: Qwrk(:, :)
 
-        Qwrk = Q ; inv_perm = 0
+        allocate(Qwrk, source=Q) ; inv_perm = 0
 
         ! Inverse permutation vector.
         do i = 1, size(perm)
@@ -1641,7 +1641,7 @@ contains
         ! Internal variables.
         complex(sp) :: alpha
         complex(sp) :: beta(size(Q))
-        integer :: idx, j, kdim, iwrk
+        integer :: j
 
         ! Deals with the optional args.
         verbose   = optval(verbosity, .false.)
@@ -1693,7 +1693,7 @@ contains
 
         ! Internal variables
         complex(sp) :: beta
-        integer :: idx, i, j, kdim, iwrk
+        integer :: idx, i, j, kdim
         integer :: idxv(1)
         complex(sp)  :: Rii(size(Q))
 
@@ -1846,7 +1846,7 @@ contains
         integer :: i
         complex(sp), allocatable :: Qwrk(:, :)
 
-        Qwrk = Q
+        allocate(Qwrk, source=Q)
         do i = 1, size(perm)
             Q(:, i) = Qwrk(:, perm(i))
         enddo
@@ -1865,7 +1865,7 @@ contains
         integer :: inv_perm(size(perm))
         complex(sp), allocatable :: Qwrk(:, :)
 
-        Qwrk = Q ; inv_perm = 0
+        allocate(Qwrk, source=Q) ; inv_perm = 0
 
         ! Inverse permutation vector.
         do i = 1, size(perm)
@@ -1898,7 +1898,7 @@ contains
         ! Internal variables.
         complex(dp) :: alpha
         complex(dp) :: beta(size(Q))
-        integer :: idx, j, kdim, iwrk
+        integer :: j
 
         ! Deals with the optional args.
         verbose   = optval(verbosity, .false.)
@@ -1950,7 +1950,7 @@ contains
 
         ! Internal variables
         complex(dp) :: beta
-        integer :: idx, i, j, kdim, iwrk
+        integer :: idx, i, j, kdim
         integer :: idxv(1)
         complex(dp)  :: Rii(size(Q))
 
@@ -2103,7 +2103,7 @@ contains
         integer :: i
         complex(dp), allocatable :: Qwrk(:, :)
 
-        Qwrk = Q
+        allocate(Qwrk, source=Q)
         do i = 1, size(perm)
             Q(:, i) = Qwrk(:, perm(i))
         enddo
@@ -2122,7 +2122,7 @@ contains
         integer :: inv_perm(size(perm))
         complex(dp), allocatable :: Qwrk(:, :)
 
-        Qwrk = Q ; inv_perm = 0
+        allocate(Qwrk, source=Q) ; inv_perm = 0
 
         ! Inverse permutation vector.
         do i = 1, size(perm)
@@ -2527,7 +2527,7 @@ contains
         logical :: verbose
         real(sp) :: tolerance
         real(sp) :: alpha, beta
-        integer :: i, j, k, kdim
+        integer :: k, kdim
 
 
         info = 0
@@ -2611,7 +2611,7 @@ contains
         logical :: verbose
         real(dp) :: tolerance
         real(dp) :: alpha, beta
-        integer :: i, j, k, kdim
+        integer :: k, kdim
 
 
         info = 0
@@ -2695,7 +2695,7 @@ contains
         logical :: verbose
         real(sp) :: tolerance
         complex(sp) :: alpha, beta
-        integer :: i, j, k, kdim
+        integer :: k, kdim
 
 
         info = 0
@@ -2779,7 +2779,7 @@ contains
         logical :: verbose
         real(dp) :: tolerance
         complex(dp) :: alpha, beta
-        integer :: i, j, k, kdim
+        integer :: k, kdim
 
 
         info = 0
@@ -2858,7 +2858,7 @@ contains
         logical :: verbose
         real(sp) :: tolerance
         real(sp) :: beta
-        integer :: i, j, k, kdim
+        integer :: k, kdim
 
         ! Deal with optional args.
         kdim = size(X) - 1
@@ -2897,7 +2897,6 @@ contains
         class(abstract_vector_rsp), intent(inout) :: X(:)
 
         ! Internal variables.
-        class(abstract_vector_rsp), allocatable :: wrk
         integer :: i, info
 
         info = 0
@@ -2929,7 +2928,7 @@ contains
         logical :: verbose
         real(dp) :: tolerance
         real(dp) :: beta
-        integer :: i, j, k, kdim
+        integer :: k, kdim
 
         ! Deal with optional args.
         kdim = size(X) - 1
@@ -2968,7 +2967,6 @@ contains
         class(abstract_vector_rdp), intent(inout) :: X(:)
 
         ! Internal variables.
-        class(abstract_vector_rdp), allocatable :: wrk
         integer :: i, info
 
         info = 0
@@ -3000,7 +2998,7 @@ contains
         logical :: verbose
         real(sp) :: tolerance
         real(sp) :: beta
-        integer :: i, j, k, kdim
+        integer :: k, kdim
 
         ! Deal with optional args.
         kdim = size(X) - 1
@@ -3039,7 +3037,6 @@ contains
         class(abstract_vector_csp), intent(inout) :: X(:)
 
         ! Internal variables.
-        class(abstract_vector_csp), allocatable :: wrk
         integer :: i, info
 
         info = 0
@@ -3071,7 +3068,7 @@ contains
         logical :: verbose
         real(dp) :: tolerance
         real(dp) :: beta
-        integer :: i, j, k, kdim
+        integer :: k, kdim
 
         ! Deal with optional args.
         kdim = size(X) - 1
@@ -3110,7 +3107,6 @@ contains
         class(abstract_vector_cdp), intent(inout) :: X(:)
 
         ! Internal variables.
-        class(abstract_vector_cdp), allocatable :: wrk
         integer :: i, info
 
         info = 0
@@ -3147,7 +3143,7 @@ contains
         !-----     Internal variables     -----
         !--------------------------------------
 
-        integer :: i, j, kdim
+        integer :: i, kdim
         
         ! Schur-related.
         real(sp) :: Z(size(H, 2), size(H, 2))
@@ -3211,7 +3207,7 @@ contains
         !-----     Internal variables     -----
         !--------------------------------------
 
-        integer :: i, j, kdim
+        integer :: i, kdim
         
         ! Schur-related.
         real(dp) :: Z(size(H, 2), size(H, 2))
@@ -3275,7 +3271,7 @@ contains
         !-----     Internal variables     -----
         !--------------------------------------
 
-        integer :: i, j, kdim
+        integer :: i, kdim
         
         ! Schur-related.
         complex(sp) :: Z(size(H, 2), size(H, 2))
@@ -3339,7 +3335,7 @@ contains
         !-----     Internal variables     -----
         !--------------------------------------
 
-        integer :: i, j, kdim
+        integer :: i, kdim
         
         ! Schur-related.
         complex(dp) :: Z(size(H, 2), size(H, 2))

--- a/src/BaseKrylov.fypp
+++ b/src/BaseKrylov.fypp
@@ -12,7 +12,7 @@ module lightkrylov_BaseKrylov
     implicit none
     private
     
-    character*128, parameter :: this_module = 'LightKrylov_BaseKrylov'
+    character(len=128), parameter :: this_module = 'LightKrylov_BaseKrylov'
 
     public :: qr
     public :: apply_permutation_matrix
@@ -383,7 +383,7 @@ contains
         ! Internal variables.
         ${type}$ :: alpha
         ${type}$ :: beta(size(Q))
-        integer :: idx, j, kdim, iwrk
+        integer :: j
 
         ! Deals with the optional args.
         verbose   = optval(verbosity, .false.)
@@ -435,7 +435,7 @@ contains
 
         ! Internal variables
         ${type}$ :: beta
-        integer :: idx, i, j, kdim, iwrk
+        integer :: idx, i, j, kdim
         integer :: idxv(1)
         ${type}$  :: Rii(size(Q))
 
@@ -588,7 +588,7 @@ contains
         integer :: i
         ${type}$, allocatable :: Qwrk(:, :)
 
-        Qwrk = Q
+        allocate(Qwrk, source=Q)
         do i = 1, size(perm)
             Q(:, i) = Qwrk(:, perm(i))
         enddo
@@ -607,7 +607,7 @@ contains
         integer :: inv_perm(size(perm))
         ${type}$, allocatable :: Qwrk(:, :)
 
-        Qwrk = Q ; inv_perm = 0
+        allocate(Qwrk, source=Q) ; inv_perm = 0
 
         ! Inverse permutation vector.
         do i = 1, size(perm)
@@ -752,7 +752,7 @@ contains
         logical :: verbose
         real(${kind}$) :: tolerance
         ${type}$ :: alpha, beta
-        integer :: i, j, k, kdim
+        integer :: k, kdim
 
 
         info = 0
@@ -837,7 +837,7 @@ contains
         logical :: verbose
         real(${kind}$) :: tolerance
         real(${kind}$) :: beta
-        integer :: i, j, k, kdim
+        integer :: k, kdim
 
         ! Deal with optional args.
         kdim = size(X) - 1
@@ -876,7 +876,6 @@ contains
         class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: X(:)
 
         ! Internal variables.
-        class(abstract_vector_${type[0]}$${kind}$), allocatable :: wrk
         integer :: i, info
 
         info = 0
@@ -915,7 +914,7 @@ contains
         !-----     Internal variables     -----
         !--------------------------------------
 
-        integer :: i, j, kdim
+        integer :: i, kdim
         
         ! Schur-related.
         ${type}$ :: Z(size(H, 2), size(H, 2))

--- a/src/Logger.f90
+++ b/src/Logger.f90
@@ -3,17 +3,34 @@ module LightKrylov_Logger
    use stdlib_logger
    use stdlib_logger, only: logger => global_logger
    use stdlib_ascii, only : to_lower
+   use stdlib_strings, only : chomp, replace_all
+   ! Testdrive
+   use testdrive, only: error_type, test_failed
    implicit none
    private
 
    logical, parameter :: exit_on_error = .true.
+   logical, parameter :: exit_on_test_error = .true.
 
+   public :: stop_error
    public :: check_info
+   public :: check_test
    public :: logger
 
 contains
 
-   subroutine check_info(info, origin, module, procedure)
+   subroutine stop_error(msg, module, procedure)
+      character(len=*),            intent(in)  :: msg
+      !! The name of the procedure in which the call happens
+      character(len=*), optional,  intent(in)  :: module
+      !! The name of the module in which the call happens
+      character(len=*), optional,  intent(in)  :: procedure
+      !! The name of the procedure in which the call happens
+      call check_info(-1, origin='', module=module, procedure=procedure, info_msg=msg)
+      return
+   end subroutine stop_error
+
+   subroutine check_info(info, origin, module, procedure, info_msg)
       integer,                     intent(in)  :: info
       !! Informaion flag
       character(len=*),            intent(in)  :: origin
@@ -22,15 +39,20 @@ contains
       !! The name of the module in which the call happens
       character(len=*), optional,  intent(in)  :: procedure
       !! The name of the procedure in which the call happens
+      character(len=*), optional,  intent(in)  :: info_msg
+      character*128                            :: str
+      !! Optional extra message
 
       ! internals
       character*256 :: msg
       integer :: ierr
 
+      str = optval(info_msg, '')
+
       ierr = 0
       if (info == 0) then
          ! Successful exit --> only log on debug
-         write(msg, *) 'The subroutine "'//trim(origin)//'" returned successfully.'
+         write(msg, *) 'The subroutine "'//trim(origin)//'" returned successfully. ', trim(str)
          call logger%log_debug(trim(msg), module=module, procedure=procedure)
       else
          !
@@ -39,91 +61,91 @@ contains
          if (trim(to_lower(origin)) == 'getref') then
             ! GETREF
             if (info < 0 ) then
-               write(msg, *) "The ", -info, "-th argument has illegal value."
+               write(msg, *) "The ", -info, "-th argument has illegal value. ", trim(str)
                call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             else
                write(msg, *) "U(", info, ",", info, ") is exactly zero. The factorization ", &
                            & "has been completed but the factor U is exactly singular. ", &
-                           & "Division by zero will occur if used to solve Ax=b."
+                           & "Division by zero will occur if used to solve Ax=b. ", trim(str)
                call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
          else if (trim(to_lower(origin)) == 'getri') then
             ! GETRI
             if (info < 0 ) then
-               write(msg, *) "The ", -info, "-th argument has illegal value."
+               write(msg, *) "The ", -info, "-th argument has illegal value. ", trim(str)
                call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             else
                write(msg, *) "U(", info, ",", info, ") is exactly zero. ", &
-                           & "The matrix is singular and its inverse cannot be computed."
+                           & "The matrix is singular and its inverse cannot be computed. ", trim(str)
                call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
          else if (trim(to_lower(origin)) == 'geev') then
             ! GEEV
             if (info < 0) then
-               write(msg, *) "The ", -info, "-th argument has illegal value."
+               write(msg, *) "The ", -info, "-th argument has illegal value. ", trim(str)
                call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             else 
                write(msg, *) "The QR alg. failed to compute all of the eigenvalues.", &
-                           & "No eigenvector has been computed."
+                           & "No eigenvector has been computed. ", trim(str)
                call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
          else if (trim(to_lower(origin)) == 'syev') then
             ! SYEV
             if (info < 0) then
-               write(msg, *) "The ", -info, "-th argument has illegal value."
+               write(msg, *) "The ", -info, "-th argument has illegal value. ", trim(str)
                call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             else 
                write(msg, *) "The QR alg. failed to compute all of the eigenvalues.", &
-                           & "No eigenvector has been computed."
+                           & "No eigenvector has been computed. ", trim(str)
                call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
          else if (trim(to_lower(origin)) == 'heev') then
             ! HEEV
             if (info < 0) then
-               write(msg, *) "The ", -info, "-th argument has illegal value."
+               write(msg, *) "The ", -info, "-th argument has illegal value. ", trim(str)
                call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             else 
                write(msg, *) "The QR alg. failed to compute all of the eigenvalues.", &
-                           & "No eigenvector has been computed."
+                           & "No eigenvector has been computed. ", trim(str)
                call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
          else if (trim(to_lower(origin)) == 'gels') then
             ! GELS
             if (info < 0) then
-               write(msg, *) "The ", -info, "-th argument has illegal value."
+               write(msg, *) "The ", -info, "-th argument has illegal value. ", trim(str)
                call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             else
-               write(msg, *) "Undocumented error."
+               write(msg, *) "Undocumented error. ", trim(str)
                call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
          else if (trim(to_lower(origin)) == 'gees') then
             ! GEES
             if (info < 0) then
-               write(msg, *) "The ", -info, "-th argument has illegal value."
+               write(msg, *) "The ", -info, "-th argument has illegal value. ", trim(str)
                call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             else
                write(msg, *) "The QR alg. failed to compute all of the eigenvalues.", &
-                           & "No eigenvector has been computed."
+                           & "No eigenvector has been computed. ", trim(str)
                call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
          else if (trim(to_lower(origin)) == 'trsen') then
             ! GEES
             if (info < 0) then
-               write(msg, *) "The ", -info, "-th argument has illegal value."
+               write(msg, *) "The ", -info, "-th argument has illegal value. ", trim(str)
                call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             else if (info == 1) then
@@ -131,11 +153,11 @@ contains
                            & "close to separate (the problem is very ill-conditioned); ", &
                            & "T may have been partially reordered, and WR and WI ", &
                            & "contain the eigenvalues in the same order as in T; S and", &
-                           & "SEP (if requested) are set to zero."
+                           & "SEP (if requested) are set to zero. ", trim(str)
                call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             else
-               write(msg, *) "Undocumented error."
+               write(msg, *) "Undocumented error. ", trim(str)
                call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
@@ -151,7 +173,7 @@ contains
                call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             else
-               write(msg, *) "Undocumented error."
+               write(msg, *) "Undocumented error. ", trim(str)
                call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
@@ -171,7 +193,7 @@ contains
                write(msg, *) 'Orthogonalization: The last column of the input basis is zero.'
                call logger%log_warning(trim(msg), module=module, procedure=procedure)
             else
-               write(msg, *) "Undocumented error."
+               write(msg, *) "Undocumented error. ", trim(str)
                call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
@@ -188,7 +210,7 @@ contains
                write(msg, *) 'Orthogonalization: The last column of the input basis is zero.'
                call logger%log_warning(trim(msg), module=module, procedure=procedure)
             else
-               write(msg, *) "Undocumented error."
+               write(msg, *) "Undocumented error. ", trim(str)
                call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
@@ -198,7 +220,7 @@ contains
                write(msg, *) 'QR factorization: Colinear column detected in column', info
                call logger%log_information(trim(msg), module=module, procedure=procedure)
             else
-               write(msg, *) "Undocumented error."
+               write(msg, *) "Undocumented error. ", trim(str)
                call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
@@ -208,7 +230,7 @@ contains
                write(msg, *) 'QR factorization: Invariant subspace found after', info, 'steps.'
                call logger%log_information(trim(msg), module=module, procedure=procedure)
             else
-               write(msg, *) "Undocumented error."
+               write(msg, *) "Undocumented error. ", trim(str)
                call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
@@ -218,7 +240,7 @@ contains
                write(msg, *) 'Arnoldi factorization: Invariant subspace computed after', info, 'iterations.'
                call logger%log_information(trim(msg), module=module, procedure=procedure)
             else
-               write(msg, *) "Undocumented error."
+               write(msg, *) "Undocumented error. ", trim(str)
                call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
@@ -228,7 +250,7 @@ contains
                write(msg, *) 'Lanczos Bidiagonalisation: Invariant subspace found after', info, 'steps.'
                call logger%log_information(trim(msg), module=module, procedure=procedure)
             else
-               write(msg, *) "Undocumented error."
+               write(msg, *) "Undocumented error. ", trim(str)
                call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
@@ -238,7 +260,7 @@ contains
                write(msg, *) 'Lanczos Tridiagonalisation: Invariant subspace found after', info, 'steps.'
                call logger%log_information(trim(msg), module=module, procedure=procedure)
             else
-               write(msg, *) "Undocumented error."
+               write(msg, *) "Undocumented error. ", trim(str)
                call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
@@ -251,7 +273,7 @@ contains
                write(msg, *) 'eigs iteration converged after', info, 'iterations'
                call logger%log_information(trim(msg), module=module, procedure=procedure)
             else
-               write(msg, *) "Undocumented error."
+               write(msg, *) "Undocumented error. ", trim(str)
                call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
@@ -261,7 +283,7 @@ contains
                write(msg, *) 'eigs iteration converged after', info, 'iterations'
                call logger%log_information(trim(msg), module=module, procedure=procedure)
             else
-               write(msg, *) "Undocumented error."
+               write(msg, *) "Undocumented error. ", trim(str)
                call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
@@ -271,7 +293,7 @@ contains
                write(msg, *) 'svds iteration converged after', info, 'iterations'
                call logger%log_information(trim(msg), module=module, procedure=procedure)
             else
-               write(msg, *) "Undocumented error."
+               write(msg, *) "Undocumented error. ", trim(str)
                call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
@@ -281,7 +303,7 @@ contains
                write(msg, *) 'GMRES iteration converged after', info, 'iterations'
                call logger%log_information(trim(msg), module=module, procedure=procedure)
             else
-               write(msg, *) "Undocumented error."
+               write(msg, *) "Undocumented error. ", trim(str)
                call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
@@ -291,7 +313,7 @@ contains
                write(msg, *) 'CG iteration converged after', info, 'iterations'
                call logger%log_information(trim(msg), module=module, procedure=procedure)
             else
-               write(msg, *) "Undocumented error."
+               write(msg, *) "Undocumented error. ", trim(str)
                call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
@@ -310,16 +332,16 @@ contains
                write(msg, *) 'kexpm did not converge. Maximum number of Krylov vectors reached.'
                call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
-            write(msg, *) "Undocumented error."
+            write(msg, *) "Undocumented error. ", trim(str)
                call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
          !
          !   Default
          !
-         else 
-            write(msg,*) 'subroutine "'//trim(origin)//'" returned with flag: ', info
-            call logger%log_error(trim(msg), module=module, procedure=procedure)
+         else
+            write(msg,*) 'subroutine "'//trim(origin)//'" returned with a non-zero error flag.'
+            call logger%log_error(trim(msg), module=module, procedure=procedure, stat=info, errmsg=trim(str))
             ierr = -1
          end if
       end if ! info /= 0
@@ -343,5 +365,111 @@ contains
       end if
       
    end subroutine error_handler
+
+   subroutine check_test(error, test_name, info_str)
+      use face 
+      type(error_type), allocatable, intent(inout) :: error
+      character(len=*),              intent(in)    :: test_name
+      character(len=*),              intent(in)    :: info_str
+      character*128                                :: name
+      
+      ! internals
+      character(len=4), dimension(4) :: substrings
+      integer :: i
+
+      name = trim(to_lower(test_name))
+      substrings = ["_rsp", "_rdp", "_csp", "_cdp"]
+      do i = 1, size(substrings)
+         name = replace_all(name, substrings(i), "")
+      end do
+
+      !write(*,'(A50)', ADVANCE='NO') trim(adjustl(to_lower(test_name)))
+
+      if (allocated(error)) then
+         print *, colorize('FAILED', color_fg='red')
+         !
+         !   TestVector
+         !
+         if      (name == "test_vector_norm") then
+            print '(4X,A)', '"'//trim(info_str)//'" failed.'
+         else if (name == "test_vector_add") then
+            print '(4X,A)', '"'//trim(info_str)//'" failed'
+         else if (name == "test_vector_sub") then
+            print '(4X,A)', '"'//trim(info_str)//'" failed'
+         else if (name == "test_vector_dot") then
+            print '(4X,A)', '"'//trim(info_str)//'" failed'
+         else if (name == "test_vector_scal") then
+            print '(4X,A)', '"'//trim(info_str)//'" failed'
+         !
+         !   TestLinops
+         !
+         else if (name == "test_matvec") then
+            print '(4X,A)', '"'//trim(info_str)//'" failed'     
+         else if (name == "test_rmatvec") then
+            print '(4X,A)', '"'//trim(info_str)//'" failed'
+         else if (name == "test_adjoint_matvec") then
+            print '(4X,A)', '"'//trim(info_str)//'" failed'
+         else if (name == "test_adjoint_rmatvec") then
+            print '(4X,A)', '"'//trim(info_str)//'" failed'
+         !
+         !   TestKrylov
+         !
+         else if (name == "test_qr_factorization") then
+            print '(4X,A)', trim(info_str)
+         else if (name == "test_pivoting_qr_exact_rank_deficiency") then
+            print '(4X,A)', trim(info_str)
+         else if (name == "test_arnoldi_factorization") then
+            print '(4X,A)', trim(info_str)
+         else if (name == "test_block_arnoldi_factorization") then
+            print '(4X,A)', trim(info_str)
+         else if (name == "test_krylov_schur") then
+            print '(4X,A)', trim(info_str)
+         else if (name == "test_lanczos_bidiag_factorization") then
+            print '(4X,A)', trim(info_str)
+         else if (name == "test_lanczos_tridiag_factorization") then
+            print '(4X,A)', trim(info_str)
+         !
+         !   TestExpmLib
+         !
+         else if (name == "test_dense_expm") then
+            print '(4X,A)', '"'//trim(info_str)//'" failed'
+         else if (name == "test_kexptA") then
+            print '(4X,A)', '"'//trim(info_str)//'" failed'
+         else if (name == "test_block_kexptA") then
+            print '(4X,A)', '"'//trim(info_str)//'" failed'
+         else if (name == "test_dense_sqrtm_pos_def") then
+            print '(4X,A)', '"'//trim(info_str)//'" failed'
+         else if (name == "test_dense_sqrtm_pos_semi_def") then
+            print '(4X,A)', '"'//trim(info_str)//'" failed'
+         !
+         !   TestIterativeSolvers
+         !
+         else if (name == "test_ks_evp") then
+            print '(4X,A)', trim(info_str)
+         else if (name == "test_evp") then
+            print '(4X,A)', trim(info_str)
+         else if (name == "test_sym_evp") then
+            print '(4X,A)', trim(info_str)
+         else if (name == "test_svd") then
+            print '(4X,A)', trim(info_str)
+         else if (name == "test_gmres") then
+            print '(4X,A)', trim(info_str)
+         else if (name == "test_gmres_spd") then
+            print '(4X,A)', trim(info_str)
+         else if (name == "test_cg") then
+            print '(4X,A)', trim(info_str)
+         end if
+
+         if (exit_on_test_error) then
+            write(*,*)
+            write(*,*) 'A fatal error was encountered. Aborting calculation as per user directive.'
+            write(*,*)
+            STOP 1
+         end if
+      else
+         print *, colorize('PASSED', color_fg='green')
+      end if
+
+   end subroutine check_test
 
 end module LightKrylov_Logger

--- a/src/Logger.f90
+++ b/src/Logger.f90
@@ -366,106 +366,54 @@ contains
       
    end subroutine error_handler
 
-   subroutine check_test(error, test_name, info_str)
+   subroutine check_test(error, test_name, info, eq, context)
       use face 
       type(error_type), allocatable, intent(inout) :: error
       character(len=*),              intent(in)    :: test_name
-      character(len=*),              intent(in)    :: info_str
+      character(len=*),    optional, intent(in)    :: info
+      character(len=*),    optional, intent(in)    :: eq
+      character(len=*),    optional, intent(in)    :: context
       character*128                                :: name
       
       ! internals
+      character*128                  :: msg, info_, eq_
+      character(len=*), parameter :: indent = repeat(" ", 7)
       character(len=4), dimension(4) :: substrings
       integer :: i
+
+      info_ = optval(info, '')
+      eq_   = optval(eq, '')
 
       name = trim(to_lower(test_name))
       substrings = ["_rsp", "_rdp", "_csp", "_cdp"]
       do i = 1, size(substrings)
          name = replace_all(name, substrings(i), "")
       end do
+      name = replace_all(name, "test_", "")
 
-      !write(*,'(A50)', ADVANCE='NO') trim(adjustl(to_lower(test_name)))
+      write(*, '(A33)', ADVANCE='NO') name
+      write(*, '(A3)',  ADVANCE='NO') ' % '
+
+      if (len(trim(info_)) == 0) then
+         msg = eq_
+      else
+         if (len(info_) > 30) then
+            msg = info_(:30) // eq_
+         else
+            msg = info_ // repeat(' ', 30 - len(trim(info_))) // eq_
+         end if 
+      end if
+      write(*, '(A62)', ADVANCE='NO') msg
 
       if (allocated(error)) then
          print *, colorize('FAILED', color_fg='red')
-         !
-         !   TestVector
-         !
-         if      (name == "test_vector_norm") then
-            print '(4X,A)', '"'//trim(info_str)//'" failed.'
-         else if (name == "test_vector_add") then
-            print '(4X,A)', '"'//trim(info_str)//'" failed'
-         else if (name == "test_vector_sub") then
-            print '(4X,A)', '"'//trim(info_str)//'" failed'
-         else if (name == "test_vector_dot") then
-            print '(4X,A)', '"'//trim(info_str)//'" failed'
-         else if (name == "test_vector_scal") then
-            print '(4X,A)', '"'//trim(info_str)//'" failed'
-         !
-         !   TestLinops
-         !
-         else if (name == "test_matvec") then
-            print '(4X,A)', '"'//trim(info_str)//'" failed'     
-         else if (name == "test_rmatvec") then
-            print '(4X,A)', '"'//trim(info_str)//'" failed'
-         else if (name == "test_adjoint_matvec") then
-            print '(4X,A)', '"'//trim(info_str)//'" failed'
-         else if (name == "test_adjoint_rmatvec") then
-            print '(4X,A)', '"'//trim(info_str)//'" failed'
-         !
-         !   TestKrylov
-         !
-         else if (name == "test_qr_factorization") then
-            print '(4X,A)', trim(info_str)
-         else if (name == "test_pivoting_qr_exact_rank_deficiency") then
-            print '(4X,A)', trim(info_str)
-         else if (name == "test_arnoldi_factorization") then
-            print '(4X,A)', trim(info_str)
-         else if (name == "test_block_arnoldi_factorization") then
-            print '(4X,A)', trim(info_str)
-         else if (name == "test_krylov_schur") then
-            print '(4X,A)', trim(info_str)
-         else if (name == "test_lanczos_bidiag_factorization") then
-            print '(4X,A)', trim(info_str)
-         else if (name == "test_lanczos_tridiag_factorization") then
-            print '(4X,A)', trim(info_str)
-         !
-         !   TestExpmLib
-         !
-         else if (name == "test_dense_expm") then
-            print '(4X,A)', '"'//trim(info_str)//'" failed'
-         else if (name == "test_kexptA") then
-            print '(4X,A)', '"'//trim(info_str)//'" failed'
-         else if (name == "test_block_kexptA") then
-            print '(4X,A)', '"'//trim(info_str)//'" failed'
-         else if (name == "test_dense_sqrtm_pos_def") then
-            print '(4X,A)', '"'//trim(info_str)//'" failed'
-         else if (name == "test_dense_sqrtm_pos_semi_def") then
-            print '(4X,A)', '"'//trim(info_str)//'" failed'
-         !
-         !   TestIterativeSolvers
-         !
-         else if (name == "test_ks_evp") then
-            print '(4X,A)', trim(info_str)
-         else if (name == "test_evp") then
-            print '(4X,A)', trim(info_str)
-         else if (name == "test_sym_evp") then
-            print '(4X,A)', trim(info_str)
-         else if (name == "test_svd") then
-            print '(4X,A)', trim(info_str)
-         else if (name == "test_gmres") then
-            print '(4X,A)', trim(info_str)
-         else if (name == "test_gmres_spd") then
-            print '(4X,A)', trim(info_str)
-         else if (name == "test_cg") then
-            print '(4X,A)', trim(info_str)
+         if (present(context)) then
+            write(*, '(A)', ADVANCE='NO') trim(context)
          end if
-
-         if (exit_on_test_error) then
-            write(*,*)
-            write(*,*) 'A fatal error was encountered. Aborting calculation as per user directive.'
-            write(*,*)
-            STOP 1
-         end if
+         write(*,*)
+         write(*,*) 'The most recent test failed. Aborting calculation as per user directive.'
+         write(*,*)
+         STOP 1
       else
          print *, colorize('PASSED', color_fg='green')
       end if

--- a/src/Utils.f90
+++ b/src/Utils.f90
@@ -1174,5 +1174,4 @@ contains
         enddo
     end function
 
-
 end module lightkrylov_utils

--- a/src/Utils.f90
+++ b/src/Utils.f90
@@ -25,7 +25,6 @@ module lightkrylov_utils
 
     character*128, parameter :: this_module = 'LightKrylov_Utils'
 
-    public :: stop_error
     public :: assert_shape
     ! Compute B = inv(A) in-place for dense matrices.
     public :: inv
@@ -167,14 +166,6 @@ contains
     !-----     VARIOUS UTILITIES     -----
     !-------------------------------------
 
-    subroutine stop_error(msg)
-        !! Utility function to print an error message.
-        character(len=*), intent(in) :: msg
-        !! Error message.
-        write(output_unit, *) msg; stop 1
-        return
-    end subroutine stop_error
-
     subroutine assert_shape_vector_rsp(v, size, routine, matname)
         !! Utility function to assert the shape of a vector.
         real(sp), intent(in) :: v(:)
@@ -185,11 +176,14 @@ contains
         !! Name of the routine where assertion is done.
         character(len=*), intent(in) :: matname
         !! Name of the asserted vector.
+        
+        ! internals
+        character*128 :: msg
 
         if(any(shape(v) /= size)) then
-            write(output_unit, *) "In routine "//routine//" vector "//matname//" has illegal length ", shape(v)
-            write(output_unit, *) "Expected length is ", size
-            call stop_error("Aborting due to illegal vector length.")
+            write(msg, *) "In routine "//routine//" vector "//matname//" has illegal length ", shape(v), &
+                           & ". Expected length is ", size, ". Aborting due to illegal vector length."
+            call stop_error(msg, module=this_module, procedure='assert_shape_vector_rsp')
         endif
         return
     end subroutine assert_shape_vector_rsp
@@ -205,10 +199,13 @@ contains
         character(len=*), intent(in) :: matname
         !! Name of the asserted matrix.
 
+        ! internals
+        character*128 :: msg
+
         if(any(shape(A) /= size)) then
-            write(output_unit, *) "In routine "//routine//" matrix "//matname//" has illegal shape ", shape(A)
-            write(output_unit, *) "Expected shape is ", size
-            call stop_error("Aborting due to illegal matrix size.")
+            write(msg, *) "In routine "//routine//" matrix "//matname//" has illegal shape ", shape(A), &
+                        & ". Expected shape is ", size, ". Aborting due to illegal vector length."
+            call stop_error(msg, module=this_module, procedure='assert_shape_vector_rsp')
         endif
         return
     end subroutine assert_shape_matrix_rsp
@@ -222,11 +219,14 @@ contains
         !! Name of the routine where assertion is done.
         character(len=*), intent(in) :: matname
         !! Name of the asserted vector.
+        
+        ! internals
+        character*128 :: msg
 
         if(any(shape(v) /= size)) then
-            write(output_unit, *) "In routine "//routine//" vector "//matname//" has illegal length ", shape(v)
-            write(output_unit, *) "Expected length is ", size
-            call stop_error("Aborting due to illegal vector length.")
+            write(msg, *) "In routine "//routine//" vector "//matname//" has illegal length ", shape(v), &
+                           & ". Expected length is ", size, ". Aborting due to illegal vector length."
+            call stop_error(msg, module=this_module, procedure='assert_shape_vector_rdp')
         endif
         return
     end subroutine assert_shape_vector_rdp
@@ -242,10 +242,13 @@ contains
         character(len=*), intent(in) :: matname
         !! Name of the asserted matrix.
 
+        ! internals
+        character*128 :: msg
+
         if(any(shape(A) /= size)) then
-            write(output_unit, *) "In routine "//routine//" matrix "//matname//" has illegal shape ", shape(A)
-            write(output_unit, *) "Expected shape is ", size
-            call stop_error("Aborting due to illegal matrix size.")
+            write(msg, *) "In routine "//routine//" matrix "//matname//" has illegal shape ", shape(A), &
+                        & ". Expected shape is ", size, ". Aborting due to illegal vector length."
+            call stop_error(msg, module=this_module, procedure='assert_shape_vector_rdp')
         endif
         return
     end subroutine assert_shape_matrix_rdp
@@ -259,11 +262,14 @@ contains
         !! Name of the routine where assertion is done.
         character(len=*), intent(in) :: matname
         !! Name of the asserted vector.
+        
+        ! internals
+        character*128 :: msg
 
         if(any(shape(v) /= size)) then
-            write(output_unit, *) "In routine "//routine//" vector "//matname//" has illegal length ", shape(v)
-            write(output_unit, *) "Expected length is ", size
-            call stop_error("Aborting due to illegal vector length.")
+            write(msg, *) "In routine "//routine//" vector "//matname//" has illegal length ", shape(v), &
+                           & ". Expected length is ", size, ". Aborting due to illegal vector length."
+            call stop_error(msg, module=this_module, procedure='assert_shape_vector_csp')
         endif
         return
     end subroutine assert_shape_vector_csp
@@ -279,10 +285,13 @@ contains
         character(len=*), intent(in) :: matname
         !! Name of the asserted matrix.
 
+        ! internals
+        character*128 :: msg
+
         if(any(shape(A) /= size)) then
-            write(output_unit, *) "In routine "//routine//" matrix "//matname//" has illegal shape ", shape(A)
-            write(output_unit, *) "Expected shape is ", size
-            call stop_error("Aborting due to illegal matrix size.")
+            write(msg, *) "In routine "//routine//" matrix "//matname//" has illegal shape ", shape(A), &
+                        & ". Expected shape is ", size, ". Aborting due to illegal vector length."
+            call stop_error(msg, module=this_module, procedure='assert_shape_vector_csp')
         endif
         return
     end subroutine assert_shape_matrix_csp
@@ -296,11 +305,14 @@ contains
         !! Name of the routine where assertion is done.
         character(len=*), intent(in) :: matname
         !! Name of the asserted vector.
+        
+        ! internals
+        character*128 :: msg
 
         if(any(shape(v) /= size)) then
-            write(output_unit, *) "In routine "//routine//" vector "//matname//" has illegal length ", shape(v)
-            write(output_unit, *) "Expected length is ", size
-            call stop_error("Aborting due to illegal vector length.")
+            write(msg, *) "In routine "//routine//" vector "//matname//" has illegal length ", shape(v), &
+                           & ". Expected length is ", size, ". Aborting due to illegal vector length."
+            call stop_error(msg, module=this_module, procedure='assert_shape_vector_cdp')
         endif
         return
     end subroutine assert_shape_vector_cdp
@@ -316,10 +328,13 @@ contains
         character(len=*), intent(in) :: matname
         !! Name of the asserted matrix.
 
+        ! internals
+        character*128 :: msg
+
         if(any(shape(A) /= size)) then
-            write(output_unit, *) "In routine "//routine//" matrix "//matname//" has illegal shape ", shape(A)
-            write(output_unit, *) "Expected shape is ", size
-            call stop_error("Aborting due to illegal matrix size.")
+            write(msg, *) "In routine "//routine//" matrix "//matname//" has illegal shape ", shape(A), &
+                        & ". Expected shape is ", size, ". Aborting due to illegal vector length."
+            call stop_error(msg, module=this_module, procedure='assert_shape_vector_cdp')
         endif
         return
     end subroutine assert_shape_matrix_cdp
@@ -487,13 +502,14 @@ contains
       real(sp) :: lambda(size(X,1))
       real(sp) :: V(size(X,1), size(X,1))
       integer :: i
+      character*128 :: msg
 
       info = 0
 
       ! Check if the matrix is symmetric
       if (.not. is_symmetric(X)) then
-        write(output_unit,*) "Error: Input matrix is not symmetric"
-        call stop_error("Aborting.")
+        write(msg,*) "Input matrix is not symmetric."
+        call stop_error(msg, module=this_module, procedure='sqrtm_rsp')
       end if
 
       ! Perform eigenvalue decomposition
@@ -679,13 +695,14 @@ contains
       real(dp) :: lambda(size(X,1))
       real(dp) :: V(size(X,1), size(X,1))
       integer :: i
+      character*128 :: msg
 
       info = 0
 
       ! Check if the matrix is symmetric
       if (.not. is_symmetric(X)) then
-        write(output_unit,*) "Error: Input matrix is not symmetric"
-        call stop_error("Aborting.")
+        write(msg,*) "Input matrix is not symmetric."
+        call stop_error(msg, module=this_module, procedure='sqrtm_rdp')
       end if
 
       ! Perform eigenvalue decomposition
@@ -866,13 +883,14 @@ contains
       real(sp) :: lambda(size(X,1))
       complex(sp) :: V(size(X,1), size(X,1))
       integer :: i
+      character*128 :: msg
 
       info = 0
 
       ! Check if the matrix is hermitian
       if (.not. is_hermitian(X)) then
-        write(output_unit,*) "Error: Input matrix is not hermitian"
-        call stop_error("Aborting.")
+        write(msg,*) "Input matrix is not hermitian"
+        call stop_error(msg, module=this_module, procedure='sqrtm_csp')
       end if
 
       ! Perform eigenvalue decomposition
@@ -1053,13 +1071,14 @@ contains
       real(dp) :: lambda(size(X,1))
       complex(dp) :: V(size(X,1), size(X,1))
       integer :: i
+      character*128 :: msg
 
       info = 0
 
       ! Check if the matrix is hermitian
       if (.not. is_hermitian(X)) then
-        write(output_unit,*) "Error: Input matrix is not hermitian"
-        call stop_error("Aborting.")
+        write(msg,*) "Input matrix is not hermitian"
+        call stop_error(msg, module=this_module, procedure='sqrtm_cdp')
       end if
 
       ! Perform eigenvalue decomposition

--- a/src/Utils.fypp
+++ b/src/Utils.fypp
@@ -27,7 +27,6 @@ module lightkrylov_utils
 
     character*128, parameter :: this_module = 'LightKrylov_Utils'
 
-    public :: stop_error
     public :: assert_shape
     ! Compute B = inv(A) in-place for dense matrices.
     public :: inv
@@ -135,14 +134,6 @@ contains
     !-----     VARIOUS UTILITIES     -----
     !-------------------------------------
 
-    subroutine stop_error(msg)
-        !! Utility function to print an error message.
-        character(len=*), intent(in) :: msg
-        !! Error message.
-        write(output_unit, *) msg; stop 1
-        return
-    end subroutine stop_error
-
     #:for kind, type in RC_KINDS_TYPES
     subroutine assert_shape_vector_${type[0]}$${kind}$(v, size, routine, matname)
         !! Utility function to assert the shape of a vector.
@@ -154,11 +145,14 @@ contains
         !! Name of the routine where assertion is done.
         character(len=*), intent(in) :: matname
         !! Name of the asserted vector.
+        
+        ! internals
+        character*128 :: msg
 
         if(any(shape(v) /= size)) then
-            write(output_unit, *) "In routine "//routine//" vector "//matname//" has illegal length ", shape(v)
-            write(output_unit, *) "Expected length is ", size
-            call stop_error("Aborting due to illegal vector length.")
+            write(msg, *) "In routine "//routine//" vector "//matname//" has illegal length ", shape(v), &
+                           & ". Expected length is ", size, ". Aborting due to illegal vector length."
+            call stop_error(msg, module=this_module, procedure='assert_shape_vector_${type[0]}$${kind}$')
         endif
         return
     end subroutine assert_shape_vector_${type[0]}$${kind}$
@@ -174,10 +168,13 @@ contains
         character(len=*), intent(in) :: matname
         !! Name of the asserted matrix.
 
+        ! internals
+        character*128 :: msg
+
         if(any(shape(A) /= size)) then
-            write(output_unit, *) "In routine "//routine//" matrix "//matname//" has illegal shape ", shape(A)
-            write(output_unit, *) "Expected shape is ", size
-            call stop_error("Aborting due to illegal matrix size.")
+            write(msg, *) "In routine "//routine//" matrix "//matname//" has illegal shape ", shape(A), &
+                        & ". Expected shape is ", size, ". Aborting due to illegal vector length."
+            call stop_error(msg, module=this_module, procedure='assert_shape_vector_${type[0]}$${kind}$')
         endif
         return
     end subroutine assert_shape_matrix_${type[0]}$${kind}$
@@ -407,20 +404,21 @@ contains
       real(${kind}$) :: lambda(size(X,1))
       ${type}$ :: V(size(X,1), size(X,1))
       integer :: i
+      character*128 :: msg
 
       info = 0
 
       #:if type[0] == "r"
       ! Check if the matrix is symmetric
       if (.not. is_symmetric(X)) then
-        write(output_unit,*) "Error: Input matrix is not symmetric"
-        call stop_error("Aborting.")
+        write(msg,*) "Input matrix is not symmetric."
+        call stop_error(msg, module=this_module, procedure='sqrtm_${type[0]}$${kind}$')
       end if
       #:else
       ! Check if the matrix is hermitian
       if (.not. is_hermitian(X)) then
-        write(output_unit,*) "Error: Input matrix is not hermitian"
-        call stop_error("Aborting.")
+        write(msg,*) "Input matrix is not hermitian"
+        call stop_error(msg, module=this_module, procedure='sqrtm_${type[0]}$${kind}$')
       end if
       #:endif
 

--- a/test/TestExpmlib.f90
+++ b/test/TestExpmlib.f90
@@ -22,7 +22,7 @@ module TestExpmlib
 
     private
 
-    character*128, parameter, private :: this_module = 'LightKrylov_TestExpmLib'
+    character(len=128), parameter, private :: this_module = 'LightKrylov_TestExpmLib'
 
     public :: collect_expm_rsp_testsuite
     public :: collect_expm_rdp_testsuite
@@ -94,7 +94,7 @@ contains
         integer, parameter :: kdim = test_size
     
         ! ----- Internal variables -----
-        real(sp) :: E(kdim, kdim)
+        real(sp), allocatable :: E(:, :)
         real(sp), parameter :: tau = 0.1_sp
         logical, parameter :: verb = .true.
         integer, parameter :: nkmax = 64
@@ -108,7 +108,7 @@ contains
         allocate(XKryl) ; call Xkryl%zero()
 
         ! Dense computation.
-        call expm(E, tau*A%data)
+        allocate(E(kdim, kdim)) ; call expm(E, tau*A%data)
         Xref%data = matmul(E, Q%data)
 
         ! Krylov exponential.
@@ -139,11 +139,7 @@ contains
         ! Krylov subspace dimension.
         integer, parameter :: kdim = test_size
         ! Test matrix.
-        real(sp) :: Adata(kdim, kdim)
-        real(sp) :: Edata(kdim, kdim)
-        ! GS factors.
-        real(sp) :: R(kdim, kdim)
-        real(sp) :: Id(kdim, kdim)
+        real(sp), allocatable :: Adata(:, :), Edata(:, :)
         ! Information flag.
         integer :: info
         ! Test parameters
@@ -153,12 +149,14 @@ contains
         real(sp), parameter :: tol = rtol_sp
         logical       , parameter :: verb = .true.
         ! Misc.
-        integer  :: i, j, k
-        real(sp) :: Xdata(test_size,p), Qdata(test_size,p)
+        integer  :: i, j
+        real(sp), allocatable :: Xdata(:, :), Qdata(:, :)
         real(sp) :: alpha
         real(sp) :: err(p, p)
 
-        Adata = 0.0_sp ; Edata = 0.0_sp ; Xdata = 0.0_sp
+        allocate(Adata(kdim, kdim)) ; Adata = 0.0_sp
+        allocate(Edata(kdim, kdim)) ; Edata = 0.0_sp
+        allocate(Xdata(test_size, p)) ; Xdata = 0.0_sp
 
         allocate(Cref(p)) ; call initialize_krylov_subspace(Cref)
         allocate(C(p))    ; call initialize_krylov_subspace(C)
@@ -168,7 +166,8 @@ contains
         A = linop_rsp() ; call init_rand(A) ; call get_data(Adata, A)
        
         ! --> Initialize rhs.
-        allocate(B(1:p)) ; call init_rand(B) ; call get_data(Qdata, B)
+        allocate(B(1:p)) ; call init_rand(B)
+        allocate(Qdata(test_size, p)) ; call get_data(Qdata, B)
 
         ! Comparison is dense computation (10th order Pade approximation)
         call expm(Edata, tau*Adata) ; Xdata = matmul(Edata,Qdata) ; call put_data(Cref, Xdata)
@@ -271,7 +270,7 @@ contains
         integer, parameter :: kdim = test_size
     
         ! ----- Internal variables -----
-        real(dp) :: E(kdim, kdim)
+        real(dp), allocatable :: E(:, :)
         real(dp), parameter :: tau = 0.1_dp
         logical, parameter :: verb = .true.
         integer, parameter :: nkmax = 64
@@ -285,7 +284,7 @@ contains
         allocate(XKryl) ; call Xkryl%zero()
 
         ! Dense computation.
-        call expm(E, tau*A%data)
+        allocate(E(kdim, kdim)) ; call expm(E, tau*A%data)
         Xref%data = matmul(E, Q%data)
 
         ! Krylov exponential.
@@ -316,11 +315,7 @@ contains
         ! Krylov subspace dimension.
         integer, parameter :: kdim = test_size
         ! Test matrix.
-        real(dp) :: Adata(kdim, kdim)
-        real(dp) :: Edata(kdim, kdim)
-        ! GS factors.
-        real(dp) :: R(kdim, kdim)
-        real(dp) :: Id(kdim, kdim)
+        real(dp), allocatable :: Adata(:, :), Edata(:, :)
         ! Information flag.
         integer :: info
         ! Test parameters
@@ -330,12 +325,14 @@ contains
         real(dp), parameter :: tol = rtol_dp
         logical       , parameter :: verb = .true.
         ! Misc.
-        integer  :: i, j, k
-        real(dp) :: Xdata(test_size,p), Qdata(test_size,p)
+        integer  :: i, j
+        real(dp), allocatable :: Xdata(:, :), Qdata(:, :)
         real(dp) :: alpha
         real(dp) :: err(p, p)
 
-        Adata = 0.0_dp ; Edata = 0.0_dp ; Xdata = 0.0_dp
+        allocate(Adata(kdim, kdim)) ; Adata = 0.0_dp
+        allocate(Edata(kdim, kdim)) ; Edata = 0.0_dp
+        allocate(Xdata(test_size, p)) ; Xdata = 0.0_dp
 
         allocate(Cref(p)) ; call initialize_krylov_subspace(Cref)
         allocate(C(p))    ; call initialize_krylov_subspace(C)
@@ -345,7 +342,8 @@ contains
         A = linop_rdp() ; call init_rand(A) ; call get_data(Adata, A)
        
         ! --> Initialize rhs.
-        allocate(B(1:p)) ; call init_rand(B) ; call get_data(Qdata, B)
+        allocate(B(1:p)) ; call init_rand(B)
+        allocate(Qdata(test_size, p)) ; call get_data(Qdata, B)
 
         ! Comparison is dense computation (10th order Pade approximation)
         call expm(Edata, tau*Adata) ; Xdata = matmul(Edata,Qdata) ; call put_data(Cref, Xdata)
@@ -448,7 +446,7 @@ contains
         integer, parameter :: kdim = test_size
     
         ! ----- Internal variables -----
-        complex(sp) :: E(kdim, kdim)
+        complex(sp), allocatable :: E(:, :)
         real(sp), parameter :: tau = 0.1_sp
         logical, parameter :: verb = .true.
         integer, parameter :: nkmax = 64
@@ -462,7 +460,7 @@ contains
         allocate(XKryl) ; call Xkryl%zero()
 
         ! Dense computation.
-        call expm(E, tau*A%data)
+        allocate(E(kdim, kdim)) ; call expm(E, tau*A%data)
         Xref%data = matmul(E, Q%data)
 
         ! Krylov exponential.
@@ -493,11 +491,7 @@ contains
         ! Krylov subspace dimension.
         integer, parameter :: kdim = test_size
         ! Test matrix.
-        complex(sp) :: Adata(kdim, kdim)
-        complex(sp) :: Edata(kdim, kdim)
-        ! GS factors.
-        complex(sp) :: R(kdim, kdim)
-        complex(sp) :: Id(kdim, kdim)
+        complex(sp), allocatable :: Adata(:, :), Edata(:, :)
         ! Information flag.
         integer :: info
         ! Test parameters
@@ -507,12 +501,14 @@ contains
         real(sp), parameter :: tol = rtol_sp
         logical       , parameter :: verb = .true.
         ! Misc.
-        integer  :: i, j, k
-        complex(sp) :: Xdata(test_size,p), Qdata(test_size,p)
+        integer  :: i, j
+        complex(sp), allocatable :: Xdata(:, :), Qdata(:, :)
         real(sp) :: alpha
         complex(sp) :: err(p, p)
 
-        Adata = 0.0_sp ; Edata = 0.0_sp ; Xdata = 0.0_sp
+        allocate(Adata(kdim, kdim)) ; Adata = 0.0_sp
+        allocate(Edata(kdim, kdim)) ; Edata = 0.0_sp
+        allocate(Xdata(test_size, p)) ; Xdata = 0.0_sp
 
         allocate(Cref(p)) ; call initialize_krylov_subspace(Cref)
         allocate(C(p))    ; call initialize_krylov_subspace(C)
@@ -522,7 +518,8 @@ contains
         A = linop_csp() ; call init_rand(A) ; call get_data(Adata, A)
        
         ! --> Initialize rhs.
-        allocate(B(1:p)) ; call init_rand(B) ; call get_data(Qdata, B)
+        allocate(B(1:p)) ; call init_rand(B)
+        allocate(Qdata(test_size, p)) ; call get_data(Qdata, B)
 
         ! Comparison is dense computation (10th order Pade approximation)
         call expm(Edata, tau*Adata) ; Xdata = matmul(Edata,Qdata) ; call put_data(Cref, Xdata)
@@ -625,7 +622,7 @@ contains
         integer, parameter :: kdim = test_size
     
         ! ----- Internal variables -----
-        complex(dp) :: E(kdim, kdim)
+        complex(dp), allocatable :: E(:, :)
         real(dp), parameter :: tau = 0.1_dp
         logical, parameter :: verb = .true.
         integer, parameter :: nkmax = 64
@@ -639,7 +636,7 @@ contains
         allocate(XKryl) ; call Xkryl%zero()
 
         ! Dense computation.
-        call expm(E, tau*A%data)
+        allocate(E(kdim, kdim)) ; call expm(E, tau*A%data)
         Xref%data = matmul(E, Q%data)
 
         ! Krylov exponential.
@@ -670,11 +667,7 @@ contains
         ! Krylov subspace dimension.
         integer, parameter :: kdim = test_size
         ! Test matrix.
-        complex(dp) :: Adata(kdim, kdim)
-        complex(dp) :: Edata(kdim, kdim)
-        ! GS factors.
-        complex(dp) :: R(kdim, kdim)
-        complex(dp) :: Id(kdim, kdim)
+        complex(dp), allocatable :: Adata(:, :), Edata(:, :)
         ! Information flag.
         integer :: info
         ! Test parameters
@@ -684,12 +677,14 @@ contains
         real(dp), parameter :: tol = rtol_dp
         logical       , parameter :: verb = .true.
         ! Misc.
-        integer  :: i, j, k
-        complex(dp) :: Xdata(test_size,p), Qdata(test_size,p)
+        integer  :: i, j
+        complex(dp), allocatable :: Xdata(:, :), Qdata(:, :)
         real(dp) :: alpha
         complex(dp) :: err(p, p)
 
-        Adata = 0.0_dp ; Edata = 0.0_dp ; Xdata = 0.0_dp
+        allocate(Adata(kdim, kdim)) ; Adata = 0.0_dp
+        allocate(Edata(kdim, kdim)) ; Edata = 0.0_dp
+        allocate(Xdata(test_size, p)) ; Xdata = 0.0_dp
 
         allocate(Cref(p)) ; call initialize_krylov_subspace(Cref)
         allocate(C(p))    ; call initialize_krylov_subspace(C)
@@ -699,7 +694,8 @@ contains
         A = linop_cdp() ; call init_rand(A) ; call get_data(Adata, A)
        
         ! --> Initialize rhs.
-        allocate(B(1:p)) ; call init_rand(B) ; call get_data(Qdata, B)
+        allocate(B(1:p)) ; call init_rand(B)
+        allocate(Qdata(test_size, p)) ; call get_data(Qdata, B)
 
         ! Comparison is dense computation (10th order Pade approximation)
         call expm(Edata, tau*Adata) ; Xdata = matmul(Edata,Qdata) ; call put_data(Cref, Xdata)
@@ -786,7 +782,7 @@ contains
           lambda(i) = abs(lambda(i)) + 0.1_sp
        end do
        ! reconstruct matrix
-       A = matmul(sqrtmA, matmul(diag(lambda), transpose(sqrtmA)))
+       A = matmul(sqrtmA, matmul(diag(abs(lambda)), transpose(sqrtmA)))
        ! ensure it is exactly symmetric/hermitian
        A = 0.5_sp*(A + transpose(A))
      
@@ -824,7 +820,7 @@ contains
        end do
        lambda(n) = zero_rsp
        ! reconstruct matrix
-       A = matmul(sqrtmA, matmul(diag(lambda), transpose(sqrtmA)))
+       A = matmul(sqrtmA, matmul(diag(abs(lambda)), transpose(sqrtmA)))
        ! ensure it is exactly symmetric/hermitian
        A = 0.5_sp*(A + transpose(A))
     
@@ -872,7 +868,7 @@ contains
           lambda(i) = abs(lambda(i)) + 0.1_dp
        end do
        ! reconstruct matrix
-       A = matmul(sqrtmA, matmul(diag(lambda), transpose(sqrtmA)))
+       A = matmul(sqrtmA, matmul(diag(abs(lambda)), transpose(sqrtmA)))
        ! ensure it is exactly symmetric/hermitian
        A = 0.5_dp*(A + transpose(A))
      
@@ -910,7 +906,7 @@ contains
        end do
        lambda(n) = zero_rdp
        ! reconstruct matrix
-       A = matmul(sqrtmA, matmul(diag(lambda), transpose(sqrtmA)))
+       A = matmul(sqrtmA, matmul(diag(abs(lambda)), transpose(sqrtmA)))
        ! ensure it is exactly symmetric/hermitian
        A = 0.5_dp*(A + transpose(A))
     
@@ -959,7 +955,7 @@ contains
           lambda(i) = abs(lambda(i)) + 0.1_sp
        end do
        ! reconstruct matrix
-       A = matmul(sqrtmA, matmul(diag(lambda), conjg(transpose(sqrtmA))))
+       A = matmul(sqrtmA, matmul(diag(abs(lambda)), conjg(transpose(sqrtmA))))
        ! ensure it is exactly symmetric/hermitian
        A = 0.5_sp*(A + conjg(transpose(A)))
      
@@ -998,7 +994,7 @@ contains
        end do
        lambda(n) = zero_rsp
        ! reconstruct matrix
-       A = matmul(sqrtmA, matmul(diag(lambda), conjg(transpose(sqrtmA))))
+       A = matmul(sqrtmA, matmul(diag(abs(lambda)), conjg(transpose(sqrtmA))))
        ! ensure it is exactly symmetric/hermitian
        A = 0.5_sp*(A + conjg(transpose(A)))
     
@@ -1047,7 +1043,7 @@ contains
           lambda(i) = abs(lambda(i)) + 0.1_dp
        end do
        ! reconstruct matrix
-       A = matmul(sqrtmA, matmul(diag(lambda), conjg(transpose(sqrtmA))))
+       A = matmul(sqrtmA, matmul(diag(abs(lambda)), conjg(transpose(sqrtmA))))
        ! ensure it is exactly symmetric/hermitian
        A = 0.5_dp*(A + conjg(transpose(A)))
      
@@ -1086,7 +1082,7 @@ contains
        end do
        lambda(n) = zero_rdp
        ! reconstruct matrix
-       A = matmul(sqrtmA, matmul(diag(lambda), conjg(transpose(sqrtmA))))
+       A = matmul(sqrtmA, matmul(diag(abs(lambda)), conjg(transpose(sqrtmA))))
        ! ensure it is exactly symmetric/hermitian
        A = 0.5_dp*(A + conjg(transpose(A)))
     

--- a/test/TestExpmlib.f90
+++ b/test/TestExpmlib.f90
@@ -79,6 +79,7 @@ contains
 
         ! Check result.
         call check(error, maxval(abs(E-Eref)) < rtol_sp)
+        call check_test(error, 'test_dense_expm_rsp', 'maxval(abs(E-Eref)) < rtol')
 
         return
     end subroutine test_dense_expm_rsp
@@ -113,13 +114,14 @@ contains
 
         ! Krylov exponential.
         call kexpm(Xkryl, A, Q, tau, rtol_sp, info, verbosity=verb, kdim=nkmax)
-        !call check_info(info, 'kexpm', module=this_module, procedure='test_kexptA_rsp')
+        call check_info(info, 'kexpm', module=this_module, procedure='test_kexptA_rsp')
 
         ! Check result.
         call Xkryl%sub(Xref) ; err = Xkryl%norm()
         if (verb) write(output_unit, *) "     True error: ||error||_2 =", err
 
-       call check(error, err < rtol_sp)
+        call check(error, err < rtol_sp)
+        call check_test(error, 'test_kexptA_rsp', 'norm2(x - x_true) < rol')
 
         return
     end subroutine test_kexptA_rsp
@@ -177,13 +179,13 @@ contains
         do i = 1,p
             if (verb) write(*,*) '    column',i
             call kexpm(C(i), A, B(i), tau, tol, info, verbosity=verb, kdim=nkmax)
-            !call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_rsp, 1')
+            call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_rsp, 1')
         end do
         
         ! Compute Krylov matrix exponential using block-arnoldi method
         if (verb) write(*,*) 'BLOCK-ARNOLDI'
         call kexpm(Cblk, A, B, tau, tol, info, verbosity=verb, kdim=nkmax)
-        !call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_rsp, 2')
+        call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_rsp, 2')
     
         do i = 1, p
             write(output_unit, *) C(i)%norm(), Cblk(i)%norm()
@@ -197,7 +199,7 @@ contains
                     err(i, j) = C(i)%dot(C(j))
                 enddo
             enddo
-            alpha = sqrt(norm2(abs(err)))
+            alpha = norm2(abs(err))
             write(*,*) '--------------------------------------------------------------------'
             write(*, *) '    true error (seq.):   ||error||_2 = ', alpha
         endif
@@ -208,10 +210,11 @@ contains
             enddo
         enddo
         
-        alpha = sqrt(norm2(abs(err)))
+        alpha = norm2(abs(err))
         if (verb) write(*, *) '    true error (block):  ||error||_2 = ', alpha
 
         call check(error, alpha < rtol_sp)
+        call check_test(error, 'test_block_kexptA_rsp', 'norm2(x - x_true) < rol')
 
         return
     end subroutine test_block_kexptA_rsp
@@ -255,6 +258,7 @@ contains
 
         ! Check result.
         call check(error, maxval(abs(E-Eref)) < rtol_dp)
+        call check_test(error, 'test_dense_expm_rdp', 'maxval(abs(E-Eref)) < rtol')
 
         return
     end subroutine test_dense_expm_rdp
@@ -289,13 +293,14 @@ contains
 
         ! Krylov exponential.
         call kexpm(Xkryl, A, Q, tau, rtol_dp, info, verbosity=verb, kdim=nkmax)
-        !call check_info(info, 'kexpm', module=this_module, procedure='test_kexptA_rdp')
+        call check_info(info, 'kexpm', module=this_module, procedure='test_kexptA_rdp')
 
         ! Check result.
         call Xkryl%sub(Xref) ; err = Xkryl%norm()
         if (verb) write(output_unit, *) "     True error: ||error||_2 =", err
 
-       call check(error, err < rtol_dp)
+        call check(error, err < rtol_dp)
+        call check_test(error, 'test_kexptA_rdp', 'norm2(x - x_true) < rol')
 
         return
     end subroutine test_kexptA_rdp
@@ -353,13 +358,13 @@ contains
         do i = 1,p
             if (verb) write(*,*) '    column',i
             call kexpm(C(i), A, B(i), tau, tol, info, verbosity=verb, kdim=nkmax)
-            !call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_rdp, 1')
+            call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_rdp, 1')
         end do
         
         ! Compute Krylov matrix exponential using block-arnoldi method
         if (verb) write(*,*) 'BLOCK-ARNOLDI'
         call kexpm(Cblk, A, B, tau, tol, info, verbosity=verb, kdim=nkmax)
-        !call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_rdp, 2')
+        call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_rdp, 2')
     
         do i = 1, p
             write(output_unit, *) C(i)%norm(), Cblk(i)%norm()
@@ -373,7 +378,7 @@ contains
                     err(i, j) = C(i)%dot(C(j))
                 enddo
             enddo
-            alpha = sqrt(norm2(abs(err)))
+            alpha = norm2(abs(err))
             write(*,*) '--------------------------------------------------------------------'
             write(*, *) '    true error (seq.):   ||error||_2 = ', alpha
         endif
@@ -384,10 +389,11 @@ contains
             enddo
         enddo
         
-        alpha = sqrt(norm2(abs(err)))
+        alpha = norm2(abs(err))
         if (verb) write(*, *) '    true error (block):  ||error||_2 = ', alpha
 
         call check(error, alpha < rtol_dp)
+        call check_test(error, 'test_block_kexptA_rdp', 'norm2(x - x_true) < rol')
 
         return
     end subroutine test_block_kexptA_rdp
@@ -431,6 +437,7 @@ contains
 
         ! Check result.
         call check(error, maxval(abs(E-Eref)) < rtol_sp)
+        call check_test(error, 'test_dense_expm_csp', 'maxval(abs(E-Eref)) < rtol')
 
         return
     end subroutine test_dense_expm_csp
@@ -465,13 +472,14 @@ contains
 
         ! Krylov exponential.
         call kexpm(Xkryl, A, Q, tau, rtol_sp, info, verbosity=verb, kdim=nkmax)
-        !call check_info(info, 'kexpm', module=this_module, procedure='test_kexptA_csp')
+        call check_info(info, 'kexpm', module=this_module, procedure='test_kexptA_csp')
 
         ! Check result.
         call Xkryl%sub(Xref) ; err = Xkryl%norm()
         if (verb) write(output_unit, *) "     True error: ||error||_2 =", err
 
-       call check(error, err < rtol_sp)
+        call check(error, err < rtol_sp)
+        call check_test(error, 'test_kexptA_csp', 'norm2(x - x_true) < rol')
 
         return
     end subroutine test_kexptA_csp
@@ -529,13 +537,13 @@ contains
         do i = 1,p
             if (verb) write(*,*) '    column',i
             call kexpm(C(i), A, B(i), tau, tol, info, verbosity=verb, kdim=nkmax)
-            !call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_csp, 1')
+            call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_csp, 1')
         end do
         
         ! Compute Krylov matrix exponential using block-arnoldi method
         if (verb) write(*,*) 'BLOCK-ARNOLDI'
         call kexpm(Cblk, A, B, tau, tol, info, verbosity=verb, kdim=nkmax)
-        !call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_csp, 2')
+        call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_csp, 2')
     
         do i = 1, p
             write(output_unit, *) C(i)%norm(), Cblk(i)%norm()
@@ -549,7 +557,7 @@ contains
                     err(i, j) = C(i)%dot(C(j))
                 enddo
             enddo
-            alpha = sqrt(norm2(abs(err)))
+            alpha = norm2(abs(err))
             write(*,*) '--------------------------------------------------------------------'
             write(*, *) '    true error (seq.):   ||error||_2 = ', alpha
         endif
@@ -560,10 +568,11 @@ contains
             enddo
         enddo
         
-        alpha = sqrt(norm2(abs(err)))
+        alpha = norm2(abs(err))
         if (verb) write(*, *) '    true error (block):  ||error||_2 = ', alpha
 
         call check(error, alpha < rtol_sp)
+        call check_test(error, 'test_block_kexptA_csp', 'norm2(x - x_true) < rol')
 
         return
     end subroutine test_block_kexptA_csp
@@ -607,6 +616,7 @@ contains
 
         ! Check result.
         call check(error, maxval(abs(E-Eref)) < rtol_dp)
+        call check_test(error, 'test_dense_expm_cdp', 'maxval(abs(E-Eref)) < rtol')
 
         return
     end subroutine test_dense_expm_cdp
@@ -641,13 +651,14 @@ contains
 
         ! Krylov exponential.
         call kexpm(Xkryl, A, Q, tau, rtol_dp, info, verbosity=verb, kdim=nkmax)
-        !call check_info(info, 'kexpm', module=this_module, procedure='test_kexptA_cdp')
+        call check_info(info, 'kexpm', module=this_module, procedure='test_kexptA_cdp')
 
         ! Check result.
         call Xkryl%sub(Xref) ; err = Xkryl%norm()
         if (verb) write(output_unit, *) "     True error: ||error||_2 =", err
 
-       call check(error, err < rtol_dp)
+        call check(error, err < rtol_dp)
+        call check_test(error, 'test_kexptA_cdp', 'norm2(x - x_true) < rol')
 
         return
     end subroutine test_kexptA_cdp
@@ -705,13 +716,13 @@ contains
         do i = 1,p
             if (verb) write(*,*) '    column',i
             call kexpm(C(i), A, B(i), tau, tol, info, verbosity=verb, kdim=nkmax)
-            !call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_cdp, 1')
+            call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_cdp, 1')
         end do
         
         ! Compute Krylov matrix exponential using block-arnoldi method
         if (verb) write(*,*) 'BLOCK-ARNOLDI'
         call kexpm(Cblk, A, B, tau, tol, info, verbosity=verb, kdim=nkmax)
-        !call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_cdp, 2')
+        call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_cdp, 2')
     
         do i = 1, p
             write(output_unit, *) C(i)%norm(), Cblk(i)%norm()
@@ -725,7 +736,7 @@ contains
                     err(i, j) = C(i)%dot(C(j))
                 enddo
             enddo
-            alpha = sqrt(norm2(abs(err)))
+            alpha = norm2(abs(err))
             write(*,*) '--------------------------------------------------------------------'
             write(*, *) '    true error (seq.):   ||error||_2 = ', alpha
         endif
@@ -736,10 +747,11 @@ contains
             enddo
         enddo
         
-        alpha = sqrt(norm2(abs(err)))
+        alpha = norm2(abs(err))
         if (verb) write(*, *) '    true error (block):  ||error||_2 = ', alpha
 
         call check(error, alpha < rtol_dp)
+        call check_test(error, 'test_block_kexptA_cdp', 'norm2(x - x_true) < rol')
 
         return
     end subroutine test_block_kexptA_cdp
@@ -788,10 +800,11 @@ contains
      
        ! compute matrix square root
        call sqrtm(A, sqrtmA, info)
-       !call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_def_rsp')
+       call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_def_rsp')
     
        write(*,*) 'max err: ', maxval(matmul(sqrtmA, sqrtmA) - A)
        call check(error, maxval(matmul(sqrtmA, sqrtmA) - A) < rtol_sp)
+       call check_test(error, 'test_dense_sqrtm_pos_def_rsp', 'sqrt(A)**2 /= A')
     
        return
     end subroutine test_dense_sqrtm_pos_def_rsp
@@ -826,10 +839,11 @@ contains
     
        ! compute matrix square root
        call sqrtm(A, sqrtmA, info)
-       !call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_semi_def_rsp')
+       call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_semi_def_rsp')
     
        write(*,*) 'max err: ', maxval(matmul(sqrtmA, sqrtmA) - A)
        call check(error, maxval(matmul(sqrtmA, sqrtmA) - A) < rtol_sp)
+       call check_test(error, 'test_dense_sqrtm_pos_semi_def_rsp', 'sqrt(A)**2 /= A')
     
        return
     end subroutine test_dense_sqrtm_pos_semi_def_rsp
@@ -874,10 +888,11 @@ contains
      
        ! compute matrix square root
        call sqrtm(A, sqrtmA, info)
-       !call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_def_rdp')
+       call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_def_rdp')
     
        write(*,*) 'max err: ', maxval(matmul(sqrtmA, sqrtmA) - A)
        call check(error, maxval(matmul(sqrtmA, sqrtmA) - A) < rtol_dp)
+       call check_test(error, 'test_dense_sqrtm_pos_def_rdp', 'sqrt(A)**2 /= A')
     
        return
     end subroutine test_dense_sqrtm_pos_def_rdp
@@ -912,10 +927,11 @@ contains
     
        ! compute matrix square root
        call sqrtm(A, sqrtmA, info)
-       !call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_semi_def_rdp')
+       call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_semi_def_rdp')
     
        write(*,*) 'max err: ', maxval(matmul(sqrtmA, sqrtmA) - A)
        call check(error, maxval(matmul(sqrtmA, sqrtmA) - A) < rtol_dp)
+       call check_test(error, 'test_dense_sqrtm_pos_semi_def_rdp', 'sqrt(A)**2 /= A')
     
        return
     end subroutine test_dense_sqrtm_pos_semi_def_rdp
@@ -961,10 +977,11 @@ contains
      
        ! compute matrix square root
        call sqrtm(A, sqrtmA, info)
-       !call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_def_csp')
+       call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_def_csp')
     
        write(*,*) 'max err: ', maxval(abs(matmul(sqrtmA, sqrtmA) - A))
        call check(error, maxval(abs(matmul(sqrtmA, sqrtmA) - A)) < rtol_sp)
+       call check_test(error, 'test_dense_sqrtm_pos_def_csp', 'sqrt(A)**2 /= A')
     
        return
     end subroutine test_dense_sqrtm_pos_def_csp
@@ -1000,10 +1017,11 @@ contains
     
        ! compute matrix square root
        call sqrtm(A, sqrtmA, info)
-       !call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_semi_def_csp')
+       call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_semi_def_csp')
     
        write(*,*) 'max err: ', maxval(abs(matmul(sqrtmA, sqrtmA) - A))
        call check(error, maxval(abs(matmul(sqrtmA, sqrtmA) - A)) < rtol_sp)
+       call check_test(error, 'test_dense_sqrtm_pos_semi_def_csp', 'sqrt(A)**2 /= A')
     
        return
     end subroutine test_dense_sqrtm_pos_semi_def_csp
@@ -1049,10 +1067,11 @@ contains
      
        ! compute matrix square root
        call sqrtm(A, sqrtmA, info)
-       !call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_def_cdp')
+       call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_def_cdp')
     
        write(*,*) 'max err: ', maxval(abs(matmul(sqrtmA, sqrtmA) - A))
        call check(error, maxval(abs(matmul(sqrtmA, sqrtmA) - A)) < rtol_dp)
+       call check_test(error, 'test_dense_sqrtm_pos_def_cdp', 'sqrt(A)**2 /= A')
     
        return
     end subroutine test_dense_sqrtm_pos_def_cdp
@@ -1088,10 +1107,11 @@ contains
     
        ! compute matrix square root
        call sqrtm(A, sqrtmA, info)
-       !call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_semi_def_cdp')
+       call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_semi_def_cdp')
     
        write(*,*) 'max err: ', maxval(abs(matmul(sqrtmA, sqrtmA) - A))
        call check(error, maxval(abs(matmul(sqrtmA, sqrtmA) - A)) < rtol_dp)
+       call check_test(error, 'test_dense_sqrtm_pos_semi_def_cdp', 'sqrt(A)**2 /= A')
     
        return
     end subroutine test_dense_sqrtm_pos_semi_def_cdp

--- a/test/TestExpmlib.fypp
+++ b/test/TestExpmlib.fypp
@@ -60,6 +60,8 @@ contains
         ! Test matrix.
         ${type}$ :: A(n, n), E(n, n), Eref(n, n)
         integer :: i, j
+        real(${kind}$) :: err
+        character*256 :: msg
 
         ! Initialize matrix.
         A = 0.0_${kind}$
@@ -79,8 +81,10 @@ contains
         call expm(E, A)
 
         ! Check result.
-        call check(error, maxval(abs(E-Eref)) < rtol_${kind}$)
-        call check_test(error, 'test_dense_expm_${type[0]}$${kind}$', 'maxval(abs(E-Eref)) < rtol')
+        err = maxval(abs(E-Eref))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_${kind}$)
+        call check_test(error, 'test_dense_expm_${type[0]}$${kind}$', eq='maxval(abs(E-Eref)) < rtol', context=msg)
 
         return
     end subroutine test_dense_expm_${type[0]}$${kind}$
@@ -98,10 +102,10 @@ contains
         ! ----- Internal variables -----
         ${type}$, allocatable :: E(:, :)
         real(${kind}$), parameter :: tau = 0.1_${kind}$
-        logical, parameter :: verb = .true.
         integer, parameter :: nkmax = 64
         real(${kind}$) :: err
         integer :: info
+        character*256 :: msg
         
         ! Initialize data.
         A = linop_${type[0]}$${kind}$() ; call init_rand(A)
@@ -114,15 +118,15 @@ contains
         Xref%data = matmul(E, Q%data)
 
         ! Krylov exponential.
-        call kexpm(Xkryl, A, Q, tau, rtol_${kind}$, info, verbosity=verb, kdim=nkmax)
+        call kexpm(Xkryl, A, Q, tau, rtol_${kind}$, info, verbosity=.false., kdim=nkmax)
         call check_info(info, 'kexpm', module=this_module, procedure='test_kexptA_${type[0]}$${kind}$')
 
         ! Check result.
         call Xkryl%sub(Xref) ; err = Xkryl%norm()
-        if (verb) write(output_unit, *) "     True error: ||error||_2 =", err
-
+        call get_err_str(msg, "max err: ", err)
         call check(error, err < rtol_${kind}$)
-        call check_test(error, 'test_kexptA_${type[0]}$${kind}$', 'norm2(x - x_true) < rol')
+        call check_test(error, 'test_kexptA_${type[0]}$${kind}$', &
+                                 & info='Comparison with matrix exponential', context=msg)
 
         return
     end subroutine test_kexptA_${type[0]}$${kind}$
@@ -150,12 +154,12 @@ contains
         integer       , parameter :: p = 3
         real(${kind}$), parameter :: tau = 0.1_${kind}$
         real(${kind}$), parameter :: tol = rtol_${kind}$
-        logical       , parameter :: verb = .true.
         ! Misc.
         integer  :: i, j
         ${type}$, allocatable :: Xdata(:, :), Qdata(:, :)
-        real(${kind}$) :: alpha
+        real(${kind}$) :: errv
         ${type}$ :: err(p, p)
+        character*256 :: msg
 
         allocate(Adata(kdim, kdim)) ; Adata = 0.0_${kind}$
         allocate(Edata(kdim, kdim)) ; Edata = 0.0_${kind}$
@@ -176,16 +180,13 @@ contains
         call expm(Edata, tau*Adata) ; Xdata = matmul(Edata,Qdata) ; call put_data(Cref, Xdata)
 
         ! Compute Krylov matrix exponential using sequential arnoldi method for each input column
-        if (verb) write(*,*) 'SEQUENTIAL ARNOLDI'
         do i = 1,p
-            if (verb) write(*,*) '    column',i
-            call kexpm(C(i), A, B(i), tau, tol, info, verbosity=verb, kdim=nkmax)
+            call kexpm(C(i), A, B(i), tau, tol, info, verbosity=.false., kdim=nkmax)
             call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_${type[0]}$${kind}$, 1')
         end do
         
         ! Compute Krylov matrix exponential using block-arnoldi method
-        if (verb) write(*,*) 'BLOCK-ARNOLDI'
-        call kexpm(Cblk, A, B, tau, tol, info, verbosity=verb, kdim=nkmax)
+        call kexpm(Cblk, A, B, tau, tol, info, verbosity=.false., kdim=nkmax)
         call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_${type[0]}$${kind}$, 2')
     
         do i = 1, p
@@ -194,28 +195,26 @@ contains
         end do
 
         ! Compute 2-norm of the error
-        if (verb) then
-            do i = 1, size(C)
-                do j = 1, size(C)
-                    err(i, j) = C(i)%dot(C(j))
-                enddo
+        
+        do i = 1, size(C)
+            do j = 1, size(C)
+                err(i, j) = C(i)%dot(C(j))
             enddo
-            alpha = norm2(abs(err))
-            write(*,*) '--------------------------------------------------------------------'
-            write(*, *) '    true error (seq.):   ||error||_2 = ', alpha
-        endif
+        enddo
+        errv = norm2(abs(err))
+        !call get_err_str(msg, "max err: ", errv)
  
         do i = 1, size(Cblk)
             do j = 1, size(Cblk)
                 err(i, j) = Cblk(i)%dot(Cblk(j))
             enddo
         enddo
-        
-        alpha = norm2(abs(err))
-        if (verb) write(*, *) '    true error (block):  ||error||_2 = ', alpha
+        errv = norm2(abs(err))
+        call get_err_str(msg, "max err: ", errv)
 
-        call check(error, alpha < rtol_${kind}$)
-        call check_test(error, 'test_block_kexptA_${type[0]}$${kind}$', 'norm2(x - x_true) < rol')
+        call check(error, errv < rtol_${kind}$)
+        call check_test(error, 'test_block_kexptA_${type[0]}$${kind}$', &
+                        & info='Comparison with matrix exponential', context=msg)
 
         return
     end subroutine test_block_kexptA_${type[0]}$${kind}$
@@ -249,7 +248,9 @@ contains
        ${type}$ :: A(n, n)
        ${type}$ :: sqrtmA(n, n)
        complex(${kind}$) :: lambda(n)
+       real(${kind}$) :: err
        integer :: i, info
+       character*256 :: msg
     
        ! --> Initialize matrix.
        #:if type[0] == "r"
@@ -284,13 +285,15 @@ contains
        call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_def_${type[0]}$${kind}$')
     
        #:if type[0] == "r"
-       write(*,*) 'max err: ', maxval(matmul(sqrtmA, sqrtmA) - A)
-       call check(error, maxval(matmul(sqrtmA, sqrtmA) - A) < rtol_${kind}$)
+       err = maxval(matmul(sqrtmA, sqrtmA) - A)
+       call get_err_str(msg, "max err: ", err)
+       call check(error, err < rtol_${kind}$)
        #:else
-       write(*,*) 'max err: ', maxval(abs(matmul(sqrtmA, sqrtmA) - A))
-       call check(error, maxval(abs(matmul(sqrtmA, sqrtmA) - A)) < rtol_${kind}$)
+       err =  maxval(abs(matmul(sqrtmA, sqrtmA) - A))
+       call get_err_str(msg, "max err: ", err)
+       call check(error, err < rtol_${kind}$)
        #:endif
-       call check_test(error, 'test_dense_sqrtm_pos_def_${type[0]}$${kind}$', 'sqrt(A)**2 /= A')
+       call check_test(error, 'test_dense_sqrtm_pos_def_${type[0]}$${kind}$', eq='sqrt(A)**2 = A', context=msg)
     
        return
     end subroutine test_dense_sqrtm_pos_def_${type[0]}$${kind}$
@@ -307,7 +310,9 @@ contains
        ${type}$ :: A(n, n)
        ${type}$ :: sqrtmA(n, n)
        complex(${kind}$) :: lambda(n)
+       real(${kind}$) :: err
        integer :: i, info
+       character*256 :: msg
     
        ! --> Initialize matrix.
        #:if type[0] == "r"
@@ -343,13 +348,15 @@ contains
        call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_semi_def_${type[0]}$${kind}$')
     
        #:if type[0] == "r"
-       write(*,*) 'max err: ', maxval(matmul(sqrtmA, sqrtmA) - A)
-       call check(error, maxval(matmul(sqrtmA, sqrtmA) - A) < rtol_${kind}$)
+       err = maxval(matmul(sqrtmA, sqrtmA) - A)
+       call get_err_str(msg, "max err: ", err)
+       call check(error, err < rtol_${kind}$)
        #:else
-       write(*,*) 'max err: ', maxval(abs(matmul(sqrtmA, sqrtmA) - A))
-       call check(error, maxval(abs(matmul(sqrtmA, sqrtmA) - A)) < rtol_${kind}$)
+       err = maxval(abs(matmul(sqrtmA, sqrtmA) - A))
+       call get_err_str(msg, "max err: ", err)
+       call check(error, err < rtol_${kind}$)
        #:endif
-       call check_test(error, 'test_dense_sqrtm_pos_semi_def_${type[0]}$${kind}$', 'sqrt(A)**2 /= A')
+       call check_test(error, 'test_dense_sqrtm_pos_semi_def_${type[0]}$${kind}$', eq='sqrt(A)**2 = A', context=trim(msg))
     
        return
     end subroutine test_dense_sqrtm_pos_semi_def_${type[0]}$${kind}$

--- a/test/TestExpmlib.fypp
+++ b/test/TestExpmlib.fypp
@@ -80,6 +80,7 @@ contains
 
         ! Check result.
         call check(error, maxval(abs(E-Eref)) < rtol_${kind}$)
+        call check_test(error, 'test_dense_expm_${type[0]}$${kind}$', 'maxval(abs(E-Eref)) < rtol')
 
         return
     end subroutine test_dense_expm_${type[0]}$${kind}$
@@ -114,13 +115,14 @@ contains
 
         ! Krylov exponential.
         call kexpm(Xkryl, A, Q, tau, rtol_${kind}$, info, verbosity=verb, kdim=nkmax)
-        !call check_info(info, 'kexpm', module=this_module, procedure='test_kexptA_${type[0]}$${kind}$')
+        call check_info(info, 'kexpm', module=this_module, procedure='test_kexptA_${type[0]}$${kind}$')
 
         ! Check result.
         call Xkryl%sub(Xref) ; err = Xkryl%norm()
         if (verb) write(output_unit, *) "     True error: ||error||_2 =", err
 
-       call check(error, err < rtol_${kind}$)
+        call check(error, err < rtol_${kind}$)
+        call check_test(error, 'test_kexptA_${type[0]}$${kind}$', 'norm2(x - x_true) < rol')
 
         return
     end subroutine test_kexptA_${type[0]}$${kind}$
@@ -178,13 +180,13 @@ contains
         do i = 1,p
             if (verb) write(*,*) '    column',i
             call kexpm(C(i), A, B(i), tau, tol, info, verbosity=verb, kdim=nkmax)
-            !call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_${type[0]}$${kind}$, 1')
+            call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_${type[0]}$${kind}$, 1')
         end do
         
         ! Compute Krylov matrix exponential using block-arnoldi method
         if (verb) write(*,*) 'BLOCK-ARNOLDI'
         call kexpm(Cblk, A, B, tau, tol, info, verbosity=verb, kdim=nkmax)
-        !call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_${type[0]}$${kind}$, 2')
+        call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_${type[0]}$${kind}$, 2')
     
         do i = 1, p
             write(output_unit, *) C(i)%norm(), Cblk(i)%norm()
@@ -198,7 +200,7 @@ contains
                     err(i, j) = C(i)%dot(C(j))
                 enddo
             enddo
-            alpha = sqrt(norm2(abs(err)))
+            alpha = norm2(abs(err))
             write(*,*) '--------------------------------------------------------------------'
             write(*, *) '    true error (seq.):   ||error||_2 = ', alpha
         endif
@@ -209,10 +211,11 @@ contains
             enddo
         enddo
         
-        alpha = sqrt(norm2(abs(err)))
+        alpha = norm2(abs(err))
         if (verb) write(*, *) '    true error (block):  ||error||_2 = ', alpha
 
         call check(error, alpha < rtol_${kind}$)
+        call check_test(error, 'test_block_kexptA_${type[0]}$${kind}$', 'norm2(x - x_true) < rol')
 
         return
     end subroutine test_block_kexptA_${type[0]}$${kind}$
@@ -278,7 +281,7 @@ contains
      
        ! compute matrix square root
        call sqrtm(A, sqrtmA, info)
-       !call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_def_${type[0]}$${kind}$')
+       call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_def_${type[0]}$${kind}$')
     
        #:if type[0] == "r"
        write(*,*) 'max err: ', maxval(matmul(sqrtmA, sqrtmA) - A)
@@ -287,6 +290,7 @@ contains
        write(*,*) 'max err: ', maxval(abs(matmul(sqrtmA, sqrtmA) - A))
        call check(error, maxval(abs(matmul(sqrtmA, sqrtmA) - A)) < rtol_${kind}$)
        #:endif
+       call check_test(error, 'test_dense_sqrtm_pos_def_${type[0]}$${kind}$', 'sqrt(A)**2 /= A')
     
        return
     end subroutine test_dense_sqrtm_pos_def_${type[0]}$${kind}$
@@ -336,7 +340,7 @@ contains
     
        ! compute matrix square root
        call sqrtm(A, sqrtmA, info)
-       !call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_semi_def_${type[0]}$${kind}$')
+       call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_semi_def_${type[0]}$${kind}$')
     
        #:if type[0] == "r"
        write(*,*) 'max err: ', maxval(matmul(sqrtmA, sqrtmA) - A)
@@ -345,6 +349,7 @@ contains
        write(*,*) 'max err: ', maxval(abs(matmul(sqrtmA, sqrtmA) - A))
        call check(error, maxval(abs(matmul(sqrtmA, sqrtmA) - A)) < rtol_${kind}$)
        #:endif
+       call check_test(error, 'test_dense_sqrtm_pos_semi_def_${type[0]}$${kind}$', 'sqrt(A)**2 /= A')
     
        return
     end subroutine test_dense_sqrtm_pos_semi_def_${type[0]}$${kind}$

--- a/test/TestExpmlib.fypp
+++ b/test/TestExpmlib.fypp
@@ -24,7 +24,7 @@ module TestExpmlib
 
     private
 
-    character*128, parameter, private :: this_module = 'LightKrylov_TestExpmLib'
+    character(len=128), parameter, private :: this_module = 'LightKrylov_TestExpmLib'
 
     #:for kind, type in RC_KINDS_TYPES
     public :: collect_expm_${type[0]}$${kind}$_testsuite
@@ -95,7 +95,7 @@ contains
         integer, parameter :: kdim = test_size
     
         ! ----- Internal variables -----
-        ${type}$ :: E(kdim, kdim)
+        ${type}$, allocatable :: E(:, :)
         real(${kind}$), parameter :: tau = 0.1_${kind}$
         logical, parameter :: verb = .true.
         integer, parameter :: nkmax = 64
@@ -109,7 +109,7 @@ contains
         allocate(XKryl) ; call Xkryl%zero()
 
         ! Dense computation.
-        call expm(E, tau*A%data)
+        allocate(E(kdim, kdim)) ; call expm(E, tau*A%data)
         Xref%data = matmul(E, Q%data)
 
         ! Krylov exponential.
@@ -140,11 +140,7 @@ contains
         ! Krylov subspace dimension.
         integer, parameter :: kdim = test_size
         ! Test matrix.
-        ${type}$ :: Adata(kdim, kdim)
-        ${type}$ :: Edata(kdim, kdim)
-        ! GS factors.
-        ${type}$ :: R(kdim, kdim)
-        ${type}$ :: Id(kdim, kdim)
+        ${type}$, allocatable :: Adata(:, :), Edata(:, :)
         ! Information flag.
         integer :: info
         ! Test parameters
@@ -154,12 +150,14 @@ contains
         real(${kind}$), parameter :: tol = rtol_${kind}$
         logical       , parameter :: verb = .true.
         ! Misc.
-        integer  :: i, j, k
-        ${type}$ :: Xdata(test_size,p), Qdata(test_size,p)
+        integer  :: i, j
+        ${type}$, allocatable :: Xdata(:, :), Qdata(:, :)
         real(${kind}$) :: alpha
         ${type}$ :: err(p, p)
 
-        Adata = 0.0_${kind}$ ; Edata = 0.0_${kind}$ ; Xdata = 0.0_${kind}$
+        allocate(Adata(kdim, kdim)) ; Adata = 0.0_${kind}$
+        allocate(Edata(kdim, kdim)) ; Edata = 0.0_${kind}$
+        allocate(Xdata(test_size, p)) ; Xdata = 0.0_${kind}$
 
         allocate(Cref(p)) ; call initialize_krylov_subspace(Cref)
         allocate(C(p))    ; call initialize_krylov_subspace(C)
@@ -169,7 +167,8 @@ contains
         A = linop_${type[0]}$${kind}$() ; call init_rand(A) ; call get_data(Adata, A)
        
         ! --> Initialize rhs.
-        allocate(B(1:p)) ; call init_rand(B) ; call get_data(Qdata, B)
+        allocate(B(1:p)) ; call init_rand(B)
+        allocate(Qdata(test_size, p)) ; call get_data(Qdata, B)
 
         ! Comparison is dense computation (10th order Pade approximation)
         call expm(Edata, tau*Adata) ; Xdata = matmul(Edata,Qdata) ; call put_data(Cref, Xdata)
@@ -268,11 +267,11 @@ contains
        end do
        ! reconstruct matrix
        #:if type[0] == "r"
-       A = matmul(sqrtmA, matmul(diag(lambda), transpose(sqrtmA)))
+       A = matmul(sqrtmA, matmul(diag(abs(lambda)), transpose(sqrtmA)))
        ! ensure it is exactly symmetric/hermitian
        A = 0.5_${kind}$*(A + transpose(A))
        #:else
-       A = matmul(sqrtmA, matmul(diag(lambda), conjg(transpose(sqrtmA))))
+       A = matmul(sqrtmA, matmul(diag(abs(lambda)), conjg(transpose(sqrtmA))))
        ! ensure it is exactly symmetric/hermitian
        A = 0.5_${kind}$*(A + conjg(transpose(A)))
        #:endif
@@ -326,11 +325,11 @@ contains
        lambda(n) = zero_r${kind}$
        ! reconstruct matrix
        #:if type[0] == "r"
-       A = matmul(sqrtmA, matmul(diag(lambda), transpose(sqrtmA)))
+       A = matmul(sqrtmA, matmul(diag(abs(lambda)), transpose(sqrtmA)))
        ! ensure it is exactly symmetric/hermitian
        A = 0.5_${kind}$*(A + transpose(A))
        #:else
-       A = matmul(sqrtmA, matmul(diag(lambda), conjg(transpose(sqrtmA))))
+       A = matmul(sqrtmA, matmul(diag(abs(lambda)), conjg(transpose(sqrtmA))))
        ! ensure it is exactly symmetric/hermitian
        A = 0.5_${kind}$*(A + conjg(transpose(A)))
        #:endif

--- a/test/TestIterativeSolvers.f90
+++ b/test/TestIterativeSolvers.f90
@@ -122,6 +122,8 @@ contains
         !end do
         !print *, norm2(abs(eigvec_residuals))
         !call check(error, norm2(abs(eigvec_residuals)) < rtol_sp)
+        call check_test(error, 'test_ks_evp_rsp', & 
+                              & 'The computed eigenvalue/eigenvector pairs (E,V) are not correct: A @ V /= diag(E) @ V')
 
         return
     end subroutine test_ks_evp_rsp
@@ -187,6 +189,8 @@ contains
 !            eigvec_residuals(:, i) = AX(i)%data - eigvals(i)*X(i)%data
 !        end do
 !        call check(error, norm2(abs(eigvec_residuals)) < rtol_sp)
+!        call check_test(error, 'test_evp_rsp', &
+!                                 & 'The computed eigenvalue/eigenvector pairs (E,V) are not correct: A @ V /= diag(E) @ V')
 
         return
     end subroutine test_evp_rsp
@@ -255,7 +259,8 @@ contains
             eigvec_residuals(:, i) = AX(i)%data - evals(i)*X(i)%data
         end do
         call check(error, norm2(abs(eigvec_residuals)) < rtol_sp)
-        if (allocated(error)) return
+        call check_test(error, 'test_sym_evp_rsp', 'The computed eigenvalue/eigenvector pairs (E,V) are not correct: A @ V /=&
+            & diag(E) @ V')
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(test_size, test_size)) ; G = zero_rsp
@@ -341,6 +346,8 @@ contains
         !end do
         !print *, norm2(abs(eigvec_residuals))
         !call check(error, norm2(abs(eigvec_residuals)) < rtol_dp)
+        call check_test(error, 'test_ks_evp_rdp', & 
+                              & 'The computed eigenvalue/eigenvector pairs (E,V) are not correct: A @ V /= diag(E) @ V')
 
         return
     end subroutine test_ks_evp_rdp
@@ -474,7 +481,8 @@ contains
             eigvec_residuals(:, i) = AX(i)%data - evals(i)*X(i)%data
         end do
         call check(error, norm2(abs(eigvec_residuals)) < rtol_dp)
-        if (allocated(error)) return
+        call check_test(error, 'test_sym_evp_rdp', 'The computed eigenvalue/eigenvector pairs (E,V) are not correct: A @ V /=&
+            & diag(E) @ V')
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(test_size, test_size)) ; G = zero_rdp
@@ -687,6 +695,7 @@ contains
         allocate(Udata(test_size, test_size)) ; call get_data(Udata, U)
         allocate(Vdata(test_size, test_size)) ; call get_data(Vdata, V)
         call check(error, maxval(abs(A%data - matmul(Udata, matmul(diag(s), transpose(Vdata))))) < rtol_sp)
+        call check_test(error, 'test_svd_rsp', 'The factorization is not correct: A /= U @ S @ V.H')
 
         return
     end subroutine test_svd_rsp
@@ -770,6 +779,7 @@ contains
         allocate(Udata(test_size, test_size)) ; call get_data(Udata, U)
         allocate(Vdata(test_size, test_size)) ; call get_data(Vdata, V)
         call check(error, maxval(abs(A%data - matmul(Udata, matmul(diag(s), transpose(Vdata))))) < rtol_dp)
+        call check_test(error, 'test_svd_rdp', 'The factorization is not correct: A /= U @ S @ V.H')
 
         return
     end subroutine test_svd_rdp
@@ -878,6 +888,7 @@ contains
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_sp)
+        call check_test(error, 'test_gmres_rsp', 'The computed solution is not correct: A @ x /= b')
 
         return
     end subroutine test_gmres_rsp
@@ -906,6 +917,7 @@ contains
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_sp)
+        call check_test(error, 'test_gmres_spd_rsp', 'The computed solution is not correct: A @ x /= b')
 
         return
     end subroutine test_gmres_spd_rsp
@@ -943,6 +955,7 @@ contains
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_dp)
+        call check_test(error, 'test_gmres_rdp', 'The computed solution is not correct: A @ x /= b')
 
         return
     end subroutine test_gmres_rdp
@@ -971,6 +984,7 @@ contains
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_dp)
+        call check_test(error, 'test_gmres_spd_rdp', 'The computed solution is not correct: A @ x /= b')
 
         return
     end subroutine test_gmres_spd_rdp
@@ -1008,6 +1022,7 @@ contains
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_sp)
+        call check_test(error, 'test_gmres_csp', 'The computed solution is not correct: A @ x /= b')
 
         return
     end subroutine test_gmres_csp
@@ -1036,6 +1051,7 @@ contains
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_sp)
+        call check_test(error, 'test_gmres_spd_csp', 'The computed solution is not correct: A @ x /= b')
 
         return
     end subroutine test_gmres_spd_csp
@@ -1073,6 +1089,7 @@ contains
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_dp)
+        call check_test(error, 'test_gmres_cdp', 'The computed solution is not correct: A @ x /= b')
 
         return
     end subroutine test_gmres_cdp
@@ -1101,6 +1118,7 @@ contains
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_dp)
+        call check_test(error, 'test_gmres_spd_cdp', 'The computed solution is not correct: A @ x /= b')
 
         return
     end subroutine test_gmres_spd_cdp
@@ -1141,6 +1159,7 @@ contains
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_sp)
+        call check_test(error, 'test_cg_rsp', 'The computed solution is not correct: A @ x /= b')
 
         return
     end subroutine test_cg_rsp
@@ -1176,6 +1195,7 @@ contains
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_dp)
+        call check_test(error, 'test_cg_rdp', 'The computed solution is not correct: A @ x /= b')
 
         return
     end subroutine test_cg_rdp
@@ -1211,6 +1231,7 @@ contains
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_sp)
+        call check_test(error, 'test_cg_csp', 'The computed solution is not correct: A @ x /= b')
 
         return
     end subroutine test_cg_csp
@@ -1246,6 +1267,7 @@ contains
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_dp)
+        call check_test(error, 'test_cg_cdp', 'The computed solution is not correct: A @ x /= b')
 
         return
     end subroutine test_cg_cdp

--- a/test/TestIterativeSolvers.f90
+++ b/test/TestIterativeSolvers.f90
@@ -23,7 +23,7 @@ module TestIterativeSolvers
     
     private
 
-    character*128, parameter, private :: this_module = 'LightKrylov_TestIterativeSolvers'
+    character(len=128), parameter, private :: this_module = 'LightKrylov_TestIterativeSolvers'
 
     public :: collect_eig_rsp_testsuite
     public :: collect_svd_rsp_testsuite
@@ -205,18 +205,19 @@ contains
         ! Information flag.
         integer :: info
         ! Toeplitz matrix.
-        real(sp) :: T(test_size, test_size), a_, b_
+        real(sp), allocatable :: T(:, :)
+        real(sp) :: a_, b_
         ! Miscellaneous.
         integer :: i
         real(sp) :: alpha, true_evals(test_size)
         real(sp), parameter :: pi = 4.0_sp * atan(1.0_sp)
         type(vector_rsp), allocatable :: AX(:)
         complex(sp), allocatable :: eigvec_residuals(:,:)
-        real(sp), allocatable, dimension(:,:) :: G, Id
+        real(sp), allocatable, dimension(:,:) :: G
 
         ! Create the sym. pos. def. Toeplitz matrix.
         call random_number(a_) ; call random_number(b_) ; b_ = -abs(b_)
-        T = 0.0_sp
+        allocate(T(test_size, test_size)) ; T = 0.0_sp
         do i = 1, test_size
             ! Diagonal entry.
             T(i, i) = a_
@@ -257,13 +258,11 @@ contains
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the Krylov basis.
-        allocate(G(test_size, test_size)) ; allocate(Id(test_size, test_size))
-        G = zero_rsp
+        allocate(G(test_size, test_size)) ; G = zero_rsp
         call innerprod(G, X, X)
 
         ! Check orthonormality of the eigenvectors.
-        Id = eye(test_size)
-        call check(error, maxval(abs(G - Id)) < rtol_sp)
+        call check(error, maxval(abs(G - eye(test_size))) < rtol_sp)
 
         return
     end subroutine test_sym_evp_rsp
@@ -425,18 +424,19 @@ contains
         ! Information flag.
         integer :: info
         ! Toeplitz matrix.
-        real(dp) :: T(test_size, test_size), a_, b_
+        real(dp), allocatable :: T(:, :)
+        real(dp) :: a_, b_
         ! Miscellaneous.
         integer :: i
         real(dp) :: alpha, true_evals(test_size)
         real(dp), parameter :: pi = 4.0_dp * atan(1.0_dp)
         type(vector_rdp), allocatable :: AX(:)
         complex(dp), allocatable :: eigvec_residuals(:,:)
-        real(dp), allocatable, dimension(:,:) :: G, Id
+        real(dp), allocatable, dimension(:,:) :: G
 
         ! Create the sym. pos. def. Toeplitz matrix.
         call random_number(a_) ; call random_number(b_) ; b_ = -abs(b_)
-        T = 0.0_dp
+        allocate(T(test_size, test_size)) ; T = 0.0_dp
         do i = 1, test_size
             ! Diagonal entry.
             T(i, i) = a_
@@ -477,13 +477,11 @@ contains
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the Krylov basis.
-        allocate(G(test_size, test_size)) ; allocate(Id(test_size, test_size))
-        G = zero_rdp
+        allocate(G(test_size, test_size)) ; G = zero_rdp
         call innerprod(G, X, X)
 
         ! Check orthonormality of the eigenvectors.
-        Id = eye(test_size)
-        call check(error, maxval(abs(G - Id)) < rtol_dp)
+        call check(error, maxval(abs(G - eye(test_size))) < rtol_dp)
 
         return
     end subroutine test_sym_evp_rdp
@@ -637,8 +635,8 @@ contains
         integer :: i, k, n
         real(sp) :: true_svdvals(test_size)
         real(sp) :: pi = 4.0_sp * atan(1.0_sp)
-        real(sp), dimension(test_size, test_size) :: G, Id
-        real(sp), dimension(test_size, test_size) :: Udata, Vdata
+        real(sp), allocatable :: G(:, :)
+        real(sp), allocatable :: Udata(:, :), Vdata(:, :)
 
         ! Allocate eigenvectors.
         allocate(U(test_size)) ; call zero_basis(U)
@@ -670,12 +668,11 @@ contains
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the Krylov basis of the left singular vectors.
-        G = zero_rsp
+        allocate(G(test_size, test_size)) ; G = zero_rsp
         call innerprod(G, U(1:test_size), U(1:test_size))
 
         ! Check orthonormality of the left singular vectors
-        Id = eye(test_size)
-        call check(error, maxval(abs(G - Id)) < rtol_sp)
+        call check(error, maxval(abs(G - eye(test_size))) < rtol_sp)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the Krylov basis of the right singular vectors.
@@ -683,12 +680,12 @@ contains
         call innerprod(G, V(1:test_size), V(1:test_size))
 
         ! Check orthonormality of the right singular vectors
-        call check(error, maxval(abs(G - Id)) < rtol_sp)
+        call check(error, maxval(abs(G - eye(test_size))) < rtol_sp)
         if (allocated(error)) return
 
         ! Check correctness of full factorization.
-        call get_data(Udata, U)
-        call get_data(Vdata, V)
+        allocate(Udata(test_size, test_size)) ; call get_data(Udata, U)
+        allocate(Vdata(test_size, test_size)) ; call get_data(Vdata, V)
         call check(error, maxval(abs(A%data - matmul(Udata, matmul(diag(s), transpose(Vdata))))) < rtol_sp)
 
         return
@@ -721,8 +718,8 @@ contains
         integer :: i, k, n
         real(dp) :: true_svdvals(test_size)
         real(dp) :: pi = 4.0_dp * atan(1.0_dp)
-        real(dp), dimension(test_size, test_size) :: G, Id
-        real(dp), dimension(test_size, test_size) :: Udata, Vdata
+        real(dp), allocatable :: G(:, :)
+        real(dp), allocatable :: Udata(:, :), Vdata(:, :)
 
         ! Allocate eigenvectors.
         allocate(U(test_size)) ; call zero_basis(U)
@@ -754,12 +751,11 @@ contains
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the Krylov basis of the left singular vectors.
-        G = zero_rdp
+        allocate(G(test_size, test_size)) ; G = zero_rdp
         call innerprod(G, U(1:test_size), U(1:test_size))
 
         ! Check orthonormality of the left singular vectors
-        Id = eye(test_size)
-        call check(error, maxval(abs(G - Id)) < rtol_dp)
+        call check(error, maxval(abs(G - eye(test_size))) < rtol_dp)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the Krylov basis of the right singular vectors.
@@ -767,12 +763,12 @@ contains
         call innerprod(G, V(1:test_size), V(1:test_size))
 
         ! Check orthonormality of the right singular vectors
-        call check(error, maxval(abs(G - Id)) < rtol_dp)
+        call check(error, maxval(abs(G - eye(test_size))) < rtol_dp)
         if (allocated(error)) return
 
         ! Check correctness of full factorization.
-        call get_data(Udata, U)
-        call get_data(Vdata, V)
+        allocate(Udata(test_size, test_size)) ; call get_data(Udata, U)
+        allocate(Vdata(test_size, test_size)) ; call get_data(Vdata, V)
         call check(error, maxval(abs(A%data - matmul(Udata, matmul(diag(s), transpose(Vdata))))) < rtol_dp)
 
         return
@@ -805,8 +801,8 @@ contains
         integer :: i, k, n
         real(sp) :: true_svdvals(test_size)
         real(sp) :: pi = 4.0_sp * atan(1.0_sp)
-        complex(sp), dimension(test_size, test_size) :: G, Id
-        complex(sp), dimension(test_size, test_size) :: Udata, Vdata
+        complex(sp), allocatable :: G(:, :)
+        complex(sp), allocatable :: Udata(:, :), Vdata(:, :)
 
         return
     end subroutine test_svd_csp
@@ -838,8 +834,8 @@ contains
         integer :: i, k, n
         real(dp) :: true_svdvals(test_size)
         real(dp) :: pi = 4.0_dp * atan(1.0_dp)
-        complex(dp), dimension(test_size, test_size) :: G, Id
-        complex(dp), dimension(test_size, test_size) :: Udata, Vdata
+        complex(dp), allocatable :: G(:, :)
+        complex(dp), allocatable :: Udata(:, :), Vdata(:, :)
 
         return
     end subroutine test_svd_cdp
@@ -1131,7 +1127,7 @@ contains
         type(vector_rsp), allocatable :: x
         type(cg_sp_opts) :: opts
         ! Information flag
-        integer :: info, i
+        integer :: info
 
         ! Initialize linear problem.
         A = spd_linop_rsp() ; call init_rand(A)
@@ -1166,7 +1162,7 @@ contains
         type(vector_rdp), allocatable :: x
         type(cg_dp_opts) :: opts
         ! Information flag
-        integer :: info, i
+        integer :: info
 
         ! Initialize linear problem.
         A = spd_linop_rdp() ; call init_rand(A)
@@ -1201,7 +1197,7 @@ contains
         type(vector_csp), allocatable :: x
         type(cg_sp_opts) :: opts
         ! Information flag
-        integer :: info, i
+        integer :: info
 
         ! Initialize linear problem.
         A = hermitian_linop_csp() ; call init_rand(A)
@@ -1236,7 +1232,7 @@ contains
         type(vector_cdp), allocatable :: x
         type(cg_dp_opts) :: opts
         ! Information flag
-        integer :: info, i
+        integer :: info
 
         ! Initialize linear problem.
         A = hermitian_linop_cdp() ; call init_rand(A)

--- a/test/TestIterativeSolvers.f90
+++ b/test/TestIterativeSolvers.f90
@@ -112,7 +112,7 @@ contains
 
         ! check eigenvalues
         call check(error, maxval(abs(eigvals - true_eigvals(:nev))) < rtol_sp)
-        !if (allocated(error)) return
+        !call check_test(error, 'test_ks_evp_rsp', 'The computed eigenvalues are not exact.')
         !! check eigenvectors
         !allocate(AX(nev))
         !allocate(eigvec_residuals(test_size, nev))
@@ -249,7 +249,7 @@ contains
 
         ! Check error.
         call check(error, maxval(abs(true_evals - evals)) < rtol_sp)
-        if (allocated(error)) return
+        call check_test(error, 'test_sym_evp_rsp', 'The computed eigenvalues E are not exact.')
 
         ! check eigenvectors
         allocate(AX(test_size))
@@ -268,6 +268,7 @@ contains
 
         ! Check orthonormality of the eigenvectors.
         call check(error, maxval(abs(G - eye(test_size))) < rtol_sp)
+        call check_test(error, 'test_sym_evp_rsp', 'The eigenvector basis X is not orthonormal: V.H @ V /= I')
 
         return
     end subroutine test_sym_evp_rsp
@@ -336,7 +337,7 @@ contains
 
         ! check eigenvalues
         call check(error, maxval(abs(eigvals - true_eigvals(:nev))) < rtol_dp)
-        !if (allocated(error)) return
+        !call check_test(error, 'test_ks_evp_rdp', 'The computed eigenvalues are not exact.')
         !! check eigenvectors
         !allocate(AX(nev))
         !allocate(eigvec_residuals(test_size, nev))
@@ -413,6 +414,8 @@ contains
 !            eigvec_residuals(:, i) = AX(i)%data - eigvals(i)*X(i)%data
 !        end do
 !        call check(error, norm2(abs(eigvec_residuals)) < rtol_dp)
+!        call check_test(error, 'test_evp_rdp', &
+!                                 & 'The computed eigenvalue/eigenvector pairs (E,V) are not correct: A @ V /= diag(E) @ V')
 
         return
     end subroutine test_evp_rdp
@@ -471,7 +474,7 @@ contains
 
         ! Check error.
         call check(error, maxval(abs(true_evals - evals)) < rtol_dp)
-        if (allocated(error)) return
+        call check_test(error, 'test_sym_evp_rdp', 'The computed eigenvalues E are not exact.')
 
         ! check eigenvectors
         allocate(AX(test_size))
@@ -490,6 +493,7 @@ contains
 
         ! Check orthonormality of the eigenvectors.
         call check(error, maxval(abs(G - eye(test_size))) < rtol_dp)
+        call check_test(error, 'test_sym_evp_rdp', 'The eigenvector basis X is not orthonormal: V.H @ V /= I')
 
         return
     end subroutine test_sym_evp_rdp
@@ -673,7 +677,7 @@ contains
         enddo
 
         call check(error, maxval(s - true_svdvals) < rtol_sp)
-        if (allocated(error)) return
+        call check_test(error, 'test_svd_rsp', 'The computed singular values S are not exact.')
 
         ! Compute Gram matrix associated to the Krylov basis of the left singular vectors.
         allocate(G(test_size, test_size)) ; G = zero_rsp
@@ -681,7 +685,7 @@ contains
 
         ! Check orthonormality of the left singular vectors
         call check(error, maxval(abs(G - eye(test_size))) < rtol_sp)
-        if (allocated(error)) return
+        call check_test(error, 'test_svd_rsp', 'The left singular vector basis U is not orthonormal: U.H @ U /= I')
 
         ! Compute Gram matrix associated to the Krylov basis of the right singular vectors.
         G = zero_rsp
@@ -689,7 +693,7 @@ contains
 
         ! Check orthonormality of the right singular vectors
         call check(error, maxval(abs(G - eye(test_size))) < rtol_sp)
-        if (allocated(error)) return
+        call check_test(error, 'test_svd_rsp', 'The right singular vector basis V is not orthonormal: V.H @ V /= I')
 
         ! Check correctness of full factorization.
         allocate(Udata(test_size, test_size)) ; call get_data(Udata, U)
@@ -757,7 +761,7 @@ contains
         enddo
 
         call check(error, maxval(s - true_svdvals) < rtol_dp)
-        if (allocated(error)) return
+        call check_test(error, 'test_svd_rdp', 'The computed singular values S are not exact.')
 
         ! Compute Gram matrix associated to the Krylov basis of the left singular vectors.
         allocate(G(test_size, test_size)) ; G = zero_rdp
@@ -765,7 +769,7 @@ contains
 
         ! Check orthonormality of the left singular vectors
         call check(error, maxval(abs(G - eye(test_size))) < rtol_dp)
-        if (allocated(error)) return
+        call check_test(error, 'test_svd_rdp', 'The left singular vector basis U is not orthonormal: U.H @ U /= I')
 
         ! Compute Gram matrix associated to the Krylov basis of the right singular vectors.
         G = zero_rdp
@@ -773,7 +777,7 @@ contains
 
         ! Check orthonormality of the right singular vectors
         call check(error, maxval(abs(G - eye(test_size))) < rtol_dp)
-        if (allocated(error)) return
+        call check_test(error, 'test_svd_rdp', 'The right singular vector basis V is not orthonormal: V.H @ V /= I')
 
         ! Check correctness of full factorization.
         allocate(Udata(test_size, test_size)) ; call get_data(Udata, U)

--- a/test/TestIterativeSolvers.f90
+++ b/test/TestIterativeSolvers.f90
@@ -1268,7 +1268,7 @@ contains
         x = vector_rsp() ; call x%zero()
 
         ! CG solver.
-        opts = cg_sp_opts(rtol=rtol_sp, atol=atol_sp)
+        opts = cg_sp_opts(rtol=rtol_sp, atol=atol_sp, maxiter=2*test_size)
         call cg(A, b, x, info, options=opts)
         call check_info(info, 'cg', module=this_module, procedure='test_cg_rsp')
 
@@ -1309,7 +1309,7 @@ contains
         x = vector_rdp() ; call x%zero()
 
         ! CG solver.
-        opts = cg_dp_opts(rtol=rtol_dp, atol=atol_dp)
+        opts = cg_dp_opts(rtol=rtol_dp, atol=atol_dp, maxiter=2*test_size)
         call cg(A, b, x, info, options=opts)
         call check_info(info, 'cg', module=this_module, procedure='test_cg_rdp')
 
@@ -1350,7 +1350,7 @@ contains
         x = vector_csp() ; call x%zero()
 
         ! CG solver.
-        opts = cg_sp_opts(rtol=rtol_sp, atol=atol_sp)
+        opts = cg_sp_opts(rtol=rtol_sp, atol=atol_sp, maxiter=2*test_size)
         call cg(A, b, x, info, options=opts)
         call check_info(info, 'cg', module=this_module, procedure='test_cg_csp')
 
@@ -1391,7 +1391,7 @@ contains
         x = vector_cdp() ; call x%zero()
 
         ! CG solver.
-        opts = cg_dp_opts(rtol=rtol_dp, atol=atol_dp)
+        opts = cg_dp_opts(rtol=rtol_dp, atol=atol_dp, maxiter=2*test_size)
         call cg(A, b, x, info, options=opts)
         call check_info(info, 'cg', module=this_module, procedure='test_cg_cdp')
 

--- a/test/TestIterativeSolvers.fypp
+++ b/test/TestIterativeSolvers.fypp
@@ -25,7 +25,7 @@ module TestIterativeSolvers
     
     private
 
-    character*128, parameter, private :: this_module = 'LightKrylov_TestIterativeSolvers'
+    character(len=128), parameter, private :: this_module = 'LightKrylov_TestIterativeSolvers'
 
     #:for kind, type in RC_KINDS_TYPES
     public :: collect_eig_${type[0]}$${kind}$_testsuite
@@ -205,18 +205,19 @@ contains
         ! Information flag.
         integer :: info
         ! Toeplitz matrix.
-        ${type}$ :: T(test_size, test_size), a_, b_
+        ${type}$, allocatable :: T(:, :)
+        ${type}$ :: a_, b_
         ! Miscellaneous.
         integer :: i
         ${type}$ :: alpha, true_evals(test_size)
         ${type}$, parameter :: pi = 4.0_${kind}$ * atan(1.0_${kind}$)
         type(vector_${type[0]}$${kind}$), allocatable :: AX(:)
         complex(${kind}$), allocatable :: eigvec_residuals(:,:)
-        ${type}$, allocatable, dimension(:,:) :: G, Id
+        ${type}$, allocatable, dimension(:,:) :: G
 
         ! Create the sym. pos. def. Toeplitz matrix.
         call random_number(a_) ; call random_number(b_) ; b_ = -abs(b_)
-        T = 0.0_${kind}$
+        allocate(T(test_size, test_size)) ; T = 0.0_${kind}$
         do i = 1, test_size
             ! Diagonal entry.
             T(i, i) = a_
@@ -257,13 +258,11 @@ contains
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the Krylov basis.
-        allocate(G(test_size, test_size)) ; allocate(Id(test_size, test_size))
-        G = zero_${type[0]}$${kind}$
+        allocate(G(test_size, test_size)) ; G = zero_${type[0]}$${kind}$
         call innerprod(G, X, X)
 
         ! Check orthonormality of the eigenvectors.
-        Id = eye(test_size)
-        call check(error, maxval(abs(G - Id)) < rtol_${kind}$)
+        call check(error, maxval(abs(G - eye(test_size))) < rtol_${kind}$)
 
         return
     end subroutine test_sym_evp_${type[0]}$${kind}$
@@ -303,8 +302,8 @@ contains
         integer :: i, k, n
         real(${kind}$) :: true_svdvals(test_size)
         real(${kind}$) :: pi = 4.0_${kind}$ * atan(1.0_${kind}$)
-        ${type}$, dimension(test_size, test_size) :: G, Id
-        ${type}$, dimension(test_size, test_size) :: Udata, Vdata
+        ${type}$, allocatable :: G(:, :)
+        ${type}$, allocatable :: Udata(:, :), Vdata(:, :)
         #:if type[0] == "r"
 
         ! Allocate eigenvectors.
@@ -337,12 +336,11 @@ contains
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the Krylov basis of the left singular vectors.
-        G = zero_${type[0]}$${kind}$
+        allocate(G(test_size, test_size)) ; G = zero_${type[0]}$${kind}$
         call innerprod(G, U(1:test_size), U(1:test_size))
 
         ! Check orthonormality of the left singular vectors
-        Id = eye(test_size)
-        call check(error, maxval(abs(G - Id)) < rtol_${kind}$)
+        call check(error, maxval(abs(G - eye(test_size))) < rtol_${kind}$)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the Krylov basis of the right singular vectors.
@@ -350,12 +348,12 @@ contains
         call innerprod(G, V(1:test_size), V(1:test_size))
 
         ! Check orthonormality of the right singular vectors
-        call check(error, maxval(abs(G - Id)) < rtol_${kind}$)
+        call check(error, maxval(abs(G - eye(test_size))) < rtol_${kind}$)
         if (allocated(error)) return
 
         ! Check correctness of full factorization.
-        call get_data(Udata, U)
-        call get_data(Vdata, V)
+        allocate(Udata(test_size, test_size)) ; call get_data(Udata, U)
+        allocate(Vdata(test_size, test_size)) ; call get_data(Vdata, V)
         call check(error, maxval(abs(A%data - matmul(Udata, matmul(diag(s), transpose(Vdata))))) < rtol_${kind}$)
         #:endif
 
@@ -470,7 +468,7 @@ contains
         type(vector_${type[0]}$${kind}$), allocatable :: x
         type(cg_${kind}$_opts) :: opts
         ! Information flag
-        integer :: info, i
+        integer :: info
 
         ! Initialize linear problem.
         #:if type[0] == "r"

--- a/test/TestIterativeSolvers.fypp
+++ b/test/TestIterativeSolvers.fypp
@@ -45,11 +45,11 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
          testsuite = [ &
-                    new_unittest("Eigs computation (eigvals & eigvecs)", test_evp_${type[0]}$${kind}$), &
+                    new_unittest("Eigs computation", test_evp_${type[0]}$${kind}$), &
                     #:if type[0] == "r"
-                    new_unittest("Sym. eigs computation (eigvals, eigvecs & eigvec orthonormality)", test_sym_evp_${type[0]}$${kind}$), &
+                    new_unittest("Sym. eigs computation", test_sym_evp_${type[0]}$${kind}$), &
                     #:endif
-                    new_unittest("KS eigs computation (eigvals & eigvecs)", test_ks_evp_${type[0]}$${kind}$) &
+                    new_unittest("KS eigs computation", test_ks_evp_${type[0]}$${kind}$) &
                     ]
         return
     end subroutine collect_eig_${type[0]}$${kind}$_testsuite
@@ -61,7 +61,7 @@ contains
         type(linop_${type[0]}$${kind}$), allocatable :: A
         ! Eigenvectors.
         type(vector_${type[0]}$${kind}$), allocatable :: X(:)
-        ! Eigenvalues.
+        ! evals.
         complex(${kind}$), allocatable :: eigvals(:)
         ! Residuals.
         real(${kind}$), allocatable :: residuals(:)
@@ -74,6 +74,8 @@ contains
         complex(${kind}$), allocatable :: eigvec_residuals(:,:)
         complex(${kind}$) :: true_eigvals(test_size)
         real(${kind}$) :: pi = 4.0_${kind}$ * atan(1.0_${kind}$)
+        real(${kind}$) :: err
+        character*256 :: msg
         #:if type[0] == "r"
         ${type}$ :: a_, b_
 
@@ -107,8 +109,10 @@ contains
         enddo
 
         ! check eigenvalues
-        call check(error, maxval(abs(eigvals - true_eigvals(:nev))) < rtol_${kind}$)
-        !call check_test(error, 'test_ks_evp_${type[0]}$${kind}$', 'The computed eigenvalues are not exact.')
+        err = maxval(abs(eigvals - true_eigvals(:nev)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_${kind}$)
+        call check_test(error, 'test_ks_evp_${type[0]}$${kind}$', info='eval correctness.', context=msg)
         !! check eigenvectors
         !allocate(AX(nev))
         !allocate(eigvec_residuals(test_size, nev))
@@ -116,10 +120,11 @@ contains
         !    call A%matvec(X(i), AX(i))
         !    eigvec_residuals(:, i) = AX(i)%data - eigvals(i)*X(i)%data
         !end do
-        !print *, norm2(abs(eigvec_residuals))
-        !call check(error, norm2(abs(eigvec_residuals)) < rtol_${kind}$)
-        call check_test(error, 'test_ks_evp_${type[0]}$${kind}$', & 
-                              & 'The computed eigenvalue/eigenvector pairs (E,V) are not correct: A @ V /= diag(E) @ V')
+        !err = norm2(abs(eigvec_residuals))
+        !call get_err_str(msg, "max err: ", err)
+        !call check(error, err < rtol_${kind}$)
+        !call check_test(error, 'test_ks_evp_${type[0]}$${kind}$', & 
+        !                      & info='evec/eval correctness', eq='A @ V = diag(E) @ V', context=msg)
         #:endif
 
         return
@@ -132,7 +137,7 @@ contains
         type(linop_${type[0]}$${kind}$), allocatable :: A
         ! Eigenvectors.
         type(vector_${type[0]}$${kind}$), allocatable :: X(:)
-        ! Eigenvalues.
+        ! evals.
         complex(${kind}$), allocatable :: eigvals(:)
         ! Residuals.
         real(${kind}$), allocatable :: residuals(:)
@@ -144,6 +149,8 @@ contains
         complex(${kind}$), allocatable :: eigvec_residuals(:,:)
         complex(${kind}$) :: true_eigvals(test_size)
         real(${kind}$) :: pi = 4.0_${kind}$ * atan(1.0_${kind}$)
+        real(${kind}$) :: err
+        character*256 :: msg
         #:if type[0] == "r"
         ${type}$ :: a_, b_
 
@@ -176,9 +183,11 @@ contains
             k = k+1
         enddo
 
-        call check(error, maxval(abs(eigvals - true_eigvals)) < rtol_${kind}$)
-!        if (allocated(error)) return
-!
+        err = maxval(abs(eigvals - true_eigvals))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_${kind}$)
+        call check_test(error, 'test_evp_${type[0]}$${kind}$', info='eval correctness', context=msg)
+
 !        ! check eigenvectors
 !        allocate(AX(test_size))
 !        allocate(eigvec_residuals(test_size, test_size)); eigvec_residuals = zero_c${kind}$
@@ -186,9 +195,11 @@ contains
 !            call A%matvec(X(i), AX(i))
 !            eigvec_residuals(:, i) = AX(i)%data - eigvals(i)*X(i)%data
 !        end do
-!        call check(error, norm2(abs(eigvec_residuals)) < rtol_${kind}$)
+!        err = norm2(abs(eigvec_residuals))
+!        call get_err_str(msg, "max err: ", err)
+!        call check(error, err < rtol_${kind}$)
 !        call check_test(error, 'test_evp_${type[0]}$${kind}$', &
-!                                 & 'The computed eigenvalue/eigenvector pairs (E,V) are not correct: A @ V /= diag(E) @ V')
+!                                 & info='evec/eval correctness', eq='A @ V = diag(E) @ V', context=msg)
         #:endif
 
         return
@@ -202,7 +213,7 @@ contains
         type(spd_linop_${type[0]}$${kind}$), allocatable :: A
         ! Eigenvectors.
         type(vector_${type[0]}$${kind}$), allocatable :: X(:)
-        ! Eigenvalues.
+        ! evals.
         ${type}$, allocatable :: evals(:)
         ! Residuals.
         ${type}$, allocatable :: residuals(:)
@@ -218,6 +229,8 @@ contains
         type(vector_${type[0]}$${kind}$), allocatable :: AX(:)
         complex(${kind}$), allocatable :: eigvec_residuals(:,:)
         ${type}$, allocatable, dimension(:,:) :: G
+        real(${kind}$) :: err
+        character*256 :: msg
 
         ! Create the sym. pos. def. Toeplitz matrix.
         call random_number(a_) ; call random_number(b_) ; b_ = -abs(b_)
@@ -248,8 +261,10 @@ contains
         enddo
 
         ! Check error.
-        call check(error, maxval(abs(true_evals - evals)) < rtol_${kind}$)
-        call check_test(error, 'test_sym_evp_${type[0]}$${kind}$', 'The computed eigenvalues E are not exact.')
+        err = maxval(abs(true_evals - evals))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_${kind}$)
+        call check_test(error, 'test_sym_evp_${type[0]}$${kind}$', info='eval correctness', context=msg)
 
         ! check eigenvectors
         allocate(AX(test_size))
@@ -258,16 +273,20 @@ contains
             call A%matvec(X(i), AX(i))
             eigvec_residuals(:, i) = AX(i)%data - evals(i)*X(i)%data
         end do
-        call check(error, norm2(abs(eigvec_residuals)) < rtol_${kind}$)
-        call check_test(error, 'test_sym_evp_${type[0]}$${kind}$', 'The computed eigenvalue/eigenvector pairs (E,V) are not correct: A @ V /= diag(E) @ V')
+        err = norm2(abs(eigvec_residuals))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_${kind}$)
+        call check_test(error, 'test_sym_evp_${type[0]}$${kind}$', info='evec/eval correctness', eq='A @ V = diag(E) @ V', context=msg)
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(test_size, test_size)) ; G = zero_${type[0]}$${kind}$
         call innerprod(G, X, X)
 
         ! Check orthonormality of the eigenvectors.
-        call check(error, maxval(abs(G - eye(test_size))) < rtol_${kind}$)
-        call check_test(error, 'test_sym_evp_${type[0]}$${kind}$', 'The eigenvector basis X is not orthonormal: V.H @ V /= I')
+        err = maxval(abs(G - eye(test_size)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_${kind}$)
+        call check_test(error, 'test_sym_evp_${type[0]}$${kind}$', info='Eigenvector orthonormality', eq='V.H @ V = I', context=msg)
 
         return
     end subroutine test_sym_evp_${type[0]}$${kind}$
@@ -285,7 +304,7 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-                    new_unittest("SVDS computation (factorization correctness, singular values, left/right orthonormality)", test_svd_${type[0]}$${kind}$) &
+                    new_unittest("SVDS computation", test_svd_${type[0]}$${kind}$) &
                     ]
         return
     end subroutine collect_svd_${type[0]}$${kind}$_testsuite
@@ -309,6 +328,8 @@ contains
         real(${kind}$) :: pi = 4.0_${kind}$ * atan(1.0_${kind}$)
         ${type}$, allocatable :: G(:, :)
         ${type}$, allocatable :: Udata(:, :), Vdata(:, :)
+        real(${kind}$) :: err
+        character*256 :: msg
         #:if type[0] == "r"
 
         ! Allocate eigenvectors.
@@ -337,30 +358,40 @@ contains
             true_svdvals(i) = 2.0_${kind}$ * (1.0_${kind}$ + cos(i*pi/(test_size+1)))
         enddo
 
-        call check(error, maxval(s - true_svdvals) < rtol_${kind}$)
-        call check_test(error, 'test_svd_${type[0]}$${kind}$', 'The computed singular values S are not exact.')
+        ! Check correctness of full factorization.
+        allocate(Udata(test_size, test_size)) ; call get_data(Udata, U)
+        allocate(Vdata(test_size, test_size)) ; call get_data(Vdata, V)
+        err = maxval(abs(A%data - matmul(Udata, matmul(diag(s), transpose(Vdata)))))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_${kind}$)
+        call check_test(error, 'test_svd_${type[0]}$${kind}$', info='Factorization', eq='A = U @ S @ V.H', context=msg)
+
+        err = maxval(abs(A%data - matmul(Udata, matmul(diag(s), transpose(Vdata)))))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_${kind}$)
+        call check_test(error, 'test_svd_${type[0]}$${kind}$', 'Singular values', context=msg)
 
         ! Compute Gram matrix associated to the Krylov basis of the left singular vectors.
         allocate(G(test_size, test_size)) ; G = zero_${type[0]}$${kind}$
         call innerprod(G, U(1:test_size), U(1:test_size))
 
         ! Check orthonormality of the left singular vectors
-        call check(error, maxval(abs(G - eye(test_size))) < rtol_${kind}$)
-        call check_test(error, 'test_svd_${type[0]}$${kind}$', 'The left singular vector basis U is not orthonormal: U.H @ U /= I')
+        err = maxval(abs(G - eye(test_size)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_${kind}$)
+        call check_test(error, 'test_svd_${type[0]}$${kind}$', info='svec orthonormality (left)', eq='U.H @ U = I', context=msg)
 
         ! Compute Gram matrix associated to the Krylov basis of the right singular vectors.
         G = zero_${type[0]}$${kind}$
         call innerprod(G, V(1:test_size), V(1:test_size))
 
         ! Check orthonormality of the right singular vectors
-        call check(error, maxval(abs(G - eye(test_size))) < rtol_${kind}$)
-        call check_test(error, 'test_svd_${type[0]}$${kind}$', 'The right singular vector basis V is not orthonormal: V.H @ V /= I')
+        err = maxval(abs(G - eye(test_size)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_${kind}$)
+        call check_test(error, 'test_svd_${type[0]}$${kind}$', info='svec orthonormality (right)', eq='V.H @ V /= I', context=msg)
 
-        ! Check correctness of full factorization.
-        allocate(Udata(test_size, test_size)) ; call get_data(Udata, U)
-        allocate(Vdata(test_size, test_size)) ; call get_data(Vdata, V)
-        call check(error, maxval(abs(A%data - matmul(Udata, matmul(diag(s), transpose(Vdata))))) < rtol_${kind}$)
-        call check_test(error, 'test_svd_${type[0]}$${kind}$', 'The factorization is not correct: A /= U @ S @ V.H')
+        
         #:endif
 
         return
@@ -393,6 +424,9 @@ contains
         type(gmres_${kind}$_opts) :: opts
         ! Information flag.
         integer :: info
+        ! Misc
+        real(${kind}$) :: err
+        character*256 :: msg
 
         ! Initialize linear problem.
         A = linop_${type[0]}$${kind}$()  ; call init_rand(A)
@@ -405,8 +439,10 @@ contains
         call check_info(info, 'gmres', module=this_module, procedure='test_gmres_${type[0]}$${kind}$')
 
         ! Check convergence.
-        call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_${kind}$)
-        call check_test(error, 'test_gmres_${type[0]}$${kind}$', 'The computed solution is not correct: A @ x /= b')
+        err = norm2(abs(matmul(A%data, x%data) - b%data))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < b%norm() * rtol_${kind}$)
+        call check_test(error, 'test_gmres_${type[0]}$${kind}$', eq='A @ x = b', context=msg)
 
         return
     end subroutine test_gmres_${type[0]}$${kind}$
@@ -426,6 +462,9 @@ contains
         type(gmres_${kind}$_opts) :: opts
         ! Information flag.
         integer :: info
+        ! Misc
+        real(${kind}$) :: err
+        character*256 :: msg
 
         ! Initialize linear problem.
         #:if type[0] == "r"
@@ -442,8 +481,10 @@ contains
         call check_info(info, 'gmres', module=this_module, procedure='test_gmres_spd_${type[0]}$${kind}$')
 
         ! Check convergence.
-        call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_${kind}$)
-        call check_test(error, 'test_gmres_spd_${type[0]}$${kind}$', 'The computed solution is not correct: A @ x /= b')
+        err = norm2(abs(matmul(A%data, x%data) - b%data))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < b%norm() * rtol_${kind}$)
+        call check_test(error, 'test_gmres_spd_${type[0]}$${kind}$', eq='A @ x = b', context=msg)
 
         return
     end subroutine test_gmres_spd_${type[0]}$${kind}$
@@ -477,6 +518,9 @@ contains
         type(cg_${kind}$_opts) :: opts
         ! Information flag
         integer :: info
+        ! Misc
+        real(${kind}$) :: err
+        character*256 :: msg
 
         ! Initialize linear problem.
         #:if type[0] == "r"
@@ -493,8 +537,10 @@ contains
         call check_info(info, 'cg', module=this_module, procedure='test_cg_${type[0]}$${kind}$')
 
         ! Check convergence.
-        call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_${kind}$)
-        call check_test(error, 'test_cg_${type[0]}$${kind}$', 'The computed solution is not correct: A @ x /= b')
+        err = norm2(abs(matmul(A%data, x%data) - b%data))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < b%norm() * rtol_${kind}$)
+        call check_test(error, 'test_cg_${type[0]}$${kind}$', eq='A @ x = b', context=msg)
 
         return
     end subroutine test_cg_${type[0]}$${kind}$

--- a/test/TestIterativeSolvers.fypp
+++ b/test/TestIterativeSolvers.fypp
@@ -108,7 +108,7 @@ contains
 
         ! check eigenvalues
         call check(error, maxval(abs(eigvals - true_eigvals(:nev))) < rtol_${kind}$)
-        !if (allocated(error)) return
+        !call check_test(error, 'test_ks_evp_${type[0]}$${kind}$', 'The computed eigenvalues are not exact.')
         !! check eigenvectors
         !allocate(AX(nev))
         !allocate(eigvec_residuals(test_size, nev))
@@ -118,6 +118,8 @@ contains
         !end do
         !print *, norm2(abs(eigvec_residuals))
         !call check(error, norm2(abs(eigvec_residuals)) < rtol_${kind}$)
+        call check_test(error, 'test_ks_evp_${type[0]}$${kind}$', & 
+                              & 'The computed eigenvalue/eigenvector pairs (E,V) are not correct: A @ V /= diag(E) @ V')
         #:endif
 
         return
@@ -185,6 +187,8 @@ contains
 !            eigvec_residuals(:, i) = AX(i)%data - eigvals(i)*X(i)%data
 !        end do
 !        call check(error, norm2(abs(eigvec_residuals)) < rtol_${kind}$)
+!        call check_test(error, 'test_evp_${type[0]}$${kind}$', &
+!                                 & 'The computed eigenvalue/eigenvector pairs (E,V) are not correct: A @ V /= diag(E) @ V')
         #:endif
 
         return
@@ -245,7 +249,7 @@ contains
 
         ! Check error.
         call check(error, maxval(abs(true_evals - evals)) < rtol_${kind}$)
-        if (allocated(error)) return
+        call check_test(error, 'test_sym_evp_${type[0]}$${kind}$', 'The computed eigenvalues E are not exact.')
 
         ! check eigenvectors
         allocate(AX(test_size))
@@ -255,14 +259,16 @@ contains
             eigvec_residuals(:, i) = AX(i)%data - evals(i)*X(i)%data
         end do
         call check(error, norm2(abs(eigvec_residuals)) < rtol_${kind}$)
-        if (allocated(error)) return
+        call check_test(error, 'test_sym_evp_${type[0]}$${kind}$', 'The computed eigenvalue/eigenvector pairs (E,V) are not correct: A @ V /= diag(E) @ V')
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(test_size, test_size)) ; G = zero_${type[0]}$${kind}$
         call innerprod(G, X, X)
 
         ! Check orthonormality of the eigenvectors.
-        call check(error, maxval(abs(G - eye(test_size))) < rtol_${kind}$)
+        Id = eye(test_size)
+        call check(error, maxval(abs(G - Id)) < rtol_${kind}$)
+        call check_test(error, 'test_sym_evp_${type[0]}$${kind}$', 'The eigenvector basis X is not orthonormal: V.H @ V /= I')
 
         return
     end subroutine test_sym_evp_${type[0]}$${kind}$
@@ -333,28 +339,30 @@ contains
         enddo
 
         call check(error, maxval(s - true_svdvals) < rtol_${kind}$)
-        if (allocated(error)) return
+        call check_test(error, 'test_svd_${type[0]}$${kind}$', 'The computed singular values S are not exact.')
 
         ! Compute Gram matrix associated to the Krylov basis of the left singular vectors.
         allocate(G(test_size, test_size)) ; G = zero_${type[0]}$${kind}$
         call innerprod(G, U(1:test_size), U(1:test_size))
 
         ! Check orthonormality of the left singular vectors
-        call check(error, maxval(abs(G - eye(test_size))) < rtol_${kind}$)
-        if (allocated(error)) return
+        Id = eye(test_size)
+        call check(error, maxval(abs(G - Id)) < rtol_${kind}$)
+        call check_test(error, 'test_svd_${type[0]}$${kind}$', 'The left singular vector basis U is not orthonormal: U.H @ U /= I')
 
         ! Compute Gram matrix associated to the Krylov basis of the right singular vectors.
         G = zero_${type[0]}$${kind}$
         call innerprod(G, V(1:test_size), V(1:test_size))
 
         ! Check orthonormality of the right singular vectors
-        call check(error, maxval(abs(G - eye(test_size))) < rtol_${kind}$)
-        if (allocated(error)) return
+        call check(error, maxval(abs(G - Id)) < rtol_${kind}$)
+        call check_test(error, 'test_svd_${type[0]}$${kind}$', 'The right singular vector basis V is not orthonormal: V.H @ V /= I')
 
         ! Check correctness of full factorization.
         allocate(Udata(test_size, test_size)) ; call get_data(Udata, U)
         allocate(Vdata(test_size, test_size)) ; call get_data(Vdata, V)
         call check(error, maxval(abs(A%data - matmul(Udata, matmul(diag(s), transpose(Vdata))))) < rtol_${kind}$)
+        call check_test(error, 'test_svd_${type[0]}$${kind}$', 'The factorization is not correct: A /= U @ S @ V.H')
         #:endif
 
         return
@@ -400,6 +408,7 @@ contains
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_${kind}$)
+        call check_test(error, 'test_gmres_${type[0]}$${kind}$', 'The computed solution is not correct: A @ x /= b')
 
         return
     end subroutine test_gmres_${type[0]}$${kind}$
@@ -436,6 +445,7 @@ contains
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_${kind}$)
+        call check_test(error, 'test_gmres_spd_${type[0]}$${kind}$', 'The computed solution is not correct: A @ x /= b')
 
         return
     end subroutine test_gmres_spd_${type[0]}$${kind}$
@@ -486,6 +496,7 @@ contains
 
         ! Check convergence.
         call check(error, norm2(abs(matmul(A%data, x%data) - b%data)) < b%norm() * rtol_${kind}$)
+        call check_test(error, 'test_cg_${type[0]}$${kind}$', 'The computed solution is not correct: A @ x /= b')
 
         return
     end subroutine test_cg_${type[0]}$${kind}$

--- a/test/TestIterativeSolvers.fypp
+++ b/test/TestIterativeSolvers.fypp
@@ -266,8 +266,7 @@ contains
         call innerprod(G, X, X)
 
         ! Check orthonormality of the eigenvectors.
-        Id = eye(test_size)
-        call check(error, maxval(abs(G - Id)) < rtol_${kind}$)
+        call check(error, maxval(abs(G - eye(test_size))) < rtol_${kind}$)
         call check_test(error, 'test_sym_evp_${type[0]}$${kind}$', 'The eigenvector basis X is not orthonormal: V.H @ V /= I')
 
         return
@@ -346,8 +345,7 @@ contains
         call innerprod(G, U(1:test_size), U(1:test_size))
 
         ! Check orthonormality of the left singular vectors
-        Id = eye(test_size)
-        call check(error, maxval(abs(G - Id)) < rtol_${kind}$)
+        call check(error, maxval(abs(G - eye(test_size))) < rtol_${kind}$)
         call check_test(error, 'test_svd_${type[0]}$${kind}$', 'The left singular vector basis U is not orthonormal: U.H @ U /= I')
 
         ! Compute Gram matrix associated to the Krylov basis of the right singular vectors.
@@ -355,7 +353,7 @@ contains
         call innerprod(G, V(1:test_size), V(1:test_size))
 
         ! Check orthonormality of the right singular vectors
-        call check(error, maxval(abs(G - Id)) < rtol_${kind}$)
+        call check(error, maxval(abs(G - eye(test_size))) < rtol_${kind}$)
         call check_test(error, 'test_svd_${type[0]}$${kind}$', 'The right singular vector basis V is not orthonormal: V.H @ V /= I')
 
         ! Check correctness of full factorization.

--- a/test/TestIterativeSolvers.fypp
+++ b/test/TestIterativeSolvers.fypp
@@ -532,7 +532,7 @@ contains
         x = vector_${type[0]}$${kind}$() ; call x%zero()
 
         ! CG solver.
-        opts = cg_${kind}$_opts(rtol=rtol_${kind}$, atol=atol_${kind}$)
+        opts = cg_${kind}$_opts(rtol=rtol_${kind}$, atol=atol_${kind}$, maxiter=2*test_size)
         call cg(A, b, x, info, options=opts)
         call check_info(info, 'cg', module=this_module, procedure='test_cg_${type[0]}$${kind}$')
 

--- a/test/TestKrylov.f90
+++ b/test/TestKrylov.f90
@@ -99,7 +99,6 @@ contains
 
         ! Check orthonormality of the computed basis.
         call check(error, norm2(abs(G - eye(kdim))) < rtol_sp)
-        call check(error, norm2(abs(G - Id)) < rtol_sp)
         call check_test(error, 'test_qr_factorization_rsp', &
                         & 'Basis Q not orthonormal: Q.H @ Q /= I')
 
@@ -169,6 +168,8 @@ contains
 
         ! Check orthonormality of the computed basis.
         call check(error, norm2(abs(G - eye(kdim))) < rtol_sp)
+        call check_test(error, 'test_pivoting_qr_exact_rank_deficiency_rsp', &
+                        & 'Basis Q not orthonormal: Q.H @ Q /= I')
 
         return
     end subroutine test_pivoting_qr_exact_rank_deficiency_rsp
@@ -222,6 +223,8 @@ contains
 
         ! Check orthonormality of the computed basis.
         call check(error, norm2(abs(G - eye(kdim))) < rtol_dp)
+        call check_test(error, 'test_qr_factorization_rdp', &
+                        & 'Basis Q not orthonormal: Q.H @ Q /= I')
 
         return
     end subroutine test_qr_factorization_rdp
@@ -289,6 +292,8 @@ contains
 
         ! Check orthonormality of the computed basis.
         call check(error, norm2(abs(G - eye(kdim))) < rtol_dp)
+        call check_test(error, 'test_pivoting_qr_exact_rank_deficiency_rdp', &
+                        & 'Basis Q not orthonormal: Q.H @ Q /= I')
 
         return
     end subroutine test_pivoting_qr_exact_rank_deficiency_rdp
@@ -342,6 +347,8 @@ contains
 
         ! Check orthonormality of the computed basis.
         call check(error, norm2(abs(G - eye(kdim))) < rtol_sp)
+        call check_test(error, 'test_qr_factorization_csp', &
+                        & 'Basis Q not orthonormal: Q.H @ Q /= I')
 
         return
     end subroutine test_qr_factorization_csp
@@ -409,6 +416,8 @@ contains
 
         ! Check orthonormality of the computed basis.
         call check(error, norm2(abs(G - eye(kdim))) < rtol_sp)
+        call check_test(error, 'test_pivoting_qr_exact_rank_deficiency_csp', &
+                        & 'Basis Q not orthonormal: Q.H @ Q /= I')
 
         return
     end subroutine test_pivoting_qr_exact_rank_deficiency_csp
@@ -462,6 +471,8 @@ contains
 
         ! Check orthonormality of the computed basis.
         call check(error, norm2(abs(G - eye(kdim))) < rtol_dp)
+        call check_test(error, 'test_qr_factorization_cdp', &
+                        & 'Basis Q not orthonormal: Q.H @ Q /= I')
 
         return
     end subroutine test_qr_factorization_cdp
@@ -529,6 +540,8 @@ contains
 
         ! Check orthonormality of the computed basis.
         call check(error, norm2(abs(G - eye(kdim))) < rtol_dp)
+        call check_test(error, 'test_pivoting_qr_exact_rank_deficiency_cdp', &
+                        & 'Basis Q not orthonormal: Q.H @ Q /= I')
 
         return
     end subroutine test_pivoting_qr_exact_rank_deficiency_cdp
@@ -589,6 +602,8 @@ contains
 
         ! Check orthonormality of the computed basis.
         call check(error, maxval(abs(G - eye(kdim))) < rtol_sp)
+        call check_test(error, 'test_arnoldi_factorization_rsp', &
+                        & 'Basis X not orthonormal: X[:,1:k].H @ X[:,1:k] /= I')
 
         return
     end subroutine test_arnoldi_factorization_rsp
@@ -635,6 +650,8 @@ contains
 
         ! Check orthonormality of the computed basis.
         call check(error, maxval(abs(G - eye(p*kdim))) < rtol_sp)
+        call check_test(error, 'test_block_arnoldi_factorization_rsp', &
+                        & 'Basis X not orthonormal: X[:,1:k].H @ X[:,1:k] /= I')
 
         return
     end subroutine test_block_arnoldi_factorization_rsp
@@ -743,6 +760,8 @@ contains
 
         ! Check orthonormality of the computed basis.
         call check(error, maxval(abs(G - eye(kdim))) < rtol_dp)
+        call check_test(error, 'test_arnoldi_factorization_rdp', &
+                        & 'Basis X not orthonormal: X[:,1:k].H @ X[:,1:k] /= I')
 
         return
     end subroutine test_arnoldi_factorization_rdp
@@ -789,6 +808,8 @@ contains
 
         ! Check orthonormality of the computed basis.
         call check(error, maxval(abs(G - eye(p*kdim))) < rtol_dp)
+        call check_test(error, 'test_block_arnoldi_factorization_rdp', &
+                        & 'Basis X not orthonormal: X[:,1:k].H @ X[:,1:k] /= I')
 
         return
     end subroutine test_block_arnoldi_factorization_rdp
@@ -897,6 +918,8 @@ contains
 
         ! Check orthonormality of the computed basis.
         call check(error, maxval(abs(G - eye(kdim))) < rtol_sp)
+        call check_test(error, 'test_arnoldi_factorization_csp', &
+                        & 'Basis X not orthonormal: X[:,1:k].H @ X[:,1:k] /= I')
 
         return
     end subroutine test_arnoldi_factorization_csp
@@ -943,6 +966,8 @@ contains
 
         ! Check orthonormality of the computed basis.
         call check(error, maxval(abs(G - eye(p*kdim))) < rtol_sp)
+        call check_test(error, 'test_block_arnoldi_factorization_csp', &
+                        & 'Basis X not orthonormal: X[:,1:k].H @ X[:,1:k] /= I')
 
         return
     end subroutine test_block_arnoldi_factorization_csp
@@ -1051,6 +1076,8 @@ contains
 
         ! Check orthonormality of the computed basis.
         call check(error, maxval(abs(G - eye(kdim))) < rtol_dp)
+        call check_test(error, 'test_arnoldi_factorization_cdp', &
+                        & 'Basis X not orthonormal: X[:,1:k].H @ X[:,1:k] /= I')
 
         return
     end subroutine test_arnoldi_factorization_cdp
@@ -1097,6 +1124,8 @@ contains
 
         ! Check orthonormality of the computed basis.
         call check(error, maxval(abs(G - eye(p*kdim))) < rtol_dp)
+        call check_test(error, 'test_block_arnoldi_factorization_cdp', &
+                        & 'Basis X not orthonormal: X[:,1:k].H @ X[:,1:k] /= I')
 
         return
     end subroutine test_block_arnoldi_factorization_cdp
@@ -1216,7 +1245,8 @@ contains
 
         ! Check orthonormality of the left basis.
         call check(error, maxval(abs(G - eye(kdim))) < rtol_sp)
-        if (allocated(error)) return
+        call check_test(error, 'test_lanczos_bidiag_factorization_rsp', &
+                              & 'Left basis U not orthonormal: U[:,1:k].H @ U[:,1:k] /= I')
 
         ! Compute Gram matrix associated to the right Krylov basis.
         G = zero_rsp
@@ -1224,6 +1254,8 @@ contains
 
         ! Check orthonormality of the right basis.
         call check(error, maxval(abs(G - eye(kdim))) < rtol_sp)
+        call check_test(error, 'test_lanczos_bidiag_factorization_rsp', &
+                              & 'Right basis V not orthonormal: V[:,1:k].H @ V[:,1:k] /= I')
 
         return
     end subroutine test_lanczos_bidiag_factorization_rsp
@@ -1285,7 +1317,8 @@ contains
 
         ! Check orthonormality of the left basis.
         call check(error, maxval(abs(G - eye(kdim))) < rtol_dp)
-        if (allocated(error)) return
+        call check_test(error, 'test_lanczos_bidiag_factorization_rdp', &
+                              & 'Left basis U not orthonormal: U[:,1:k].H @ U[:,1:k] /= I')
 
         ! Compute Gram matrix associated to the right Krylov basis.
         G = zero_rdp
@@ -1293,6 +1326,8 @@ contains
 
         ! Check orthonormality of the right basis.
         call check(error, maxval(abs(G - eye(kdim))) < rtol_dp)
+        call check_test(error, 'test_lanczos_bidiag_factorization_rdp', &
+                              & 'Right basis V not orthonormal: V[:,1:k].H @ V[:,1:k] /= I')
 
         return
     end subroutine test_lanczos_bidiag_factorization_rdp
@@ -1354,7 +1389,8 @@ contains
 
         ! Check orthonormality of the left basis.
         call check(error, maxval(abs(G - eye(kdim))) < rtol_sp)
-        if (allocated(error)) return
+        call check_test(error, 'test_lanczos_bidiag_factorization_csp', &
+                              & 'Left basis U not orthonormal: U[:,1:k].H @ U[:,1:k] /= I')
 
         ! Compute Gram matrix associated to the right Krylov basis.
         G = zero_csp
@@ -1362,6 +1398,8 @@ contains
 
         ! Check orthonormality of the right basis.
         call check(error, maxval(abs(G - eye(kdim))) < rtol_sp)
+        call check_test(error, 'test_lanczos_bidiag_factorization_csp', &
+                              & 'Right basis V not orthonormal: V[:,1:k].H @ V[:,1:k] /= I')
 
         return
     end subroutine test_lanczos_bidiag_factorization_csp
@@ -1423,7 +1461,8 @@ contains
 
         ! Check orthonormality of the left basis.
         call check(error, maxval(abs(G - eye(kdim))) < rtol_dp)
-        if (allocated(error)) return
+        call check_test(error, 'test_lanczos_bidiag_factorization_cdp', &
+                              & 'Left basis U not orthonormal: U[:,1:k].H @ U[:,1:k] /= I')
 
         ! Compute Gram matrix associated to the right Krylov basis.
         G = zero_cdp
@@ -1431,6 +1470,8 @@ contains
 
         ! Check orthonormality of the right basis.
         call check(error, maxval(abs(G - eye(kdim))) < rtol_dp)
+        call check_test(error, 'test_lanczos_bidiag_factorization_cdp', &
+                              & 'Right basis V not orthonormal: V[:,1:k].H @ V[:,1:k] /= I')
 
         return
     end subroutine test_lanczos_bidiag_factorization_cdp
@@ -1502,6 +1543,8 @@ contains
 
         ! Check orthonormality of the Krylov basis.
         call check(error, maxval(abs(G - eye(kdim))) < rtol_sp)
+        call check_test(error, 'test_lanczos_tridiag_factorization_rsp', &
+                                 & 'Basis X not orthonormal: X[:,1:k].H @ X[:,1:k] /= I')
 
         return
     end subroutine test_lanczos_tridiag_factorization_rsp
@@ -1568,6 +1611,8 @@ contains
 
         ! Check orthonormality of the Krylov basis.
         call check(error, maxval(abs(G - eye(kdim))) < rtol_dp)
+        call check_test(error, 'test_lanczos_tridiag_factorization_rdp', &
+                                 & 'Basis X not orthonormal: X[:,1:k].H @ X[:,1:k] /= I')
 
         return
     end subroutine test_lanczos_tridiag_factorization_rdp
@@ -1634,6 +1679,8 @@ contains
 
         ! Check orthonormality of the Krylov basis.
         call check(error, maxval(abs(G - eye(kdim))) < rtol_sp)
+        call check_test(error, 'test_lanczos_tridiag_factorization_csp', &
+                                 & 'Basis X not orthonormal: X[:,1:k].H @ X[:,1:k] /= I')
 
         return
     end subroutine test_lanczos_tridiag_factorization_csp
@@ -1700,6 +1747,8 @@ contains
 
         ! Check orthonormality of the Krylov basis.
         call check(error, maxval(abs(G - eye(kdim))) < rtol_dp)
+        call check_test(error, 'test_lanczos_tridiag_factorization_cdp', &
+                                 & 'Basis X not orthonormal: X[:,1:k].H @ X[:,1:k] /= I')
 
         return
     end subroutine test_lanczos_tridiag_factorization_cdp

--- a/test/TestKrylov.f90
+++ b/test/TestKrylov.f90
@@ -21,7 +21,7 @@ module TestKrylov
     
     private
 
-    character*128, parameter, private :: this_module = 'LightKrylov_TestKrylov'
+    character(len=128), parameter, private :: this_module = 'LightKrylov_TestKrylov'
 
     public :: collect_qr_rsp_testsuite
     public :: collect_arnoldi_rsp_testsuite
@@ -72,33 +72,32 @@ contains
         ! Information flag.
         integer :: info
         ! Miscellaneous.
-        real(sp), dimension(test_size, kdim) :: Adata, Qdata
-        real(sp), dimension(kdim, kdim) :: G, Id
+        real(sp), allocatable :: Adata(:, :), Qdata(:, :)
+        real(sp), allocatable :: G(:, :)
 
         ! Initiliaze matrix.
         allocate(A(1:kdim)) ; call init_rand(A)
 
         ! Get data.
-        call get_data(Adata, A)
+        allocate(Adata(test_size, kdim)) ; call get_data(Adata, A)
 
         ! In-place QR factorization.
         call qr(A, R, info, tol=atol_sp)
         call check_info(info, 'qr', module=this_module, procedure='test_qr_factorization_rsp')
 
         ! Get data.
-        call get_data(Qdata, A)
+        allocate(Qdata(test_size, kdim)) ; call get_data(Qdata, A)
 
         ! Check correctness.
         call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_sp)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the Krylov basis.
-        G = zero_rsp
+        allocate(G(kdim, kdim)) ; G = zero_rsp
         call innerprod(G, A(1:kdim), A(1:kdim))
 
         ! Check orthonormality of the computed basis.
-        Id = eye(kdim)
-        call check(error, norm2(abs(G - Id)) < rtol_sp)
+        call check(error, norm2(abs(G - eye(kdim))) < rtol_sp)
 
         return
     end subroutine test_qr_factorization_rsp
@@ -123,8 +122,8 @@ contains
         integer :: k, idx, rk
         real(sp) :: alpha
         logical :: mask(kdim)
-        real(sp), dimension(test_size, kdim) :: Adata, Qdata
-        real(sp), dimension(kdim, kdim) :: G, Id
+        real(sp), allocatable :: Adata(:, :), Qdata(:, :)
+        real(sp), allocatable :: G(:, :)
 
         ! Effective rank.
         rk = kdim - nzero
@@ -145,14 +144,14 @@ contains
         enddo
 
         ! Copy data.
-        call get_data(Adata, A)
+        allocate(Adata(test_size, kdim)) ; call get_data(Adata, A)
 
         ! In-place QR factorization.
         call qr(A, R, perm, info, tol=atol_sp)
         call check_info(info, 'qr_pivot', module=this_module, procedure='test_pivoting_qr_exact_rank_deficiency_rsp')
 
         ! Extract data
-        call get_data(Qdata, A)
+        allocate(Qdata(test_size, kdim)) ; call get_data(Qdata, A)
         Adata = Adata(:, perm)
 
         ! Check correctness.
@@ -160,12 +159,11 @@ contains
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the Krylov basis.
-        G = zero_rsp
+        allocate(G(kdim, kdim)) ; G = zero_rsp
         call innerprod(G, A(1:kdim), A(1:kdim))
 
         ! Check orthonormality of the computed basis.
-        Id = eye(kdim)
-        call check(error, norm2(abs(G - Id)) < rtol_sp)
+        call check(error, norm2(abs(G - eye(kdim))) < rtol_sp)
 
         return
     end subroutine test_pivoting_qr_exact_rank_deficiency_rsp
@@ -192,33 +190,32 @@ contains
         ! Information flag.
         integer :: info
         ! Miscellaneous.
-        real(dp), dimension(test_size, kdim) :: Adata, Qdata
-        real(dp), dimension(kdim, kdim) :: G, Id
+        real(dp), allocatable :: Adata(:, :), Qdata(:, :)
+        real(dp), allocatable :: G(:, :)
 
         ! Initiliaze matrix.
         allocate(A(1:kdim)) ; call init_rand(A)
 
         ! Get data.
-        call get_data(Adata, A)
+        allocate(Adata(test_size, kdim)) ; call get_data(Adata, A)
 
         ! In-place QR factorization.
         call qr(A, R, info, tol=atol_dp)
         call check_info(info, 'qr', module=this_module, procedure='test_qr_factorization_rdp')
 
         ! Get data.
-        call get_data(Qdata, A)
+        allocate(Qdata(test_size, kdim)) ; call get_data(Qdata, A)
 
         ! Check correctness.
         call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_dp)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the Krylov basis.
-        G = zero_rdp
+        allocate(G(kdim, kdim)) ; G = zero_rdp
         call innerprod(G, A(1:kdim), A(1:kdim))
 
         ! Check orthonormality of the computed basis.
-        Id = eye(kdim)
-        call check(error, norm2(abs(G - Id)) < rtol_dp)
+        call check(error, norm2(abs(G - eye(kdim))) < rtol_dp)
 
         return
     end subroutine test_qr_factorization_rdp
@@ -243,8 +240,8 @@ contains
         integer :: k, idx, rk
         real(dp) :: alpha
         logical :: mask(kdim)
-        real(dp), dimension(test_size, kdim) :: Adata, Qdata
-        real(dp), dimension(kdim, kdim) :: G, Id
+        real(dp), allocatable :: Adata(:, :), Qdata(:, :)
+        real(dp), allocatable :: G(:, :)
 
         ! Effective rank.
         rk = kdim - nzero
@@ -265,14 +262,14 @@ contains
         enddo
 
         ! Copy data.
-        call get_data(Adata, A)
+        allocate(Adata(test_size, kdim)) ; call get_data(Adata, A)
 
         ! In-place QR factorization.
         call qr(A, R, perm, info, tol=atol_dp)
         call check_info(info, 'qr_pivot', module=this_module, procedure='test_pivoting_qr_exact_rank_deficiency_rdp')
 
         ! Extract data
-        call get_data(Qdata, A)
+        allocate(Qdata(test_size, kdim)) ; call get_data(Qdata, A)
         Adata = Adata(:, perm)
 
         ! Check correctness.
@@ -280,12 +277,11 @@ contains
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the Krylov basis.
-        G = zero_rdp
+        allocate(G(kdim, kdim)) ; G = zero_rdp
         call innerprod(G, A(1:kdim), A(1:kdim))
 
         ! Check orthonormality of the computed basis.
-        Id = eye(kdim)
-        call check(error, norm2(abs(G - Id)) < rtol_dp)
+        call check(error, norm2(abs(G - eye(kdim))) < rtol_dp)
 
         return
     end subroutine test_pivoting_qr_exact_rank_deficiency_rdp
@@ -312,33 +308,32 @@ contains
         ! Information flag.
         integer :: info
         ! Miscellaneous.
-        complex(sp), dimension(test_size, kdim) :: Adata, Qdata
-        complex(sp), dimension(kdim, kdim) :: G, Id
+        complex(sp), allocatable :: Adata(:, :), Qdata(:, :)
+        complex(sp), allocatable :: G(:, :)
 
         ! Initiliaze matrix.
         allocate(A(1:kdim)) ; call init_rand(A)
 
         ! Get data.
-        call get_data(Adata, A)
+        allocate(Adata(test_size, kdim)) ; call get_data(Adata, A)
 
         ! In-place QR factorization.
         call qr(A, R, info, tol=atol_sp)
         call check_info(info, 'qr', module=this_module, procedure='test_qr_factorization_csp')
 
         ! Get data.
-        call get_data(Qdata, A)
+        allocate(Qdata(test_size, kdim)) ; call get_data(Qdata, A)
 
         ! Check correctness.
         call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_sp)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the Krylov basis.
-        G = zero_csp
+        allocate(G(kdim, kdim)) ; G = zero_csp
         call innerprod(G, A(1:kdim), A(1:kdim))
 
         ! Check orthonormality of the computed basis.
-        Id = eye(kdim)
-        call check(error, norm2(abs(G - Id)) < rtol_sp)
+        call check(error, norm2(abs(G - eye(kdim))) < rtol_sp)
 
         return
     end subroutine test_qr_factorization_csp
@@ -363,8 +358,8 @@ contains
         integer :: k, idx, rk
         real(sp) :: alpha
         logical :: mask(kdim)
-        complex(sp), dimension(test_size, kdim) :: Adata, Qdata
-        complex(sp), dimension(kdim, kdim) :: G, Id
+        complex(sp), allocatable :: Adata(:, :), Qdata(:, :)
+        complex(sp), allocatable :: G(:, :)
 
         ! Effective rank.
         rk = kdim - nzero
@@ -385,14 +380,14 @@ contains
         enddo
 
         ! Copy data.
-        call get_data(Adata, A)
+        allocate(Adata(test_size, kdim)) ; call get_data(Adata, A)
 
         ! In-place QR factorization.
         call qr(A, R, perm, info, tol=atol_sp)
         call check_info(info, 'qr_pivot', module=this_module, procedure='test_pivoting_qr_exact_rank_deficiency_csp')
 
         ! Extract data
-        call get_data(Qdata, A)
+        allocate(Qdata(test_size, kdim)) ; call get_data(Qdata, A)
         Adata = Adata(:, perm)
 
         ! Check correctness.
@@ -400,12 +395,11 @@ contains
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the Krylov basis.
-        G = zero_csp
+        allocate(G(kdim, kdim)) ; G = zero_csp
         call innerprod(G, A(1:kdim), A(1:kdim))
 
         ! Check orthonormality of the computed basis.
-        Id = eye(kdim)
-        call check(error, norm2(abs(G - Id)) < rtol_sp)
+        call check(error, norm2(abs(G - eye(kdim))) < rtol_sp)
 
         return
     end subroutine test_pivoting_qr_exact_rank_deficiency_csp
@@ -432,33 +426,32 @@ contains
         ! Information flag.
         integer :: info
         ! Miscellaneous.
-        complex(dp), dimension(test_size, kdim) :: Adata, Qdata
-        complex(dp), dimension(kdim, kdim) :: G, Id
+        complex(dp), allocatable :: Adata(:, :), Qdata(:, :)
+        complex(dp), allocatable :: G(:, :)
 
         ! Initiliaze matrix.
         allocate(A(1:kdim)) ; call init_rand(A)
 
         ! Get data.
-        call get_data(Adata, A)
+        allocate(Adata(test_size, kdim)) ; call get_data(Adata, A)
 
         ! In-place QR factorization.
         call qr(A, R, info, tol=atol_dp)
         call check_info(info, 'qr', module=this_module, procedure='test_qr_factorization_cdp')
 
         ! Get data.
-        call get_data(Qdata, A)
+        allocate(Qdata(test_size, kdim)) ; call get_data(Qdata, A)
 
         ! Check correctness.
         call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_dp)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the Krylov basis.
-        G = zero_cdp
+        allocate(G(kdim, kdim)) ; G = zero_cdp
         call innerprod(G, A(1:kdim), A(1:kdim))
 
         ! Check orthonormality of the computed basis.
-        Id = eye(kdim)
-        call check(error, norm2(abs(G - Id)) < rtol_dp)
+        call check(error, norm2(abs(G - eye(kdim))) < rtol_dp)
 
         return
     end subroutine test_qr_factorization_cdp
@@ -483,8 +476,8 @@ contains
         integer :: k, idx, rk
         real(dp) :: alpha
         logical :: mask(kdim)
-        complex(dp), dimension(test_size, kdim) :: Adata, Qdata
-        complex(dp), dimension(kdim, kdim) :: G, Id
+        complex(dp), allocatable :: Adata(:, :), Qdata(:, :)
+        complex(dp), allocatable :: G(:, :)
 
         ! Effective rank.
         rk = kdim - nzero
@@ -505,14 +498,14 @@ contains
         enddo
 
         ! Copy data.
-        call get_data(Adata, A)
+        allocate(Adata(test_size, kdim)) ; call get_data(Adata, A)
 
         ! In-place QR factorization.
         call qr(A, R, perm, info, tol=atol_dp)
         call check_info(info, 'qr_pivot', module=this_module, procedure='test_pivoting_qr_exact_rank_deficiency_cdp')
 
         ! Extract data
-        call get_data(Qdata, A)
+        allocate(Qdata(test_size, kdim)) ; call get_data(Qdata, A)
         Adata = Adata(:, perm)
 
         ! Check correctness.
@@ -520,12 +513,11 @@ contains
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the Krylov basis.
-        G = zero_cdp
+        allocate(G(kdim, kdim)) ; G = zero_cdp
         call innerprod(G, A(1:kdim), A(1:kdim))
 
         ! Check orthonormality of the computed basis.
-        Id = eye(kdim)
-        call check(error, norm2(abs(G - Id)) < rtol_dp)
+        call check(error, norm2(abs(G - eye(kdim))) < rtol_dp)
 
         return
     end subroutine test_pivoting_qr_exact_rank_deficiency_cdp
@@ -556,35 +548,34 @@ contains
         type(vector_rsp), dimension(:), allocatable :: X0
         integer, parameter :: kdim = test_size
         ! Hessenberg matrix.
-        real(sp) :: H(kdim+1, kdim)
+        real(sp), allocatable :: H(:, :)
         ! Information flag.
         integer :: info
         ! Miscellaneous.
-        real(sp) :: Xdata(test_size, kdim+1)
-        real(sp), dimension(kdim, kdim) :: G, Id
+        real(sp), allocatable :: Xdata(:, :)
+        real(sp), allocatable :: G(:, :)
            
         ! Initialize linear operator.
         A = linop_rsp() ; call init_rand(A)
         ! Initialize Krylov subspace.
         allocate(X(1:kdim+1)) ; allocate (X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
-        H = zero_rsp
+        allocate(H(kdim+1, kdim)) ; H = zero_rsp
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, tol=atol_sp)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_arnoldi_factorization_rsp')
 
         ! Check correctness of full factorization.
-        call get_data(Xdata, X)
+        allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
         call check(error, maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, H))) < rtol_sp)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the Krylov basis.
-        G = zero_rsp
+        allocate(G(kdim, kdim)) ; G = zero_rsp
         call innerprod(G, X(1:kdim), X(1:kdim))
 
         ! Check orthonormality of the computed basis.
-        Id = eye(kdim)
-        call check(error, maxval(abs(G - Id)) < rtol_sp)
+        call check(error, maxval(abs(G - eye(kdim))) < rtol_sp)
 
         return
     end subroutine test_arnoldi_factorization_rsp
@@ -599,14 +590,13 @@ contains
         integer, parameter :: p = 2
         integer, parameter :: kdim = test_size/2
         ! Hessenberg matrix.
-        real(sp) :: H(p*(kdim+1), p*kdim)
+        real(sp), allocatable :: H(:, :)
         ! Information flag.
         integer :: info
         ! Miscellaneous.
         type(vector_rsp), allocatable :: X0(:)
-        real(sp), dimension(test_size, p*(kdim+1)) :: Xdata
-        real(sp), dimension(p*kdim, p*kdim) :: G
-        real(sp), dimension(p*kdim, p*kdim) :: Id
+        real(sp), allocatable :: Xdata(:, :)
+        real(sp), allocatable :: G(:, :)
 
         ! Initialize linear operator.
         A = linop_rsp() ; call init_rand(A)
@@ -614,24 +604,23 @@ contains
         ! Initialize Krylov subspace.
         allocate(X(1:p*(kdim+1))) ; allocate(X0(1:p))
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
-        H = zero_rsp
+        allocate(H(p*(kdim+1), p*kdim)) ; H = zero_rsp
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, blksize=p, tol=atol_sp)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_block_arnoldi_factorization_rsp')
 
         ! Check correctness of full factorization.
-        call get_data(Xdata, X)
+        allocate(Xdata(test_size, p*(kdim+1))) ; call get_data(Xdata, X)
         call check(error, maxval(abs(matmul(A%data, Xdata(:, 1:p*kdim)) - matmul(Xdata, H))) < rtol_sp)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the Krylov basis.
-        G = zero_rsp
+        allocate(G(p*kdim, p*kdim)) ; G = zero_rsp
         call innerprod(G, X(1:p*kdim), X(1:p*kdim))
 
         ! Check orthonormality of the computed basis.
-        Id = eye(p*kdim)
-        call check(error, maxval(abs(G - Id)) < rtol_sp)
+        call check(error, maxval(abs(G - eye(p*kdim))) < rtol_sp)
 
         return
     end subroutine test_block_arnoldi_factorization_rsp
@@ -646,13 +635,13 @@ contains
         ! Krylov subspace dimension.
         integer, parameter :: kdim = 100
         ! Hessenberg matrix.
-        real(sp) :: H(kdim+1, kdim)
+        real(sp), allocatable :: H(:, :)
         ! Information flag.
         integer :: info
 
         ! Miscellaneous.
         integer :: n
-        real(sp) :: Xdata(test_size, kdim+1)
+        real(sp), allocatable :: Xdata(:, :)
         real(sp) :: alpha
 
         ! Initialize matrix.
@@ -662,7 +651,7 @@ contains
         ! Initialize Krylov subspace.
         allocate(X(kdim+1)) ; allocate(X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
-        H = zero_rsp
+        allocate(H(kdim+1, kdim)) ; H = zero_rsp
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, tol=atol_sp)
@@ -672,7 +661,7 @@ contains
         call krylov_schur(n, X, H, select_eigs)
 
         ! Check correctness.
-        call get_data(Xdata, X)
+        allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
         alpha = maxval(abs(matmul(A%data, Xdata(:, :n)) - matmul(Xdata(:, :n+1), H(:n+1, :n))))
         call check(error, alpha < rtol_sp)
 
@@ -708,35 +697,34 @@ contains
         type(vector_rdp), dimension(:), allocatable :: X0
         integer, parameter :: kdim = test_size
         ! Hessenberg matrix.
-        real(dp) :: H(kdim+1, kdim)
+        real(dp), allocatable :: H(:, :)
         ! Information flag.
         integer :: info
         ! Miscellaneous.
-        real(dp) :: Xdata(test_size, kdim+1)
-        real(dp), dimension(kdim, kdim) :: G, Id
+        real(dp), allocatable :: Xdata(:, :)
+        real(dp), allocatable :: G(:, :)
            
         ! Initialize linear operator.
         A = linop_rdp() ; call init_rand(A)
         ! Initialize Krylov subspace.
         allocate(X(1:kdim+1)) ; allocate (X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
-        H = zero_rdp
+        allocate(H(kdim+1, kdim)) ; H = zero_rdp
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, tol=atol_dp)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_arnoldi_factorization_rdp')
 
         ! Check correctness of full factorization.
-        call get_data(Xdata, X)
+        allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
         call check(error, maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, H))) < rtol_dp)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the Krylov basis.
-        G = zero_rdp
+        allocate(G(kdim, kdim)) ; G = zero_rdp
         call innerprod(G, X(1:kdim), X(1:kdim))
 
         ! Check orthonormality of the computed basis.
-        Id = eye(kdim)
-        call check(error, maxval(abs(G - Id)) < rtol_dp)
+        call check(error, maxval(abs(G - eye(kdim))) < rtol_dp)
 
         return
     end subroutine test_arnoldi_factorization_rdp
@@ -751,14 +739,13 @@ contains
         integer, parameter :: p = 2
         integer, parameter :: kdim = test_size/2
         ! Hessenberg matrix.
-        real(dp) :: H(p*(kdim+1), p*kdim)
+        real(dp), allocatable :: H(:, :)
         ! Information flag.
         integer :: info
         ! Miscellaneous.
         type(vector_rdp), allocatable :: X0(:)
-        real(dp), dimension(test_size, p*(kdim+1)) :: Xdata
-        real(dp), dimension(p*kdim, p*kdim) :: G
-        real(dp), dimension(p*kdim, p*kdim) :: Id
+        real(dp), allocatable :: Xdata(:, :)
+        real(dp), allocatable :: G(:, :)
 
         ! Initialize linear operator.
         A = linop_rdp() ; call init_rand(A)
@@ -766,24 +753,23 @@ contains
         ! Initialize Krylov subspace.
         allocate(X(1:p*(kdim+1))) ; allocate(X0(1:p))
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
-        H = zero_rdp
+        allocate(H(p*(kdim+1), p*kdim)) ; H = zero_rdp
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, blksize=p, tol=atol_dp)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_block_arnoldi_factorization_rdp')
 
         ! Check correctness of full factorization.
-        call get_data(Xdata, X)
+        allocate(Xdata(test_size, p*(kdim+1))) ; call get_data(Xdata, X)
         call check(error, maxval(abs(matmul(A%data, Xdata(:, 1:p*kdim)) - matmul(Xdata, H))) < rtol_dp)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the Krylov basis.
-        G = zero_rdp
+        allocate(G(p*kdim, p*kdim)) ; G = zero_rdp
         call innerprod(G, X(1:p*kdim), X(1:p*kdim))
 
         ! Check orthonormality of the computed basis.
-        Id = eye(p*kdim)
-        call check(error, maxval(abs(G - Id)) < rtol_dp)
+        call check(error, maxval(abs(G - eye(p*kdim))) < rtol_dp)
 
         return
     end subroutine test_block_arnoldi_factorization_rdp
@@ -798,13 +784,13 @@ contains
         ! Krylov subspace dimension.
         integer, parameter :: kdim = 100
         ! Hessenberg matrix.
-        real(dp) :: H(kdim+1, kdim)
+        real(dp), allocatable :: H(:, :)
         ! Information flag.
         integer :: info
 
         ! Miscellaneous.
         integer :: n
-        real(dp) :: Xdata(test_size, kdim+1)
+        real(dp), allocatable :: Xdata(:, :)
         real(dp) :: alpha
 
         ! Initialize matrix.
@@ -814,7 +800,7 @@ contains
         ! Initialize Krylov subspace.
         allocate(X(kdim+1)) ; allocate(X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
-        H = zero_rdp
+        allocate(H(kdim+1, kdim)) ; H = zero_rdp
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, tol=atol_dp)
@@ -824,7 +810,7 @@ contains
         call krylov_schur(n, X, H, select_eigs)
 
         ! Check correctness.
-        call get_data(Xdata, X)
+        allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
         alpha = maxval(abs(matmul(A%data, Xdata(:, :n)) - matmul(Xdata(:, :n+1), H(:n+1, :n))))
         call check(error, alpha < rtol_dp)
 
@@ -860,35 +846,34 @@ contains
         type(vector_csp), dimension(:), allocatable :: X0
         integer, parameter :: kdim = test_size
         ! Hessenberg matrix.
-        complex(sp) :: H(kdim+1, kdim)
+        complex(sp), allocatable :: H(:, :)
         ! Information flag.
         integer :: info
         ! Miscellaneous.
-        complex(sp) :: Xdata(test_size, kdim+1)
-        complex(sp), dimension(kdim, kdim) :: G, Id
+        complex(sp), allocatable :: Xdata(:, :)
+        complex(sp), allocatable :: G(:, :)
            
         ! Initialize linear operator.
         A = linop_csp() ; call init_rand(A)
         ! Initialize Krylov subspace.
         allocate(X(1:kdim+1)) ; allocate (X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
-        H = zero_csp
+        allocate(H(kdim+1, kdim)) ; H = zero_csp
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, tol=atol_sp)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_arnoldi_factorization_csp')
 
         ! Check correctness of full factorization.
-        call get_data(Xdata, X)
+        allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
         call check(error, maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, H))) < rtol_sp)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the Krylov basis.
-        G = zero_csp
+        allocate(G(kdim, kdim)) ; G = zero_csp
         call innerprod(G, X(1:kdim), X(1:kdim))
 
         ! Check orthonormality of the computed basis.
-        Id = eye(kdim)
-        call check(error, maxval(abs(G - Id)) < rtol_sp)
+        call check(error, maxval(abs(G - eye(kdim))) < rtol_sp)
 
         return
     end subroutine test_arnoldi_factorization_csp
@@ -903,14 +888,13 @@ contains
         integer, parameter :: p = 2
         integer, parameter :: kdim = test_size/2
         ! Hessenberg matrix.
-        complex(sp) :: H(p*(kdim+1), p*kdim)
+        complex(sp), allocatable :: H(:, :)
         ! Information flag.
         integer :: info
         ! Miscellaneous.
         type(vector_csp), allocatable :: X0(:)
-        complex(sp), dimension(test_size, p*(kdim+1)) :: Xdata
-        complex(sp), dimension(p*kdim, p*kdim) :: G
-        real(sp), dimension(p*kdim, p*kdim) :: Id
+        complex(sp), allocatable :: Xdata(:, :)
+        complex(sp), allocatable :: G(:, :)
 
         ! Initialize linear operator.
         A = linop_csp() ; call init_rand(A)
@@ -918,24 +902,23 @@ contains
         ! Initialize Krylov subspace.
         allocate(X(1:p*(kdim+1))) ; allocate(X0(1:p))
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
-        H = zero_csp
+        allocate(H(p*(kdim+1), p*kdim)) ; H = zero_csp
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, blksize=p, tol=atol_sp)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_block_arnoldi_factorization_csp')
 
         ! Check correctness of full factorization.
-        call get_data(Xdata, X)
+        allocate(Xdata(test_size, p*(kdim+1))) ; call get_data(Xdata, X)
         call check(error, maxval(abs(matmul(A%data, Xdata(:, 1:p*kdim)) - matmul(Xdata, H))) < rtol_sp)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the Krylov basis.
-        G = zero_csp
+        allocate(G(p*kdim, p*kdim)) ; G = zero_csp
         call innerprod(G, X(1:p*kdim), X(1:p*kdim))
 
         ! Check orthonormality of the computed basis.
-        Id = eye(p*kdim)
-        call check(error, maxval(abs(G - Id)) < rtol_sp)
+        call check(error, maxval(abs(G - eye(p*kdim))) < rtol_sp)
 
         return
     end subroutine test_block_arnoldi_factorization_csp
@@ -950,13 +933,13 @@ contains
         ! Krylov subspace dimension.
         integer, parameter :: kdim = 100
         ! Hessenberg matrix.
-        complex(sp) :: H(kdim+1, kdim)
+        complex(sp), allocatable :: H(:, :)
         ! Information flag.
         integer :: info
 
         ! Miscellaneous.
         integer :: n
-        complex(sp) :: Xdata(test_size, kdim+1)
+        complex(sp), allocatable :: Xdata(:, :)
         real(sp) :: alpha
 
         ! Initialize matrix.
@@ -966,7 +949,7 @@ contains
         ! Initialize Krylov subspace.
         allocate(X(kdim+1)) ; allocate(X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
-        H = zero_csp
+        allocate(H(kdim+1, kdim)) ; H = zero_csp
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, tol=atol_sp)
@@ -976,7 +959,7 @@ contains
         call krylov_schur(n, X, H, select_eigs)
 
         ! Check correctness.
-        call get_data(Xdata, X)
+        allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
         alpha = maxval(abs(matmul(A%data, Xdata(:, :n)) - matmul(Xdata(:, :n+1), H(:n+1, :n))))
         call check(error, alpha < rtol_sp)
 
@@ -1012,35 +995,34 @@ contains
         type(vector_cdp), dimension(:), allocatable :: X0
         integer, parameter :: kdim = test_size
         ! Hessenberg matrix.
-        complex(dp) :: H(kdim+1, kdim)
+        complex(dp), allocatable :: H(:, :)
         ! Information flag.
         integer :: info
         ! Miscellaneous.
-        complex(dp) :: Xdata(test_size, kdim+1)
-        complex(dp), dimension(kdim, kdim) :: G, Id
+        complex(dp), allocatable :: Xdata(:, :)
+        complex(dp), allocatable :: G(:, :)
            
         ! Initialize linear operator.
         A = linop_cdp() ; call init_rand(A)
         ! Initialize Krylov subspace.
         allocate(X(1:kdim+1)) ; allocate (X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
-        H = zero_cdp
+        allocate(H(kdim+1, kdim)) ; H = zero_cdp
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, tol=atol_dp)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_arnoldi_factorization_cdp')
 
         ! Check correctness of full factorization.
-        call get_data(Xdata, X)
+        allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
         call check(error, maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, H))) < rtol_dp)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the Krylov basis.
-        G = zero_cdp
+        allocate(G(kdim, kdim)) ; G = zero_cdp
         call innerprod(G, X(1:kdim), X(1:kdim))
 
         ! Check orthonormality of the computed basis.
-        Id = eye(kdim)
-        call check(error, maxval(abs(G - Id)) < rtol_dp)
+        call check(error, maxval(abs(G - eye(kdim))) < rtol_dp)
 
         return
     end subroutine test_arnoldi_factorization_cdp
@@ -1055,14 +1037,13 @@ contains
         integer, parameter :: p = 2
         integer, parameter :: kdim = test_size/2
         ! Hessenberg matrix.
-        complex(dp) :: H(p*(kdim+1), p*kdim)
+        complex(dp), allocatable :: H(:, :)
         ! Information flag.
         integer :: info
         ! Miscellaneous.
         type(vector_cdp), allocatable :: X0(:)
-        complex(dp), dimension(test_size, p*(kdim+1)) :: Xdata
-        complex(dp), dimension(p*kdim, p*kdim) :: G
-        real(dp), dimension(p*kdim, p*kdim) :: Id
+        complex(dp), allocatable :: Xdata(:, :)
+        complex(dp), allocatable :: G(:, :)
 
         ! Initialize linear operator.
         A = linop_cdp() ; call init_rand(A)
@@ -1070,24 +1051,23 @@ contains
         ! Initialize Krylov subspace.
         allocate(X(1:p*(kdim+1))) ; allocate(X0(1:p))
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
-        H = zero_cdp
+        allocate(H(p*(kdim+1), p*kdim)) ; H = zero_cdp
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, blksize=p, tol=atol_dp)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_block_arnoldi_factorization_cdp')
 
         ! Check correctness of full factorization.
-        call get_data(Xdata, X)
+        allocate(Xdata(test_size, p*(kdim+1))) ; call get_data(Xdata, X)
         call check(error, maxval(abs(matmul(A%data, Xdata(:, 1:p*kdim)) - matmul(Xdata, H))) < rtol_dp)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the Krylov basis.
-        G = zero_cdp
+        allocate(G(p*kdim, p*kdim)) ; G = zero_cdp
         call innerprod(G, X(1:p*kdim), X(1:p*kdim))
 
         ! Check orthonormality of the computed basis.
-        Id = eye(p*kdim)
-        call check(error, maxval(abs(G - Id)) < rtol_dp)
+        call check(error, maxval(abs(G - eye(p*kdim))) < rtol_dp)
 
         return
     end subroutine test_block_arnoldi_factorization_cdp
@@ -1102,13 +1082,13 @@ contains
         ! Krylov subspace dimension.
         integer, parameter :: kdim = 100
         ! Hessenberg matrix.
-        complex(dp) :: H(kdim+1, kdim)
+        complex(dp), allocatable :: H(:, :)
         ! Information flag.
         integer :: info
 
         ! Miscellaneous.
         integer :: n
-        complex(dp) :: Xdata(test_size, kdim+1)
+        complex(dp), allocatable :: Xdata(:, :)
         real(dp) :: alpha
 
         ! Initialize matrix.
@@ -1118,7 +1098,7 @@ contains
         ! Initialize Krylov subspace.
         allocate(X(kdim+1)) ; allocate(X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
-        H = zero_cdp
+        allocate(H(kdim+1, kdim)) ; H = zero_cdp
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, tol=atol_dp)
@@ -1128,7 +1108,7 @@ contains
         call krylov_schur(n, X, H, select_eigs)
 
         ! Check correctness.
-        call get_data(Xdata, X)
+        allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
         alpha = maxval(abs(matmul(A%data, Xdata(:, :n)) - matmul(Xdata(:, :n+1), H(:n+1, :n))))
         call check(error, alpha < rtol_dp)
 
@@ -1168,13 +1148,13 @@ contains
         ! Krylov subspace dimension.
         integer, parameter :: kdim = test_size
         ! Bidiagonal matrix.
-        real(sp) :: B(kdim+1, kdim)
+        real(sp), allocatable :: B(:, :)
         ! Information flag.
         integer :: info
         ! Miscellaneous.
         real(sp) :: alpha
-        real(sp), dimension(test_size, kdim+1) :: Udata, Vdata
-        real(sp), dimension(kdim, kdim) :: G, Id
+        real(sp), allocatable :: Udata(:, :), Vdata(:, :)
+        real(sp), allocatable :: G(:, :)
         type(vector_rsp), allocatable :: X0(:)
 
         ! Initialize linear operator.
@@ -1183,7 +1163,7 @@ contains
         ! Initialize Krylov subspaces.
         allocate(U(1:kdim+1)) ; allocate(V(1:kdim+1)) ; allocate(X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(U, X0)
-        call initialize_krylov_subspace(V) ; B = zero_rsp
+        call zero_basis(V) ; allocate(B(kdim+1, kdim)) ; B = zero_rsp
 
         ! Lanczos bidiagonalization.
         call lanczos_bidiagonalization(A, U, V, B, info, tol=atol_sp)
@@ -1191,20 +1171,19 @@ contains
                         & procedure='test_lanczos_bidiag_factorization_rsp')
 
         ! Check correctness.
-        call get_data(Udata, U)
-        call get_data(Vdata, V)
+        allocate(Udata(test_size, kdim+1)) ; call get_data(Udata, U)
+        allocate(Vdata(test_size, kdim+1)) ; call get_data(Vdata, V)
 
         alpha = maxval(abs(matmul(A%data, Vdata(:, 1:kdim)) - matmul(Udata, B)))
         call check(error, alpha < rtol_sp)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the left Krylov basis.
-        G = zero_rsp
+        allocate(G(kdim, kdim)) ; G = zero_rsp
         call innerprod(G, U(1:kdim), U(1:kdim))
 
         ! Check orthonormality of the left basis.
-        Id = eye(kdim)
-        call check(error, maxval(abs(G - Id)) < rtol_sp)
+        call check(error, maxval(abs(G - eye(kdim))) < rtol_sp)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the right Krylov basis.
@@ -1212,7 +1191,7 @@ contains
         call innerprod(G, V(1:kdim), V(1:kdim))
 
         ! Check orthonormality of the right basis.
-        call check(error, maxval(abs(G - Id)) < rtol_sp)
+        call check(error, maxval(abs(G - eye(kdim))) < rtol_sp)
 
         return
     end subroutine test_lanczos_bidiag_factorization_rsp
@@ -1237,13 +1216,13 @@ contains
         ! Krylov subspace dimension.
         integer, parameter :: kdim = test_size
         ! Bidiagonal matrix.
-        real(dp) :: B(kdim+1, kdim)
+        real(dp), allocatable :: B(:, :)
         ! Information flag.
         integer :: info
         ! Miscellaneous.
         real(dp) :: alpha
-        real(dp), dimension(test_size, kdim+1) :: Udata, Vdata
-        real(dp), dimension(kdim, kdim) :: G, Id
+        real(dp), allocatable :: Udata(:, :), Vdata(:, :)
+        real(dp), allocatable :: G(:, :)
         type(vector_rdp), allocatable :: X0(:)
 
         ! Initialize linear operator.
@@ -1252,7 +1231,7 @@ contains
         ! Initialize Krylov subspaces.
         allocate(U(1:kdim+1)) ; allocate(V(1:kdim+1)) ; allocate(X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(U, X0)
-        call initialize_krylov_subspace(V) ; B = zero_rdp
+        call zero_basis(V) ; allocate(B(kdim+1, kdim)) ; B = zero_rdp
 
         ! Lanczos bidiagonalization.
         call lanczos_bidiagonalization(A, U, V, B, info, tol=atol_dp)
@@ -1260,20 +1239,19 @@ contains
                         & procedure='test_lanczos_bidiag_factorization_rdp')
 
         ! Check correctness.
-        call get_data(Udata, U)
-        call get_data(Vdata, V)
+        allocate(Udata(test_size, kdim+1)) ; call get_data(Udata, U)
+        allocate(Vdata(test_size, kdim+1)) ; call get_data(Vdata, V)
 
         alpha = maxval(abs(matmul(A%data, Vdata(:, 1:kdim)) - matmul(Udata, B)))
         call check(error, alpha < rtol_dp)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the left Krylov basis.
-        G = zero_rdp
+        allocate(G(kdim, kdim)) ; G = zero_rdp
         call innerprod(G, U(1:kdim), U(1:kdim))
 
         ! Check orthonormality of the left basis.
-        Id = eye(kdim)
-        call check(error, maxval(abs(G - Id)) < rtol_dp)
+        call check(error, maxval(abs(G - eye(kdim))) < rtol_dp)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the right Krylov basis.
@@ -1281,7 +1259,7 @@ contains
         call innerprod(G, V(1:kdim), V(1:kdim))
 
         ! Check orthonormality of the right basis.
-        call check(error, maxval(abs(G - Id)) < rtol_dp)
+        call check(error, maxval(abs(G - eye(kdim))) < rtol_dp)
 
         return
     end subroutine test_lanczos_bidiag_factorization_rdp
@@ -1306,13 +1284,13 @@ contains
         ! Krylov subspace dimension.
         integer, parameter :: kdim = test_size
         ! Bidiagonal matrix.
-        complex(sp) :: B(kdim+1, kdim)
+        complex(sp), allocatable :: B(:, :)
         ! Information flag.
         integer :: info
         ! Miscellaneous.
         real(sp) :: alpha
-        complex(sp), dimension(test_size, kdim+1) :: Udata, Vdata
-        complex(sp), dimension(kdim, kdim) :: G, Id
+        complex(sp), allocatable :: Udata(:, :), Vdata(:, :)
+        complex(sp), allocatable :: G(:, :)
         type(vector_csp), allocatable :: X0(:)
 
         ! Initialize linear operator.
@@ -1321,7 +1299,7 @@ contains
         ! Initialize Krylov subspaces.
         allocate(U(1:kdim+1)) ; allocate(V(1:kdim+1)) ; allocate(X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(U, X0)
-        call initialize_krylov_subspace(V) ; B = zero_csp
+        call zero_basis(V) ; allocate(B(kdim+1, kdim)) ; B = zero_csp
 
         ! Lanczos bidiagonalization.
         call lanczos_bidiagonalization(A, U, V, B, info, tol=atol_sp)
@@ -1329,20 +1307,19 @@ contains
                         & procedure='test_lanczos_bidiag_factorization_csp')
 
         ! Check correctness.
-        call get_data(Udata, U)
-        call get_data(Vdata, V)
+        allocate(Udata(test_size, kdim+1)) ; call get_data(Udata, U)
+        allocate(Vdata(test_size, kdim+1)) ; call get_data(Vdata, V)
 
         alpha = maxval(abs(matmul(A%data, Vdata(:, 1:kdim)) - matmul(Udata, B)))
         call check(error, alpha < rtol_sp)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the left Krylov basis.
-        G = zero_csp
+        allocate(G(kdim, kdim)) ; G = zero_csp
         call innerprod(G, U(1:kdim), U(1:kdim))
 
         ! Check orthonormality of the left basis.
-        Id = eye(kdim)
-        call check(error, maxval(abs(G - Id)) < rtol_sp)
+        call check(error, maxval(abs(G - eye(kdim))) < rtol_sp)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the right Krylov basis.
@@ -1350,7 +1327,7 @@ contains
         call innerprod(G, V(1:kdim), V(1:kdim))
 
         ! Check orthonormality of the right basis.
-        call check(error, maxval(abs(G - Id)) < rtol_sp)
+        call check(error, maxval(abs(G - eye(kdim))) < rtol_sp)
 
         return
     end subroutine test_lanczos_bidiag_factorization_csp
@@ -1375,13 +1352,13 @@ contains
         ! Krylov subspace dimension.
         integer, parameter :: kdim = test_size
         ! Bidiagonal matrix.
-        complex(dp) :: B(kdim+1, kdim)
+        complex(dp), allocatable :: B(:, :)
         ! Information flag.
         integer :: info
         ! Miscellaneous.
         real(dp) :: alpha
-        complex(dp), dimension(test_size, kdim+1) :: Udata, Vdata
-        complex(dp), dimension(kdim, kdim) :: G, Id
+        complex(dp), allocatable :: Udata(:, :), Vdata(:, :)
+        complex(dp), allocatable :: G(:, :)
         type(vector_cdp), allocatable :: X0(:)
 
         ! Initialize linear operator.
@@ -1390,7 +1367,7 @@ contains
         ! Initialize Krylov subspaces.
         allocate(U(1:kdim+1)) ; allocate(V(1:kdim+1)) ; allocate(X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(U, X0)
-        call initialize_krylov_subspace(V) ; B = zero_cdp
+        call zero_basis(V) ; allocate(B(kdim+1, kdim)) ; B = zero_cdp
 
         ! Lanczos bidiagonalization.
         call lanczos_bidiagonalization(A, U, V, B, info, tol=atol_dp)
@@ -1398,20 +1375,19 @@ contains
                         & procedure='test_lanczos_bidiag_factorization_cdp')
 
         ! Check correctness.
-        call get_data(Udata, U)
-        call get_data(Vdata, V)
+        allocate(Udata(test_size, kdim+1)) ; call get_data(Udata, U)
+        allocate(Vdata(test_size, kdim+1)) ; call get_data(Vdata, V)
 
         alpha = maxval(abs(matmul(A%data, Vdata(:, 1:kdim)) - matmul(Udata, B)))
         call check(error, alpha < rtol_dp)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the left Krylov basis.
-        G = zero_cdp
+        allocate(G(kdim, kdim)) ; G = zero_cdp
         call innerprod(G, U(1:kdim), U(1:kdim))
 
         ! Check orthonormality of the left basis.
-        Id = eye(kdim)
-        call check(error, maxval(abs(G - Id)) < rtol_dp)
+        call check(error, maxval(abs(G - eye(kdim))) < rtol_dp)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the right Krylov basis.
@@ -1419,7 +1395,7 @@ contains
         call innerprod(G, V(1:kdim), V(1:kdim))
 
         ! Check orthonormality of the right basis.
-        call check(error, maxval(abs(G - Id)) < rtol_dp)
+        call check(error, maxval(abs(G - eye(kdim))) < rtol_dp)
 
         return
     end subroutine test_lanczos_bidiag_factorization_cdp
@@ -1450,18 +1426,18 @@ contains
         ! Krylov subspace dimension.
         integer, parameter :: kdim = test_size
         ! Tridiagonal matrix.
-        real(sp) :: T(kdim+1, kdim)
+        real(sp), allocatable :: T(:, :)
         ! Information flag.
         integer :: info
 
         ! Internal variables.
-        real(sp) :: Xdata(test_size, kdim+1)
+        real(sp), allocatable :: Xdata(:, :)
         real(sp) :: alpha
         class(vector_rsp), allocatable :: X0(:)
-        real(sp), dimension(kdim, kdim) :: G, Id
+        real(sp), allocatable :: G(:, :)
 
         ! Initialize tridiagonal matrix.
-        T = zero_rsp
+        allocate(T(kdim+1, kdim)) ; T = zero_rsp
 
         ! Initialize operator.
         A = spd_linop_rsp()
@@ -1477,7 +1453,7 @@ contains
                         & procedure='test_lanczos_tridiag_full_factorization_rsp')
 
         ! Check correctness.
-        call get_data(Xdata, X)
+        allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
 
         ! Infinity-norm check.
         alpha = maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, T)))
@@ -1485,12 +1461,11 @@ contains
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the right Krylov basis.
-        G = zero_rsp
+        allocate(G(kdim, kdim)) ; G = zero_rsp
         call innerprod(G, X(1:kdim), X(1:kdim))
 
         ! Check orthonormality of the Krylov basis.
-        Id = eye(kdim)
-        call check(error, maxval(abs(G - Id)) < rtol_sp)
+        call check(error, maxval(abs(G - eye(kdim))) < rtol_sp)
 
         return
     end subroutine test_lanczos_tridiag_factorization_rsp
@@ -1516,18 +1491,18 @@ contains
         ! Krylov subspace dimension.
         integer, parameter :: kdim = test_size
         ! Tridiagonal matrix.
-        real(dp) :: T(kdim+1, kdim)
+        real(dp), allocatable :: T(:, :)
         ! Information flag.
         integer :: info
 
         ! Internal variables.
-        real(dp) :: Xdata(test_size, kdim+1)
+        real(dp), allocatable :: Xdata(:, :)
         real(dp) :: alpha
         class(vector_rdp), allocatable :: X0(:)
-        real(dp), dimension(kdim, kdim) :: G, Id
+        real(dp), allocatable :: G(:, :)
 
         ! Initialize tridiagonal matrix.
-        T = zero_rdp
+        allocate(T(kdim+1, kdim)) ; T = zero_rdp
 
         ! Initialize operator.
         A = spd_linop_rdp()
@@ -1543,7 +1518,7 @@ contains
                         & procedure='test_lanczos_tridiag_full_factorization_rdp')
 
         ! Check correctness.
-        call get_data(Xdata, X)
+        allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
 
         ! Infinity-norm check.
         alpha = maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, T)))
@@ -1551,12 +1526,11 @@ contains
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the right Krylov basis.
-        G = zero_rdp
+        allocate(G(kdim, kdim)) ; G = zero_rdp
         call innerprod(G, X(1:kdim), X(1:kdim))
 
         ! Check orthonormality of the Krylov basis.
-        Id = eye(kdim)
-        call check(error, maxval(abs(G - Id)) < rtol_dp)
+        call check(error, maxval(abs(G - eye(kdim))) < rtol_dp)
 
         return
     end subroutine test_lanczos_tridiag_factorization_rdp
@@ -1582,18 +1556,18 @@ contains
         ! Krylov subspace dimension.
         integer, parameter :: kdim = test_size
         ! Tridiagonal matrix.
-        complex(sp) :: T(kdim+1, kdim)
+        complex(sp), allocatable :: T(:, :)
         ! Information flag.
         integer :: info
 
         ! Internal variables.
-        complex(sp) :: Xdata(test_size, kdim+1)
+        complex(sp), allocatable :: Xdata(:, :)
         real(sp) :: alpha
         class(vector_csp), allocatable :: X0(:)
-        complex(sp), dimension(kdim, kdim) :: G, Id
+        complex(sp), allocatable :: G(:, :)
 
         ! Initialize tridiagonal matrix.
-        T = zero_csp
+        allocate(T(kdim+1, kdim)) ; T = zero_csp
 
         ! Initialize operator.
         A = hermitian_linop_csp()
@@ -1609,7 +1583,7 @@ contains
                         & procedure='test_lanczos_tridiag_full_factorization_csp')
 
         ! Check correctness.
-        call get_data(Xdata, X)
+        allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
 
         ! Infinity-norm check.
         alpha = maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, T)))
@@ -1617,12 +1591,11 @@ contains
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the right Krylov basis.
-        G = zero_csp
+        allocate(G(kdim, kdim)) ; G = zero_csp
         call innerprod(G, X(1:kdim), X(1:kdim))
 
         ! Check orthonormality of the Krylov basis.
-        Id = eye(kdim)
-        call check(error, maxval(abs(G - Id)) < rtol_sp)
+        call check(error, maxval(abs(G - eye(kdim))) < rtol_sp)
 
         return
     end subroutine test_lanczos_tridiag_factorization_csp
@@ -1648,18 +1621,18 @@ contains
         ! Krylov subspace dimension.
         integer, parameter :: kdim = test_size
         ! Tridiagonal matrix.
-        complex(dp) :: T(kdim+1, kdim)
+        complex(dp), allocatable :: T(:, :)
         ! Information flag.
         integer :: info
 
         ! Internal variables.
-        complex(dp) :: Xdata(test_size, kdim+1)
+        complex(dp), allocatable :: Xdata(:, :)
         real(dp) :: alpha
         class(vector_cdp), allocatable :: X0(:)
-        complex(dp), dimension(kdim, kdim) :: G, Id
+        complex(dp), allocatable :: G(:, :)
 
         ! Initialize tridiagonal matrix.
-        T = zero_cdp
+        allocate(T(kdim+1, kdim)) ; T = zero_cdp
 
         ! Initialize operator.
         A = hermitian_linop_cdp()
@@ -1675,7 +1648,7 @@ contains
                         & procedure='test_lanczos_tridiag_full_factorization_cdp')
 
         ! Check correctness.
-        call get_data(Xdata, X)
+        allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
 
         ! Infinity-norm check.
         alpha = maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, T)))
@@ -1683,12 +1656,11 @@ contains
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the right Krylov basis.
-        G = zero_cdp
+        allocate(G(kdim, kdim)) ; G = zero_cdp
         call innerprod(G, X(1:kdim), X(1:kdim))
 
         ! Check orthonormality of the Krylov basis.
-        Id = eye(kdim)
-        call check(error, maxval(abs(G - Id)) < rtol_dp)
+        call check(error, maxval(abs(G - eye(kdim))) < rtol_dp)
 
         return
     end subroutine test_lanczos_tridiag_factorization_cdp

--- a/test/TestKrylov.f90
+++ b/test/TestKrylov.f90
@@ -54,9 +54,8 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-                        new_unittest("QR factorization (correctness & orthonormality)", test_qr_factorization_rsp), &
-                        new_unittest("Pivoting QR for a rank deficient matrix (correctness & orthonormality))",&
-                            & test_pivoting_qr_exact_rank_deficiency_rsp) &
+                        new_unittest("QR factorization", test_qr_factorization_rsp), &
+                        new_unittest("Pivoting QR for a rank deficient matrix", test_pivoting_qr_exact_rank_deficiency_rsp) &
                     ]
         return
     end subroutine collect_qr_rsp_testsuite
@@ -74,6 +73,8 @@ contains
         ! Miscellaneous.
         real(sp), allocatable :: Adata(:, :), Qdata(:, :)
         real(sp), allocatable :: G(:, :)
+        real(sp) :: err
+        character*256 :: msg
 
         ! Initiliaze matrix.
         allocate(A(1:kdim)) ; call init_rand(A)
@@ -89,18 +90,22 @@ contains
         allocate(Qdata(test_size, kdim)) ; call get_data(Qdata, A)
 
         ! Check correctness.
-        call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_sp)
+        err = maxval(abs(Adata - matmul(Qdata, R)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_sp)
         call check_test(error, 'test_qr_factorization_rsp', &
-                        & 'QR factorization not correct: A /= Q @ R')
+                              & info='Factorization', eq='A = Q @ R', context=msg)
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_rsp
         call innerprod(G, A(1:kdim), A(1:kdim))
 
         ! Check orthonormality of the computed basis.
-        call check(error, norm2(abs(G - eye(kdim))) < rtol_sp)
+        err = norm2(abs(G - eye(kdim)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_sp)
         call check_test(error, 'test_qr_factorization_rsp', &
-                        & 'Basis Q not orthonormal: Q.H @ Q /= I')
+                              & info='Basis orthonormality', eq='Q.H @ Q = I', context=msg)
 
         return
     end subroutine test_qr_factorization_rsp
@@ -127,6 +132,8 @@ contains
         logical :: mask(kdim)
         real(sp), allocatable :: Adata(:, :), Qdata(:, :)
         real(sp), allocatable :: G(:, :)
+        real(sp) :: err
+        character*256 :: msg
 
         ! Effective rank.
         rk = kdim - nzero
@@ -158,18 +165,22 @@ contains
         Adata = Adata(:, perm)
 
         ! Check correctness.
-        call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_sp)
+        err = maxval(abs(Adata - matmul(Qdata, R)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_sp)
         call check_test(error, 'test_pivoting_qr_exact_rank_deficiency_rsp', &
-                        & 'QR factorization not correct: A /= Q @ R')
+                              & info='Factorization', eq='A = Q @ R', context=msg)
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_rsp
         call innerprod(G, A(1:kdim), A(1:kdim))
 
         ! Check orthonormality of the computed basis.
-        call check(error, norm2(abs(G - eye(kdim))) < rtol_sp)
+        err = norm2(abs(G - eye(kdim)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_sp)
         call check_test(error, 'test_pivoting_qr_exact_rank_deficiency_rsp', &
-                        & 'Basis Q not orthonormal: Q.H @ Q /= I')
+                              & info='Basis orthonormality', eq='Q.H @ Q = I', context=msg)
 
         return
     end subroutine test_pivoting_qr_exact_rank_deficiency_rsp
@@ -178,9 +189,8 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-                        new_unittest("QR factorization (correctness & orthonormality)", test_qr_factorization_rdp), &
-                        new_unittest("Pivoting QR for a rank deficient matrix (correctness & orthonormality))",&
-                            & test_pivoting_qr_exact_rank_deficiency_rdp) &
+                        new_unittest("QR factorization", test_qr_factorization_rdp), &
+                        new_unittest("Pivoting QR for a rank deficient matrix", test_pivoting_qr_exact_rank_deficiency_rdp) &
                     ]
         return
     end subroutine collect_qr_rdp_testsuite
@@ -198,6 +208,8 @@ contains
         ! Miscellaneous.
         real(dp), allocatable :: Adata(:, :), Qdata(:, :)
         real(dp), allocatable :: G(:, :)
+        real(dp) :: err
+        character*256 :: msg
 
         ! Initiliaze matrix.
         allocate(A(1:kdim)) ; call init_rand(A)
@@ -213,18 +225,22 @@ contains
         allocate(Qdata(test_size, kdim)) ; call get_data(Qdata, A)
 
         ! Check correctness.
-        call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_dp)
+        err = maxval(abs(Adata - matmul(Qdata, R)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_dp)
         call check_test(error, 'test_qr_factorization_rdp', &
-                        & 'QR factorization not correct: A /= Q @ R')
+                              & info='Factorization', eq='A = Q @ R', context=msg)
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_rdp
         call innerprod(G, A(1:kdim), A(1:kdim))
 
         ! Check orthonormality of the computed basis.
-        call check(error, norm2(abs(G - eye(kdim))) < rtol_dp)
+        err = norm2(abs(G - eye(kdim)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_dp)
         call check_test(error, 'test_qr_factorization_rdp', &
-                        & 'Basis Q not orthonormal: Q.H @ Q /= I')
+                              & info='Basis orthonormality', eq='Q.H @ Q = I', context=msg)
 
         return
     end subroutine test_qr_factorization_rdp
@@ -251,6 +267,8 @@ contains
         logical :: mask(kdim)
         real(dp), allocatable :: Adata(:, :), Qdata(:, :)
         real(dp), allocatable :: G(:, :)
+        real(dp) :: err
+        character*256 :: msg
 
         ! Effective rank.
         rk = kdim - nzero
@@ -282,18 +300,22 @@ contains
         Adata = Adata(:, perm)
 
         ! Check correctness.
-        call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_dp)
+        err = maxval(abs(Adata - matmul(Qdata, R)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_dp)
         call check_test(error, 'test_pivoting_qr_exact_rank_deficiency_rdp', &
-                        & 'QR factorization not correct: A /= Q @ R')
+                              & info='Factorization', eq='A = Q @ R', context=msg)
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_rdp
         call innerprod(G, A(1:kdim), A(1:kdim))
 
         ! Check orthonormality of the computed basis.
-        call check(error, norm2(abs(G - eye(kdim))) < rtol_dp)
+        err = norm2(abs(G - eye(kdim)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_dp)
         call check_test(error, 'test_pivoting_qr_exact_rank_deficiency_rdp', &
-                        & 'Basis Q not orthonormal: Q.H @ Q /= I')
+                              & info='Basis orthonormality', eq='Q.H @ Q = I', context=msg)
 
         return
     end subroutine test_pivoting_qr_exact_rank_deficiency_rdp
@@ -302,9 +324,8 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-                        new_unittest("QR factorization (correctness & orthonormality)", test_qr_factorization_csp), &
-                        new_unittest("Pivoting QR for a rank deficient matrix (correctness & orthonormality))",&
-                            & test_pivoting_qr_exact_rank_deficiency_csp) &
+                        new_unittest("QR factorization", test_qr_factorization_csp), &
+                        new_unittest("Pivoting QR for a rank deficient matrix", test_pivoting_qr_exact_rank_deficiency_csp) &
                     ]
         return
     end subroutine collect_qr_csp_testsuite
@@ -322,6 +343,8 @@ contains
         ! Miscellaneous.
         complex(sp), allocatable :: Adata(:, :), Qdata(:, :)
         complex(sp), allocatable :: G(:, :)
+        real(sp) :: err
+        character*256 :: msg
 
         ! Initiliaze matrix.
         allocate(A(1:kdim)) ; call init_rand(A)
@@ -337,18 +360,22 @@ contains
         allocate(Qdata(test_size, kdim)) ; call get_data(Qdata, A)
 
         ! Check correctness.
-        call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_sp)
+        err = maxval(abs(Adata - matmul(Qdata, R)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_sp)
         call check_test(error, 'test_qr_factorization_csp', &
-                        & 'QR factorization not correct: A /= Q @ R')
+                              & info='Factorization', eq='A = Q @ R', context=msg)
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_csp
         call innerprod(G, A(1:kdim), A(1:kdim))
 
         ! Check orthonormality of the computed basis.
-        call check(error, norm2(abs(G - eye(kdim))) < rtol_sp)
+        err = norm2(abs(G - eye(kdim)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_sp)
         call check_test(error, 'test_qr_factorization_csp', &
-                        & 'Basis Q not orthonormal: Q.H @ Q /= I')
+                              & info='Basis orthonormality', eq='Q.H @ Q = I', context=msg)
 
         return
     end subroutine test_qr_factorization_csp
@@ -375,6 +402,8 @@ contains
         logical :: mask(kdim)
         complex(sp), allocatable :: Adata(:, :), Qdata(:, :)
         complex(sp), allocatable :: G(:, :)
+        real(sp) :: err
+        character*256 :: msg
 
         ! Effective rank.
         rk = kdim - nzero
@@ -406,18 +435,22 @@ contains
         Adata = Adata(:, perm)
 
         ! Check correctness.
-        call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_sp)
+        err = maxval(abs(Adata - matmul(Qdata, R)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_sp)
         call check_test(error, 'test_pivoting_qr_exact_rank_deficiency_csp', &
-                        & 'QR factorization not correct: A /= Q @ R')
+                              & info='Factorization', eq='A = Q @ R', context=msg)
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_csp
         call innerprod(G, A(1:kdim), A(1:kdim))
 
         ! Check orthonormality of the computed basis.
-        call check(error, norm2(abs(G - eye(kdim))) < rtol_sp)
+        err = norm2(abs(G - eye(kdim)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_sp)
         call check_test(error, 'test_pivoting_qr_exact_rank_deficiency_csp', &
-                        & 'Basis Q not orthonormal: Q.H @ Q /= I')
+                              & info='Basis orthonormality', eq='Q.H @ Q = I', context=msg)
 
         return
     end subroutine test_pivoting_qr_exact_rank_deficiency_csp
@@ -426,9 +459,8 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-                        new_unittest("QR factorization (correctness & orthonormality)", test_qr_factorization_cdp), &
-                        new_unittest("Pivoting QR for a rank deficient matrix (correctness & orthonormality))",&
-                            & test_pivoting_qr_exact_rank_deficiency_cdp) &
+                        new_unittest("QR factorization", test_qr_factorization_cdp), &
+                        new_unittest("Pivoting QR for a rank deficient matrix", test_pivoting_qr_exact_rank_deficiency_cdp) &
                     ]
         return
     end subroutine collect_qr_cdp_testsuite
@@ -446,6 +478,8 @@ contains
         ! Miscellaneous.
         complex(dp), allocatable :: Adata(:, :), Qdata(:, :)
         complex(dp), allocatable :: G(:, :)
+        real(dp) :: err
+        character*256 :: msg
 
         ! Initiliaze matrix.
         allocate(A(1:kdim)) ; call init_rand(A)
@@ -461,18 +495,22 @@ contains
         allocate(Qdata(test_size, kdim)) ; call get_data(Qdata, A)
 
         ! Check correctness.
-        call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_dp)
+        err = maxval(abs(Adata - matmul(Qdata, R)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_dp)
         call check_test(error, 'test_qr_factorization_cdp', &
-                        & 'QR factorization not correct: A /= Q @ R')
+                              & info='Factorization', eq='A = Q @ R', context=msg)
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_cdp
         call innerprod(G, A(1:kdim), A(1:kdim))
 
         ! Check orthonormality of the computed basis.
-        call check(error, norm2(abs(G - eye(kdim))) < rtol_dp)
+        err = norm2(abs(G - eye(kdim)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_dp)
         call check_test(error, 'test_qr_factorization_cdp', &
-                        & 'Basis Q not orthonormal: Q.H @ Q /= I')
+                              & info='Basis orthonormality', eq='Q.H @ Q = I', context=msg)
 
         return
     end subroutine test_qr_factorization_cdp
@@ -499,6 +537,8 @@ contains
         logical :: mask(kdim)
         complex(dp), allocatable :: Adata(:, :), Qdata(:, :)
         complex(dp), allocatable :: G(:, :)
+        real(dp) :: err
+        character*256 :: msg
 
         ! Effective rank.
         rk = kdim - nzero
@@ -530,18 +570,22 @@ contains
         Adata = Adata(:, perm)
 
         ! Check correctness.
-        call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_dp)
+        err = maxval(abs(Adata - matmul(Qdata, R)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_dp)
         call check_test(error, 'test_pivoting_qr_exact_rank_deficiency_cdp', &
-                        & 'QR factorization not correct: A /= Q @ R')
+                              & info='Factorization', eq='A = Q @ R', context=msg)
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_cdp
         call innerprod(G, A(1:kdim), A(1:kdim))
 
         ! Check orthonormality of the computed basis.
-        call check(error, norm2(abs(G - eye(kdim))) < rtol_dp)
+        err = norm2(abs(G - eye(kdim)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_dp)
         call check_test(error, 'test_pivoting_qr_exact_rank_deficiency_cdp', &
-                        & 'Basis Q not orthonormal: Q.H @ Q /= I')
+                              & info='Basis orthonormality', eq='Q.H @ Q = I', context=msg)
 
         return
     end subroutine test_pivoting_qr_exact_rank_deficiency_cdp
@@ -555,8 +599,8 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-            new_unittest("Arnoldi factorization (correctness & orthonormality)", test_arnoldi_factorization_rsp), &
-            new_unittest("Block Arnoldi factorization (correctness & orthonormality)", test_block_arnoldi_factorization_rsp), &
+            new_unittest("Arnoldi factorization", test_arnoldi_factorization_rsp), &
+            new_unittest("Block Arnoldi factorization", test_block_arnoldi_factorization_rsp), &
             new_unittest("Krylov-Schur factorization", test_krylov_schur_rsp) &
                     ]
         return
@@ -578,6 +622,8 @@ contains
         ! Miscellaneous.
         real(sp), allocatable :: Xdata(:, :)
         real(sp), allocatable :: G(:, :)
+        real(sp) :: err
+        character*256 :: msg
            
         ! Initialize linear operator.
         A = linop_rsp() ; call init_rand(A)
@@ -591,9 +637,11 @@ contains
 
         ! Check correctness of full factorization.
         allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
-        call check(error, maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, H))) < rtol_sp)
+        err = maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, H)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_sp)
         call check_test(error, 'test_arnoldi_factorization_rsp', &
-                        & 'Arnoldi factorization not correct: A @ X[:,1:k] /= X[:,1:k+1] @ H[1:k+1,1:k]')
+                              & info='Factorization', eq='A @ X = X_ @ H_', context=msg)
 
 
         ! Compute Gram matrix associated to the Krylov basis.
@@ -601,9 +649,11 @@ contains
         call innerprod(G, X(1:kdim), X(1:kdim))
 
         ! Check orthonormality of the computed basis.
-        call check(error, maxval(abs(G - eye(kdim))) < rtol_sp)
+        err = maxval(abs(G - eye(kdim)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_sp)
         call check_test(error, 'test_arnoldi_factorization_rsp', &
-                        & 'Basis X not orthonormal: X[:,1:k].H @ X[:,1:k] /= I')
+                              & info='Orthonomality', eq='X.H @ X = I', context=msg)
 
         return
     end subroutine test_arnoldi_factorization_rsp
@@ -625,6 +675,8 @@ contains
         type(vector_rsp), allocatable :: X0(:)
         real(sp), allocatable :: Xdata(:, :)
         real(sp), allocatable :: G(:, :)
+        real(sp) :: err
+        character*256 :: msg
 
         ! Initialize linear operator.
         A = linop_rsp() ; call init_rand(A)
@@ -640,18 +692,22 @@ contains
 
         ! Check correctness of full factorization.
         allocate(Xdata(test_size, p*(kdim+1))) ; call get_data(Xdata, X)
-        call check(error, maxval(abs(matmul(A%data, Xdata(:, 1:p*kdim)) - matmul(Xdata, H))) < rtol_sp)
+        err = maxval(abs(matmul(A%data, Xdata(:, 1:p*kdim)) - matmul(Xdata, H)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_sp)
         call check_test(error, 'test_block_arnoldi_factorization_rsp', &
-                        & 'Arnoldi factorization not correct: A @ X[:,1:p*k] /= X[:,1:p*(k+1)] @ H[1:p*(k+1),1:k]')
+                              & info='Factorization', eq='A @ X = X_ @ H_', context=msg)
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(p*kdim, p*kdim)) ; G = zero_rsp
         call innerprod(G, X(1:p*kdim), X(1:p*kdim))
 
         ! Check orthonormality of the computed basis.
-        call check(error, maxval(abs(G - eye(p*kdim))) < rtol_sp)
+        err = maxval(abs(G - eye(p*kdim)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_sp)
         call check_test(error, 'test_block_arnoldi_factorization_rsp', &
-                        & 'Basis X not orthonormal: X[:,1:k].H @ X[:,1:k] /= I')
+                              & info='Basis orthonormality', eq='X.H @ X = I', context=msg)
 
         return
     end subroutine test_block_arnoldi_factorization_rsp
@@ -673,7 +729,8 @@ contains
         ! Miscellaneous.
         integer :: n
         real(sp), allocatable :: Xdata(:, :)
-        real(sp) :: alpha
+        real(sp) :: err
+        character*256 :: msg
 
         ! Initialize matrix.
         A = linop_rsp() ; call init_rand(A)
@@ -693,10 +750,11 @@ contains
 
         ! Check correctness.
         allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
-        alpha = maxval(abs(matmul(A%data, Xdata(:, :n)) - matmul(Xdata(:, :n+1), H(:n+1, :n))))
-        call check(error, alpha < rtol_sp)
+        err = maxval(abs(matmul(A%data, Xdata(:, :n)) - matmul(Xdata(:, :n+1), H(:n+1, :n))))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_sp)
         call check_test(error, 'test_krylov_schur_rsp', &
-                        & 'Arnoldi factorization not correct: A @ X[:,1:k] /= X[:,1:k+1] @ H[1:k+1,1:k]')
+                              & info='Factorization', eq='A @ X = X_ @ H_', context=msg)
 
         return
     contains
@@ -713,8 +771,8 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-            new_unittest("Arnoldi factorization (correctness & orthonormality)", test_arnoldi_factorization_rdp), &
-            new_unittest("Block Arnoldi factorization (correctness & orthonormality)", test_block_arnoldi_factorization_rdp), &
+            new_unittest("Arnoldi factorization", test_arnoldi_factorization_rdp), &
+            new_unittest("Block Arnoldi factorization", test_block_arnoldi_factorization_rdp), &
             new_unittest("Krylov-Schur factorization", test_krylov_schur_rdp) &
                     ]
         return
@@ -736,6 +794,8 @@ contains
         ! Miscellaneous.
         real(dp), allocatable :: Xdata(:, :)
         real(dp), allocatable :: G(:, :)
+        real(dp) :: err
+        character*256 :: msg
            
         ! Initialize linear operator.
         A = linop_rdp() ; call init_rand(A)
@@ -749,9 +809,11 @@ contains
 
         ! Check correctness of full factorization.
         allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
-        call check(error, maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, H))) < rtol_dp)
+        err = maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, H)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_dp)
         call check_test(error, 'test_arnoldi_factorization_rdp', &
-                        & 'Arnoldi factorization not correct: A @ X[:,1:k] /= X[:,1:k+1] @ H[1:k+1,1:k]')
+                              & info='Factorization', eq='A @ X = X_ @ H_', context=msg)
 
 
         ! Compute Gram matrix associated to the Krylov basis.
@@ -759,9 +821,11 @@ contains
         call innerprod(G, X(1:kdim), X(1:kdim))
 
         ! Check orthonormality of the computed basis.
-        call check(error, maxval(abs(G - eye(kdim))) < rtol_dp)
+        err = maxval(abs(G - eye(kdim)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_dp)
         call check_test(error, 'test_arnoldi_factorization_rdp', &
-                        & 'Basis X not orthonormal: X[:,1:k].H @ X[:,1:k] /= I')
+                              & info='Orthonomality', eq='X.H @ X = I', context=msg)
 
         return
     end subroutine test_arnoldi_factorization_rdp
@@ -783,6 +847,8 @@ contains
         type(vector_rdp), allocatable :: X0(:)
         real(dp), allocatable :: Xdata(:, :)
         real(dp), allocatable :: G(:, :)
+        real(dp) :: err
+        character*256 :: msg
 
         ! Initialize linear operator.
         A = linop_rdp() ; call init_rand(A)
@@ -798,18 +864,22 @@ contains
 
         ! Check correctness of full factorization.
         allocate(Xdata(test_size, p*(kdim+1))) ; call get_data(Xdata, X)
-        call check(error, maxval(abs(matmul(A%data, Xdata(:, 1:p*kdim)) - matmul(Xdata, H))) < rtol_dp)
+        err = maxval(abs(matmul(A%data, Xdata(:, 1:p*kdim)) - matmul(Xdata, H)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_dp)
         call check_test(error, 'test_block_arnoldi_factorization_rdp', &
-                        & 'Arnoldi factorization not correct: A @ X[:,1:p*k] /= X[:,1:p*(k+1)] @ H[1:p*(k+1),1:k]')
+                              & info='Factorization', eq='A @ X = X_ @ H_', context=msg)
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(p*kdim, p*kdim)) ; G = zero_rdp
         call innerprod(G, X(1:p*kdim), X(1:p*kdim))
 
         ! Check orthonormality of the computed basis.
-        call check(error, maxval(abs(G - eye(p*kdim))) < rtol_dp)
+        err = maxval(abs(G - eye(p*kdim)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_dp)
         call check_test(error, 'test_block_arnoldi_factorization_rdp', &
-                        & 'Basis X not orthonormal: X[:,1:k].H @ X[:,1:k] /= I')
+                              & info='Basis orthonormality', eq='X.H @ X = I', context=msg)
 
         return
     end subroutine test_block_arnoldi_factorization_rdp
@@ -831,7 +901,8 @@ contains
         ! Miscellaneous.
         integer :: n
         real(dp), allocatable :: Xdata(:, :)
-        real(dp) :: alpha
+        real(dp) :: err
+        character*256 :: msg
 
         ! Initialize matrix.
         A = linop_rdp() ; call init_rand(A)
@@ -851,10 +922,11 @@ contains
 
         ! Check correctness.
         allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
-        alpha = maxval(abs(matmul(A%data, Xdata(:, :n)) - matmul(Xdata(:, :n+1), H(:n+1, :n))))
-        call check(error, alpha < rtol_dp)
+        err = maxval(abs(matmul(A%data, Xdata(:, :n)) - matmul(Xdata(:, :n+1), H(:n+1, :n))))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_dp)
         call check_test(error, 'test_krylov_schur_rdp', &
-                        & 'Arnoldi factorization not correct: A @ X[:,1:k] /= X[:,1:k+1] @ H[1:k+1,1:k]')
+                              & info='Factorization', eq='A @ X = X_ @ H_', context=msg)
 
         return
     contains
@@ -871,8 +943,8 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-            new_unittest("Arnoldi factorization (correctness & orthonormality)", test_arnoldi_factorization_csp), &
-            new_unittest("Block Arnoldi factorization (correctness & orthonormality)", test_block_arnoldi_factorization_csp), &
+            new_unittest("Arnoldi factorization", test_arnoldi_factorization_csp), &
+            new_unittest("Block Arnoldi factorization", test_block_arnoldi_factorization_csp), &
             new_unittest("Krylov-Schur factorization", test_krylov_schur_csp) &
                     ]
         return
@@ -894,6 +966,8 @@ contains
         ! Miscellaneous.
         complex(sp), allocatable :: Xdata(:, :)
         complex(sp), allocatable :: G(:, :)
+        real(sp) :: err
+        character*256 :: msg
            
         ! Initialize linear operator.
         A = linop_csp() ; call init_rand(A)
@@ -907,9 +981,11 @@ contains
 
         ! Check correctness of full factorization.
         allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
-        call check(error, maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, H))) < rtol_sp)
+        err = maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, H)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_sp)
         call check_test(error, 'test_arnoldi_factorization_csp', &
-                        & 'Arnoldi factorization not correct: A @ X[:,1:k] /= X[:,1:k+1] @ H[1:k+1,1:k]')
+                              & info='Factorization', eq='A @ X = X_ @ H_', context=msg)
 
 
         ! Compute Gram matrix associated to the Krylov basis.
@@ -917,9 +993,11 @@ contains
         call innerprod(G, X(1:kdim), X(1:kdim))
 
         ! Check orthonormality of the computed basis.
-        call check(error, maxval(abs(G - eye(kdim))) < rtol_sp)
+        err = maxval(abs(G - eye(kdim)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_sp)
         call check_test(error, 'test_arnoldi_factorization_csp', &
-                        & 'Basis X not orthonormal: X[:,1:k].H @ X[:,1:k] /= I')
+                              & info='Orthonomality', eq='X.H @ X = I', context=msg)
 
         return
     end subroutine test_arnoldi_factorization_csp
@@ -941,6 +1019,8 @@ contains
         type(vector_csp), allocatable :: X0(:)
         complex(sp), allocatable :: Xdata(:, :)
         complex(sp), allocatable :: G(:, :)
+        real(sp) :: err
+        character*256 :: msg
 
         ! Initialize linear operator.
         A = linop_csp() ; call init_rand(A)
@@ -956,18 +1036,22 @@ contains
 
         ! Check correctness of full factorization.
         allocate(Xdata(test_size, p*(kdim+1))) ; call get_data(Xdata, X)
-        call check(error, maxval(abs(matmul(A%data, Xdata(:, 1:p*kdim)) - matmul(Xdata, H))) < rtol_sp)
+        err = maxval(abs(matmul(A%data, Xdata(:, 1:p*kdim)) - matmul(Xdata, H)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_sp)
         call check_test(error, 'test_block_arnoldi_factorization_csp', &
-                        & 'Arnoldi factorization not correct: A @ X[:,1:p*k] /= X[:,1:p*(k+1)] @ H[1:p*(k+1),1:k]')
+                              & info='Factorization', eq='A @ X = X_ @ H_', context=msg)
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(p*kdim, p*kdim)) ; G = zero_csp
         call innerprod(G, X(1:p*kdim), X(1:p*kdim))
 
         ! Check orthonormality of the computed basis.
-        call check(error, maxval(abs(G - eye(p*kdim))) < rtol_sp)
+        err = maxval(abs(G - eye(p*kdim)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_sp)
         call check_test(error, 'test_block_arnoldi_factorization_csp', &
-                        & 'Basis X not orthonormal: X[:,1:k].H @ X[:,1:k] /= I')
+                              & info='Basis orthonormality', eq='X.H @ X = I', context=msg)
 
         return
     end subroutine test_block_arnoldi_factorization_csp
@@ -989,7 +1073,8 @@ contains
         ! Miscellaneous.
         integer :: n
         complex(sp), allocatable :: Xdata(:, :)
-        real(sp) :: alpha
+        real(sp) :: err
+        character*256 :: msg
 
         ! Initialize matrix.
         A = linop_csp() ; call init_rand(A)
@@ -1009,10 +1094,11 @@ contains
 
         ! Check correctness.
         allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
-        alpha = maxval(abs(matmul(A%data, Xdata(:, :n)) - matmul(Xdata(:, :n+1), H(:n+1, :n))))
-        call check(error, alpha < rtol_sp)
+        err = maxval(abs(matmul(A%data, Xdata(:, :n)) - matmul(Xdata(:, :n+1), H(:n+1, :n))))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_sp)
         call check_test(error, 'test_krylov_schur_csp', &
-                        & 'Arnoldi factorization not correct: A @ X[:,1:k] /= X[:,1:k+1] @ H[1:k+1,1:k]')
+                              & info='Factorization', eq='A @ X = X_ @ H_', context=msg)
 
         return
     contains
@@ -1029,8 +1115,8 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-            new_unittest("Arnoldi factorization (correctness & orthonormality)", test_arnoldi_factorization_cdp), &
-            new_unittest("Block Arnoldi factorization (correctness & orthonormality)", test_block_arnoldi_factorization_cdp), &
+            new_unittest("Arnoldi factorization", test_arnoldi_factorization_cdp), &
+            new_unittest("Block Arnoldi factorization", test_block_arnoldi_factorization_cdp), &
             new_unittest("Krylov-Schur factorization", test_krylov_schur_cdp) &
                     ]
         return
@@ -1052,6 +1138,8 @@ contains
         ! Miscellaneous.
         complex(dp), allocatable :: Xdata(:, :)
         complex(dp), allocatable :: G(:, :)
+        real(dp) :: err
+        character*256 :: msg
            
         ! Initialize linear operator.
         A = linop_cdp() ; call init_rand(A)
@@ -1065,9 +1153,11 @@ contains
 
         ! Check correctness of full factorization.
         allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
-        call check(error, maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, H))) < rtol_dp)
+        err = maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, H)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_dp)
         call check_test(error, 'test_arnoldi_factorization_cdp', &
-                        & 'Arnoldi factorization not correct: A @ X[:,1:k] /= X[:,1:k+1] @ H[1:k+1,1:k]')
+                              & info='Factorization', eq='A @ X = X_ @ H_', context=msg)
 
 
         ! Compute Gram matrix associated to the Krylov basis.
@@ -1075,9 +1165,11 @@ contains
         call innerprod(G, X(1:kdim), X(1:kdim))
 
         ! Check orthonormality of the computed basis.
-        call check(error, maxval(abs(G - eye(kdim))) < rtol_dp)
+        err = maxval(abs(G - eye(kdim)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_dp)
         call check_test(error, 'test_arnoldi_factorization_cdp', &
-                        & 'Basis X not orthonormal: X[:,1:k].H @ X[:,1:k] /= I')
+                              & info='Orthonomality', eq='X.H @ X = I', context=msg)
 
         return
     end subroutine test_arnoldi_factorization_cdp
@@ -1099,6 +1191,8 @@ contains
         type(vector_cdp), allocatable :: X0(:)
         complex(dp), allocatable :: Xdata(:, :)
         complex(dp), allocatable :: G(:, :)
+        real(dp) :: err
+        character*256 :: msg
 
         ! Initialize linear operator.
         A = linop_cdp() ; call init_rand(A)
@@ -1114,18 +1208,22 @@ contains
 
         ! Check correctness of full factorization.
         allocate(Xdata(test_size, p*(kdim+1))) ; call get_data(Xdata, X)
-        call check(error, maxval(abs(matmul(A%data, Xdata(:, 1:p*kdim)) - matmul(Xdata, H))) < rtol_dp)
+        err = maxval(abs(matmul(A%data, Xdata(:, 1:p*kdim)) - matmul(Xdata, H)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_dp)
         call check_test(error, 'test_block_arnoldi_factorization_cdp', &
-                        & 'Arnoldi factorization not correct: A @ X[:,1:p*k] /= X[:,1:p*(k+1)] @ H[1:p*(k+1),1:k]')
+                              & info='Factorization', eq='A @ X = X_ @ H_', context=msg)
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(p*kdim, p*kdim)) ; G = zero_cdp
         call innerprod(G, X(1:p*kdim), X(1:p*kdim))
 
         ! Check orthonormality of the computed basis.
-        call check(error, maxval(abs(G - eye(p*kdim))) < rtol_dp)
+        err = maxval(abs(G - eye(p*kdim)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_dp)
         call check_test(error, 'test_block_arnoldi_factorization_cdp', &
-                        & 'Basis X not orthonormal: X[:,1:k].H @ X[:,1:k] /= I')
+                              & info='Basis orthonormality', eq='X.H @ X = I', context=msg)
 
         return
     end subroutine test_block_arnoldi_factorization_cdp
@@ -1147,7 +1245,8 @@ contains
         ! Miscellaneous.
         integer :: n
         complex(dp), allocatable :: Xdata(:, :)
-        real(dp) :: alpha
+        real(dp) :: err
+        character*256 :: msg
 
         ! Initialize matrix.
         A = linop_cdp() ; call init_rand(A)
@@ -1167,10 +1266,11 @@ contains
 
         ! Check correctness.
         allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
-        alpha = maxval(abs(matmul(A%data, Xdata(:, :n)) - matmul(Xdata(:, :n+1), H(:n+1, :n))))
-        call check(error, alpha < rtol_dp)
+        err = maxval(abs(matmul(A%data, Xdata(:, :n)) - matmul(Xdata(:, :n+1), H(:n+1, :n))))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_dp)
         call check_test(error, 'test_krylov_schur_cdp', &
-                        & 'Arnoldi factorization not correct: A @ X[:,1:k] /= X[:,1:k+1] @ H[1:k+1,1:k]')
+                              & info='Factorization', eq='A @ X = X_ @ H_', context=msg)
 
         return
     contains
@@ -1192,8 +1292,7 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-            new_unittest("Lanczos Bidiagonalization (correctness and left/right orthonormality)",&
-                & test_lanczos_bidiag_factorization_rsp) &
+            new_unittest("Lanczos Bidiagonalization", test_lanczos_bidiag_factorization_rsp) &
                 ]
         return
     end subroutine collect_lanczos_bidiag_rsp_testsuite
@@ -1212,10 +1311,11 @@ contains
         ! Information flag.
         integer :: info
         ! Miscellaneous.
-        real(sp) :: alpha
         real(sp), allocatable :: Udata(:, :), Vdata(:, :)
         real(sp), allocatable :: G(:, :)
         type(vector_rsp), allocatable :: X0(:)
+        real(sp) :: err
+        character*256 :: msg
 
         ! Initialize linear operator.
         A = linop_rsp() ; call init_rand(A)
@@ -1234,28 +1334,33 @@ contains
         allocate(Udata(test_size, kdim+1)) ; call get_data(Udata, U)
         allocate(Vdata(test_size, kdim+1)) ; call get_data(Vdata, V)
 
-        alpha = maxval(abs(matmul(A%data, Vdata(:, 1:kdim)) - matmul(Udata, B)))
-        call check(error, alpha < rtol_sp)
+        err = maxval(abs(matmul(A%data, Vdata(:, 1:kdim)) - matmul(Udata, B)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_sp)
         call check_test(error, 'test_lanczos_bidiag_factorization_rsp', &
-                              & 'Bidiagonal Lanczos factorization not correct: A @ V[:,1:k] /= U[:,1:k+1] @ B[1:k+1,1:k]')
+                              & info='Factorization', eq='A @ V = U_ @ B_', context=msg)
 
         ! Compute Gram matrix associated to the left Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_rsp
         call innerprod(G, U(1:kdim), U(1:kdim))
 
         ! Check orthonormality of the left basis.
-        call check(error, maxval(abs(G - eye(kdim))) < rtol_sp)
+        err = maxval(abs(G - eye(kdim)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_sp)
         call check_test(error, 'test_lanczos_bidiag_factorization_rsp', &
-                              & 'Left basis U not orthonormal: U[:,1:k].H @ U[:,1:k] /= I')
+                              & info='Basis orthonormality (left)', eq='U.H @ U = I', context=msg)
 
         ! Compute Gram matrix associated to the right Krylov basis.
         G = zero_rsp
         call innerprod(G, V(1:kdim), V(1:kdim))
 
         ! Check orthonormality of the right basis.
-        call check(error, maxval(abs(G - eye(kdim))) < rtol_sp)
+        err = maxval(abs(G - eye(kdim)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_sp)
         call check_test(error, 'test_lanczos_bidiag_factorization_rsp', &
-                              & 'Right basis V not orthonormal: V[:,1:k].H @ V[:,1:k] /= I')
+                              & info='Basis orthonormality (right)', eq='V.H @ V = I', context=msg)
 
         return
     end subroutine test_lanczos_bidiag_factorization_rsp
@@ -1264,8 +1369,7 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-            new_unittest("Lanczos Bidiagonalization (correctness and left/right orthonormality)",&
-                & test_lanczos_bidiag_factorization_rdp) &
+            new_unittest("Lanczos Bidiagonalization", test_lanczos_bidiag_factorization_rdp) &
                 ]
         return
     end subroutine collect_lanczos_bidiag_rdp_testsuite
@@ -1284,10 +1388,11 @@ contains
         ! Information flag.
         integer :: info
         ! Miscellaneous.
-        real(dp) :: alpha
         real(dp), allocatable :: Udata(:, :), Vdata(:, :)
         real(dp), allocatable :: G(:, :)
         type(vector_rdp), allocatable :: X0(:)
+        real(dp) :: err
+        character*256 :: msg
 
         ! Initialize linear operator.
         A = linop_rdp() ; call init_rand(A)
@@ -1306,28 +1411,33 @@ contains
         allocate(Udata(test_size, kdim+1)) ; call get_data(Udata, U)
         allocate(Vdata(test_size, kdim+1)) ; call get_data(Vdata, V)
 
-        alpha = maxval(abs(matmul(A%data, Vdata(:, 1:kdim)) - matmul(Udata, B)))
-        call check(error, alpha < rtol_dp)
+        err = maxval(abs(matmul(A%data, Vdata(:, 1:kdim)) - matmul(Udata, B)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_dp)
         call check_test(error, 'test_lanczos_bidiag_factorization_rdp', &
-                              & 'Bidiagonal Lanczos factorization not correct: A @ V[:,1:k] /= U[:,1:k+1] @ B[1:k+1,1:k]')
+                              & info='Factorization', eq='A @ V = U_ @ B_', context=msg)
 
         ! Compute Gram matrix associated to the left Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_rdp
         call innerprod(G, U(1:kdim), U(1:kdim))
 
         ! Check orthonormality of the left basis.
-        call check(error, maxval(abs(G - eye(kdim))) < rtol_dp)
+        err = maxval(abs(G - eye(kdim)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_dp)
         call check_test(error, 'test_lanczos_bidiag_factorization_rdp', &
-                              & 'Left basis U not orthonormal: U[:,1:k].H @ U[:,1:k] /= I')
+                              & info='Basis orthonormality (left)', eq='U.H @ U = I', context=msg)
 
         ! Compute Gram matrix associated to the right Krylov basis.
         G = zero_rdp
         call innerprod(G, V(1:kdim), V(1:kdim))
 
         ! Check orthonormality of the right basis.
-        call check(error, maxval(abs(G - eye(kdim))) < rtol_dp)
+        err = maxval(abs(G - eye(kdim)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_dp)
         call check_test(error, 'test_lanczos_bidiag_factorization_rdp', &
-                              & 'Right basis V not orthonormal: V[:,1:k].H @ V[:,1:k] /= I')
+                              & info='Basis orthonormality (right)', eq='V.H @ V = I', context=msg)
 
         return
     end subroutine test_lanczos_bidiag_factorization_rdp
@@ -1336,8 +1446,7 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-            new_unittest("Lanczos Bidiagonalization (correctness and left/right orthonormality)",&
-                & test_lanczos_bidiag_factorization_csp) &
+            new_unittest("Lanczos Bidiagonalization", test_lanczos_bidiag_factorization_csp) &
                 ]
         return
     end subroutine collect_lanczos_bidiag_csp_testsuite
@@ -1356,10 +1465,11 @@ contains
         ! Information flag.
         integer :: info
         ! Miscellaneous.
-        real(sp) :: alpha
         complex(sp), allocatable :: Udata(:, :), Vdata(:, :)
         complex(sp), allocatable :: G(:, :)
         type(vector_csp), allocatable :: X0(:)
+        real(sp) :: err
+        character*256 :: msg
 
         ! Initialize linear operator.
         A = linop_csp() ; call init_rand(A)
@@ -1378,28 +1488,33 @@ contains
         allocate(Udata(test_size, kdim+1)) ; call get_data(Udata, U)
         allocate(Vdata(test_size, kdim+1)) ; call get_data(Vdata, V)
 
-        alpha = maxval(abs(matmul(A%data, Vdata(:, 1:kdim)) - matmul(Udata, B)))
-        call check(error, alpha < rtol_sp)
+        err = maxval(abs(matmul(A%data, Vdata(:, 1:kdim)) - matmul(Udata, B)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_sp)
         call check_test(error, 'test_lanczos_bidiag_factorization_csp', &
-                              & 'Bidiagonal Lanczos factorization not correct: A @ V[:,1:k] /= U[:,1:k+1] @ B[1:k+1,1:k]')
+                              & info='Factorization', eq='A @ V = U_ @ B_', context=msg)
 
         ! Compute Gram matrix associated to the left Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_csp
         call innerprod(G, U(1:kdim), U(1:kdim))
 
         ! Check orthonormality of the left basis.
-        call check(error, maxval(abs(G - eye(kdim))) < rtol_sp)
+        err = maxval(abs(G - eye(kdim)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_sp)
         call check_test(error, 'test_lanczos_bidiag_factorization_csp', &
-                              & 'Left basis U not orthonormal: U[:,1:k].H @ U[:,1:k] /= I')
+                              & info='Basis orthonormality (left)', eq='U.H @ U = I', context=msg)
 
         ! Compute Gram matrix associated to the right Krylov basis.
         G = zero_csp
         call innerprod(G, V(1:kdim), V(1:kdim))
 
         ! Check orthonormality of the right basis.
-        call check(error, maxval(abs(G - eye(kdim))) < rtol_sp)
+        err = maxval(abs(G - eye(kdim)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_sp)
         call check_test(error, 'test_lanczos_bidiag_factorization_csp', &
-                              & 'Right basis V not orthonormal: V[:,1:k].H @ V[:,1:k] /= I')
+                              & info='Basis orthonormality (right)', eq='V.H @ V = I', context=msg)
 
         return
     end subroutine test_lanczos_bidiag_factorization_csp
@@ -1408,8 +1523,7 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-            new_unittest("Lanczos Bidiagonalization (correctness and left/right orthonormality)",&
-                & test_lanczos_bidiag_factorization_cdp) &
+            new_unittest("Lanczos Bidiagonalization", test_lanczos_bidiag_factorization_cdp) &
                 ]
         return
     end subroutine collect_lanczos_bidiag_cdp_testsuite
@@ -1428,10 +1542,11 @@ contains
         ! Information flag.
         integer :: info
         ! Miscellaneous.
-        real(dp) :: alpha
         complex(dp), allocatable :: Udata(:, :), Vdata(:, :)
         complex(dp), allocatable :: G(:, :)
         type(vector_cdp), allocatable :: X0(:)
+        real(dp) :: err
+        character*256 :: msg
 
         ! Initialize linear operator.
         A = linop_cdp() ; call init_rand(A)
@@ -1450,28 +1565,33 @@ contains
         allocate(Udata(test_size, kdim+1)) ; call get_data(Udata, U)
         allocate(Vdata(test_size, kdim+1)) ; call get_data(Vdata, V)
 
-        alpha = maxval(abs(matmul(A%data, Vdata(:, 1:kdim)) - matmul(Udata, B)))
-        call check(error, alpha < rtol_dp)
+        err = maxval(abs(matmul(A%data, Vdata(:, 1:kdim)) - matmul(Udata, B)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_dp)
         call check_test(error, 'test_lanczos_bidiag_factorization_cdp', &
-                              & 'Bidiagonal Lanczos factorization not correct: A @ V[:,1:k] /= U[:,1:k+1] @ B[1:k+1,1:k]')
+                              & info='Factorization', eq='A @ V = U_ @ B_', context=msg)
 
         ! Compute Gram matrix associated to the left Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_cdp
         call innerprod(G, U(1:kdim), U(1:kdim))
 
         ! Check orthonormality of the left basis.
-        call check(error, maxval(abs(G - eye(kdim))) < rtol_dp)
+        err = maxval(abs(G - eye(kdim)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_dp)
         call check_test(error, 'test_lanczos_bidiag_factorization_cdp', &
-                              & 'Left basis U not orthonormal: U[:,1:k].H @ U[:,1:k] /= I')
+                              & info='Basis orthonormality (left)', eq='U.H @ U = I', context=msg)
 
         ! Compute Gram matrix associated to the right Krylov basis.
         G = zero_cdp
         call innerprod(G, V(1:kdim), V(1:kdim))
 
         ! Check orthonormality of the right basis.
-        call check(error, maxval(abs(G - eye(kdim))) < rtol_dp)
+        err = maxval(abs(G - eye(kdim)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_dp)
         call check_test(error, 'test_lanczos_bidiag_factorization_cdp', &
-                              & 'Right basis V not orthonormal: V[:,1:k].H @ V[:,1:k] /= I')
+                              & info='Basis orthonormality (right)', eq='V.H @ V = I', context=msg)
 
         return
     end subroutine test_lanczos_bidiag_factorization_cdp
@@ -1486,7 +1606,7 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-             new_unittest("Lanczos Tridiagonalization (correctness & orthonormality)", test_lanczos_tridiag_factorization_rsp) &
+             new_unittest("Lanczos Tridiagonalization", test_lanczos_tridiag_factorization_rsp) &
             ]
 
         return
@@ -1508,9 +1628,10 @@ contains
 
         ! Internal variables.
         real(sp), allocatable :: Xdata(:, :)
-        real(sp) :: alpha
         class(vector_rsp), allocatable :: X0(:)
         real(sp), allocatable :: G(:, :)
+        real(sp) :: err
+        character*256 :: msg
 
         ! Initialize tridiagonal matrix.
         allocate(T(kdim+1, kdim)) ; T = zero_rsp
@@ -1532,19 +1653,22 @@ contains
         allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
 
         ! Infinity-norm check.
-        alpha = maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, T)))
-        call check(error, alpha < rtol_sp)
+        err = maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, T)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_sp)
         call check_test(error, 'test_lanczos_tridiag_factorization_rsp', &
-                                 & 'Tridiagonal Lanczos factorization not correct: A @ X[:,1:k] /= X[:,1:k+1] @ T[1:k+1,1:k]')
+                                 & info='Factorization', eq='A @ X = X_ @ T_', context=msg)
 
         ! Compute Gram matrix associated to the right Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_rsp
         call innerprod(G, X(1:kdim), X(1:kdim))
 
         ! Check orthonormality of the Krylov basis.
-        call check(error, maxval(abs(G - eye(kdim))) < rtol_sp)
+        err = maxval(abs(G - eye(kdim)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_sp)
         call check_test(error, 'test_lanczos_tridiag_factorization_rsp', &
-                                 & 'Basis X not orthonormal: X[:,1:k].H @ X[:,1:k] /= I')
+                                 & info='Orthonomality', eq='X.H @ X = I', context=msg)
 
         return
     end subroutine test_lanczos_tridiag_factorization_rsp
@@ -1554,7 +1678,7 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-             new_unittest("Lanczos Tridiagonalization (correctness & orthonormality)", test_lanczos_tridiag_factorization_rdp) &
+             new_unittest("Lanczos Tridiagonalization", test_lanczos_tridiag_factorization_rdp) &
             ]
 
         return
@@ -1576,9 +1700,10 @@ contains
 
         ! Internal variables.
         real(dp), allocatable :: Xdata(:, :)
-        real(dp) :: alpha
         class(vector_rdp), allocatable :: X0(:)
         real(dp), allocatable :: G(:, :)
+        real(dp) :: err
+        character*256 :: msg
 
         ! Initialize tridiagonal matrix.
         allocate(T(kdim+1, kdim)) ; T = zero_rdp
@@ -1600,19 +1725,22 @@ contains
         allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
 
         ! Infinity-norm check.
-        alpha = maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, T)))
-        call check(error, alpha < rtol_dp)
+        err = maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, T)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_dp)
         call check_test(error, 'test_lanczos_tridiag_factorization_rdp', &
-                                 & 'Tridiagonal Lanczos factorization not correct: A @ X[:,1:k] /= X[:,1:k+1] @ T[1:k+1,1:k]')
+                                 & info='Factorization', eq='A @ X = X_ @ T_', context=msg)
 
         ! Compute Gram matrix associated to the right Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_rdp
         call innerprod(G, X(1:kdim), X(1:kdim))
 
         ! Check orthonormality of the Krylov basis.
-        call check(error, maxval(abs(G - eye(kdim))) < rtol_dp)
+        err = maxval(abs(G - eye(kdim)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_dp)
         call check_test(error, 'test_lanczos_tridiag_factorization_rdp', &
-                                 & 'Basis X not orthonormal: X[:,1:k].H @ X[:,1:k] /= I')
+                                 & info='Orthonomality', eq='X.H @ X = I', context=msg)
 
         return
     end subroutine test_lanczos_tridiag_factorization_rdp
@@ -1622,7 +1750,7 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-             new_unittest("Lanczos Tridiagonalization (correctness & orthonormality)", test_lanczos_tridiag_factorization_csp) &
+             new_unittest("Lanczos Tridiagonalization", test_lanczos_tridiag_factorization_csp) &
             ]
 
         return
@@ -1644,9 +1772,10 @@ contains
 
         ! Internal variables.
         complex(sp), allocatable :: Xdata(:, :)
-        real(sp) :: alpha
         class(vector_csp), allocatable :: X0(:)
         complex(sp), allocatable :: G(:, :)
+        real(sp) :: err
+        character*256 :: msg
 
         ! Initialize tridiagonal matrix.
         allocate(T(kdim+1, kdim)) ; T = zero_csp
@@ -1668,19 +1797,22 @@ contains
         allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
 
         ! Infinity-norm check.
-        alpha = maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, T)))
-        call check(error, alpha < rtol_sp)
+        err = maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, T)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_sp)
         call check_test(error, 'test_lanczos_tridiag_factorization_csp', &
-                                 & 'Tridiagonal Lanczos factorization not correct: A @ X[:,1:k] /= X[:,1:k+1] @ T[1:k+1,1:k]')
+                                 & info='Factorization', eq='A @ X = X_ @ T_', context=msg)
 
         ! Compute Gram matrix associated to the right Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_csp
         call innerprod(G, X(1:kdim), X(1:kdim))
 
         ! Check orthonormality of the Krylov basis.
-        call check(error, maxval(abs(G - eye(kdim))) < rtol_sp)
+        err = maxval(abs(G - eye(kdim)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_sp)
         call check_test(error, 'test_lanczos_tridiag_factorization_csp', &
-                                 & 'Basis X not orthonormal: X[:,1:k].H @ X[:,1:k] /= I')
+                                 & info='Orthonomality', eq='X.H @ X = I', context=msg)
 
         return
     end subroutine test_lanczos_tridiag_factorization_csp
@@ -1690,7 +1822,7 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-             new_unittest("Lanczos Tridiagonalization (correctness & orthonormality)", test_lanczos_tridiag_factorization_cdp) &
+             new_unittest("Lanczos Tridiagonalization", test_lanczos_tridiag_factorization_cdp) &
             ]
 
         return
@@ -1712,9 +1844,10 @@ contains
 
         ! Internal variables.
         complex(dp), allocatable :: Xdata(:, :)
-        real(dp) :: alpha
         class(vector_cdp), allocatable :: X0(:)
         complex(dp), allocatable :: G(:, :)
+        real(dp) :: err
+        character*256 :: msg
 
         ! Initialize tridiagonal matrix.
         allocate(T(kdim+1, kdim)) ; T = zero_cdp
@@ -1736,19 +1869,22 @@ contains
         allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
 
         ! Infinity-norm check.
-        alpha = maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, T)))
-        call check(error, alpha < rtol_dp)
+        err = maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, T)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_dp)
         call check_test(error, 'test_lanczos_tridiag_factorization_cdp', &
-                                 & 'Tridiagonal Lanczos factorization not correct: A @ X[:,1:k] /= X[:,1:k+1] @ T[1:k+1,1:k]')
+                                 & info='Factorization', eq='A @ X = X_ @ T_', context=msg)
 
         ! Compute Gram matrix associated to the right Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_cdp
         call innerprod(G, X(1:kdim), X(1:kdim))
 
         ! Check orthonormality of the Krylov basis.
-        call check(error, maxval(abs(G - eye(kdim))) < rtol_dp)
+        err = maxval(abs(G - eye(kdim)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_dp)
         call check_test(error, 'test_lanczos_tridiag_factorization_cdp', &
-                                 & 'Basis X not orthonormal: X[:,1:k].H @ X[:,1:k] /= I')
+                                 & info='Orthonomality', eq='X.H @ X = I', context=msg)
 
         return
     end subroutine test_lanczos_tridiag_factorization_cdp

--- a/test/TestKrylov.f90
+++ b/test/TestKrylov.f90
@@ -90,7 +90,8 @@ contains
 
         ! Check correctness.
         call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_sp)
-        if (allocated(error)) return
+        call check_test(error, 'test_qr_factorization_rsp', &
+                        & 'QR factorization not correct: A /= Q @ R')
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_rsp
@@ -98,6 +99,9 @@ contains
 
         ! Check orthonormality of the computed basis.
         call check(error, norm2(abs(G - eye(kdim))) < rtol_sp)
+        call check(error, norm2(abs(G - Id)) < rtol_sp)
+        call check_test(error, 'test_qr_factorization_rsp', &
+                        & 'Basis Q not orthonormal: Q.H @ Q /= I')
 
         return
     end subroutine test_qr_factorization_rsp
@@ -156,7 +160,8 @@ contains
 
         ! Check correctness.
         call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_sp)
-        if (allocated(error)) return
+        call check_test(error, 'test_pivoting_qr_exact_rank_deficiency_rsp', &
+                        & 'QR factorization not correct: A /= Q @ R')
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_rsp
@@ -208,7 +213,8 @@ contains
 
         ! Check correctness.
         call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_dp)
-        if (allocated(error)) return
+        call check_test(error, 'test_qr_factorization_rdp', &
+                        & 'QR factorization not correct: A /= Q @ R')
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_rdp
@@ -274,7 +280,8 @@ contains
 
         ! Check correctness.
         call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_dp)
-        if (allocated(error)) return
+        call check_test(error, 'test_pivoting_qr_exact_rank_deficiency_rdp', &
+                        & 'QR factorization not correct: A /= Q @ R')
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_rdp
@@ -326,7 +333,8 @@ contains
 
         ! Check correctness.
         call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_sp)
-        if (allocated(error)) return
+        call check_test(error, 'test_qr_factorization_csp', &
+                        & 'QR factorization not correct: A /= Q @ R')
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_csp
@@ -392,7 +400,8 @@ contains
 
         ! Check correctness.
         call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_sp)
-        if (allocated(error)) return
+        call check_test(error, 'test_pivoting_qr_exact_rank_deficiency_csp', &
+                        & 'QR factorization not correct: A /= Q @ R')
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_csp
@@ -444,7 +453,8 @@ contains
 
         ! Check correctness.
         call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_dp)
-        if (allocated(error)) return
+        call check_test(error, 'test_qr_factorization_cdp', &
+                        & 'QR factorization not correct: A /= Q @ R')
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_cdp
@@ -510,7 +520,8 @@ contains
 
         ! Check correctness.
         call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_dp)
-        if (allocated(error)) return
+        call check_test(error, 'test_pivoting_qr_exact_rank_deficiency_cdp', &
+                        & 'QR factorization not correct: A /= Q @ R')
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_cdp
@@ -568,7 +579,9 @@ contains
         ! Check correctness of full factorization.
         allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
         call check(error, maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, H))) < rtol_sp)
-        if (allocated(error)) return
+        call check_test(error, 'test_arnoldi_factorization_rsp', &
+                        & 'Arnoldi factorization not correct: A @ X[:,1:k] /= X[:,1:k+1] @ H[1:k+1,1:k]')
+
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_rsp
@@ -613,7 +626,8 @@ contains
         ! Check correctness of full factorization.
         allocate(Xdata(test_size, p*(kdim+1))) ; call get_data(Xdata, X)
         call check(error, maxval(abs(matmul(A%data, Xdata(:, 1:p*kdim)) - matmul(Xdata, H))) < rtol_sp)
-        if (allocated(error)) return
+        call check_test(error, 'test_block_arnoldi_factorization_rsp', &
+                        & 'Arnoldi factorization not correct: A @ X[:,1:p*k] /= X[:,1:p*(k+1)] @ H[1:p*(k+1),1:k]')
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(p*kdim, p*kdim)) ; G = zero_rsp
@@ -664,6 +678,8 @@ contains
         allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
         alpha = maxval(abs(matmul(A%data, Xdata(:, :n)) - matmul(Xdata(:, :n+1), H(:n+1, :n))))
         call check(error, alpha < rtol_sp)
+        call check_test(error, 'test_krylov_schur_rsp', &
+                        & 'Arnoldi factorization not correct: A @ X[:,1:k] /= X[:,1:k+1] @ H[1:k+1,1:k]')
 
         return
     contains
@@ -717,7 +733,9 @@ contains
         ! Check correctness of full factorization.
         allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
         call check(error, maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, H))) < rtol_dp)
-        if (allocated(error)) return
+        call check_test(error, 'test_arnoldi_factorization_rdp', &
+                        & 'Arnoldi factorization not correct: A @ X[:,1:k] /= X[:,1:k+1] @ H[1:k+1,1:k]')
+
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_rdp
@@ -762,7 +780,8 @@ contains
         ! Check correctness of full factorization.
         allocate(Xdata(test_size, p*(kdim+1))) ; call get_data(Xdata, X)
         call check(error, maxval(abs(matmul(A%data, Xdata(:, 1:p*kdim)) - matmul(Xdata, H))) < rtol_dp)
-        if (allocated(error)) return
+        call check_test(error, 'test_block_arnoldi_factorization_rdp', &
+                        & 'Arnoldi factorization not correct: A @ X[:,1:p*k] /= X[:,1:p*(k+1)] @ H[1:p*(k+1),1:k]')
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(p*kdim, p*kdim)) ; G = zero_rdp
@@ -813,6 +832,8 @@ contains
         allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
         alpha = maxval(abs(matmul(A%data, Xdata(:, :n)) - matmul(Xdata(:, :n+1), H(:n+1, :n))))
         call check(error, alpha < rtol_dp)
+        call check_test(error, 'test_krylov_schur_rdp', &
+                        & 'Arnoldi factorization not correct: A @ X[:,1:k] /= X[:,1:k+1] @ H[1:k+1,1:k]')
 
         return
     contains
@@ -866,7 +887,9 @@ contains
         ! Check correctness of full factorization.
         allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
         call check(error, maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, H))) < rtol_sp)
-        if (allocated(error)) return
+        call check_test(error, 'test_arnoldi_factorization_csp', &
+                        & 'Arnoldi factorization not correct: A @ X[:,1:k] /= X[:,1:k+1] @ H[1:k+1,1:k]')
+
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_csp
@@ -911,7 +934,8 @@ contains
         ! Check correctness of full factorization.
         allocate(Xdata(test_size, p*(kdim+1))) ; call get_data(Xdata, X)
         call check(error, maxval(abs(matmul(A%data, Xdata(:, 1:p*kdim)) - matmul(Xdata, H))) < rtol_sp)
-        if (allocated(error)) return
+        call check_test(error, 'test_block_arnoldi_factorization_csp', &
+                        & 'Arnoldi factorization not correct: A @ X[:,1:p*k] /= X[:,1:p*(k+1)] @ H[1:p*(k+1),1:k]')
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(p*kdim, p*kdim)) ; G = zero_csp
@@ -962,6 +986,8 @@ contains
         allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
         alpha = maxval(abs(matmul(A%data, Xdata(:, :n)) - matmul(Xdata(:, :n+1), H(:n+1, :n))))
         call check(error, alpha < rtol_sp)
+        call check_test(error, 'test_krylov_schur_csp', &
+                        & 'Arnoldi factorization not correct: A @ X[:,1:k] /= X[:,1:k+1] @ H[1:k+1,1:k]')
 
         return
     contains
@@ -1015,7 +1041,9 @@ contains
         ! Check correctness of full factorization.
         allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
         call check(error, maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, H))) < rtol_dp)
-        if (allocated(error)) return
+        call check_test(error, 'test_arnoldi_factorization_cdp', &
+                        & 'Arnoldi factorization not correct: A @ X[:,1:k] /= X[:,1:k+1] @ H[1:k+1,1:k]')
+
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_cdp
@@ -1060,7 +1088,8 @@ contains
         ! Check correctness of full factorization.
         allocate(Xdata(test_size, p*(kdim+1))) ; call get_data(Xdata, X)
         call check(error, maxval(abs(matmul(A%data, Xdata(:, 1:p*kdim)) - matmul(Xdata, H))) < rtol_dp)
-        if (allocated(error)) return
+        call check_test(error, 'test_block_arnoldi_factorization_cdp', &
+                        & 'Arnoldi factorization not correct: A @ X[:,1:p*k] /= X[:,1:p*(k+1)] @ H[1:p*(k+1),1:k]')
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(p*kdim, p*kdim)) ; G = zero_cdp
@@ -1111,6 +1140,8 @@ contains
         allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
         alpha = maxval(abs(matmul(A%data, Xdata(:, :n)) - matmul(Xdata(:, :n+1), H(:n+1, :n))))
         call check(error, alpha < rtol_dp)
+        call check_test(error, 'test_krylov_schur_cdp', &
+                        & 'Arnoldi factorization not correct: A @ X[:,1:k] /= X[:,1:k+1] @ H[1:k+1,1:k]')
 
         return
     contains
@@ -1176,7 +1207,8 @@ contains
 
         alpha = maxval(abs(matmul(A%data, Vdata(:, 1:kdim)) - matmul(Udata, B)))
         call check(error, alpha < rtol_sp)
-        if (allocated(error)) return
+        call check_test(error, 'test_lanczos_bidiag_factorization_rsp', &
+                              & 'Bidiagonal Lanczos factorization not correct: A @ V[:,1:k] /= U[:,1:k+1] @ B[1:k+1,1:k]')
 
         ! Compute Gram matrix associated to the left Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_rsp
@@ -1244,7 +1276,8 @@ contains
 
         alpha = maxval(abs(matmul(A%data, Vdata(:, 1:kdim)) - matmul(Udata, B)))
         call check(error, alpha < rtol_dp)
-        if (allocated(error)) return
+        call check_test(error, 'test_lanczos_bidiag_factorization_rdp', &
+                              & 'Bidiagonal Lanczos factorization not correct: A @ V[:,1:k] /= U[:,1:k+1] @ B[1:k+1,1:k]')
 
         ! Compute Gram matrix associated to the left Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_rdp
@@ -1312,7 +1345,8 @@ contains
 
         alpha = maxval(abs(matmul(A%data, Vdata(:, 1:kdim)) - matmul(Udata, B)))
         call check(error, alpha < rtol_sp)
-        if (allocated(error)) return
+        call check_test(error, 'test_lanczos_bidiag_factorization_csp', &
+                              & 'Bidiagonal Lanczos factorization not correct: A @ V[:,1:k] /= U[:,1:k+1] @ B[1:k+1,1:k]')
 
         ! Compute Gram matrix associated to the left Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_csp
@@ -1380,7 +1414,8 @@ contains
 
         alpha = maxval(abs(matmul(A%data, Vdata(:, 1:kdim)) - matmul(Udata, B)))
         call check(error, alpha < rtol_dp)
-        if (allocated(error)) return
+        call check_test(error, 'test_lanczos_bidiag_factorization_cdp', &
+                              & 'Bidiagonal Lanczos factorization not correct: A @ V[:,1:k] /= U[:,1:k+1] @ B[1:k+1,1:k]')
 
         ! Compute Gram matrix associated to the left Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_cdp
@@ -1450,7 +1485,7 @@ contains
         ! Lanczos factorization.
         call lanczos_tridiagonalization(A, X, T, info, tol=atol_sp)
         call check_info(info, 'lanczos_tridiagonalization', module=this_module, & 
-                        & procedure='test_lanczos_tridiag_full_factorization_rsp')
+                        & procedure='test_lanczos_tridiag_factorization_rsp')
 
         ! Check correctness.
         allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
@@ -1458,7 +1493,8 @@ contains
         ! Infinity-norm check.
         alpha = maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, T)))
         call check(error, alpha < rtol_sp)
-        if (allocated(error)) return
+        call check_test(error, 'test_lanczos_tridiag_factorization_rsp', &
+                                 & 'Tridiagonal Lanczos factorization not correct: A @ X[:,1:k] /= X[:,1:k+1] @ T[1:k+1,1:k]')
 
         ! Compute Gram matrix associated to the right Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_rsp
@@ -1515,7 +1551,7 @@ contains
         ! Lanczos factorization.
         call lanczos_tridiagonalization(A, X, T, info, tol=atol_dp)
         call check_info(info, 'lanczos_tridiagonalization', module=this_module, & 
-                        & procedure='test_lanczos_tridiag_full_factorization_rdp')
+                        & procedure='test_lanczos_tridiag_factorization_rdp')
 
         ! Check correctness.
         allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
@@ -1523,7 +1559,8 @@ contains
         ! Infinity-norm check.
         alpha = maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, T)))
         call check(error, alpha < rtol_dp)
-        if (allocated(error)) return
+        call check_test(error, 'test_lanczos_tridiag_factorization_rdp', &
+                                 & 'Tridiagonal Lanczos factorization not correct: A @ X[:,1:k] /= X[:,1:k+1] @ T[1:k+1,1:k]')
 
         ! Compute Gram matrix associated to the right Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_rdp
@@ -1580,7 +1617,7 @@ contains
         ! Lanczos factorization.
         call lanczos_tridiagonalization(A, X, T, info, tol=atol_sp)
         call check_info(info, 'lanczos_tridiagonalization', module=this_module, & 
-                        & procedure='test_lanczos_tridiag_full_factorization_csp')
+                        & procedure='test_lanczos_tridiag_factorization_csp')
 
         ! Check correctness.
         allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
@@ -1588,7 +1625,8 @@ contains
         ! Infinity-norm check.
         alpha = maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, T)))
         call check(error, alpha < rtol_sp)
-        if (allocated(error)) return
+        call check_test(error, 'test_lanczos_tridiag_factorization_csp', &
+                                 & 'Tridiagonal Lanczos factorization not correct: A @ X[:,1:k] /= X[:,1:k+1] @ T[1:k+1,1:k]')
 
         ! Compute Gram matrix associated to the right Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_csp
@@ -1645,7 +1683,7 @@ contains
         ! Lanczos factorization.
         call lanczos_tridiagonalization(A, X, T, info, tol=atol_dp)
         call check_info(info, 'lanczos_tridiagonalization', module=this_module, & 
-                        & procedure='test_lanczos_tridiag_full_factorization_cdp')
+                        & procedure='test_lanczos_tridiag_factorization_cdp')
 
         ! Check correctness.
         allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
@@ -1653,7 +1691,8 @@ contains
         ! Infinity-norm check.
         alpha = maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, T)))
         call check(error, alpha < rtol_dp)
-        if (allocated(error)) return
+        call check_test(error, 'test_lanczos_tridiag_factorization_cdp', &
+                                 & 'Tridiagonal Lanczos factorization not correct: A @ X[:,1:k] /= X[:,1:k+1] @ T[1:k+1,1:k]')
 
         ! Compute Gram matrix associated to the right Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_cdp

--- a/test/TestKrylov.fypp
+++ b/test/TestKrylov.fypp
@@ -79,7 +79,8 @@ contains
 
         ! Check correctness.
         call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_${kind}$)
-        if (allocated(error)) return
+        call check_test(error, 'test_qr_factorization_${type[0]}$${kind}$', &
+                        & 'QR factorization not correct: A /= Q @ R')
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_${type[0]}$${kind}$
@@ -87,6 +88,8 @@ contains
 
         ! Check orthonormality of the computed basis.
         call check(error, norm2(abs(G - eye(kdim))) < rtol_${kind}$)
+        call check_test(error, 'test_qr_factorization_${type[0]}$${kind}$', &
+                        & 'Basis Q not orthonormal: Q.H @ Q /= I')
 
         return
     end subroutine test_qr_factorization_${type[0]}$${kind}$
@@ -145,7 +148,8 @@ contains
 
         ! Check correctness.
         call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_${kind}$)
-        if (allocated(error)) return
+        call check_test(error, 'test_pivoting_qr_exact_rank_deficiency_${type[0]}$${kind}$', &
+                        & 'QR factorization not correct: A /= Q @ R')
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_${type[0]}$${kind}$
@@ -153,6 +157,8 @@ contains
 
         ! Check orthonormality of the computed basis.
         call check(error, norm2(abs(G - eye(kdim))) < rtol_${kind}$)
+        call check_test(error, 'test_pivoting_qr_exact_rank_deficiency_${type[0]}$${kind}$', &
+                        & 'Basis Q not orthonormal: Q.H @ Q /= I')
 
         return
     end subroutine test_pivoting_qr_exact_rank_deficiency_${type[0]}$${kind}$
@@ -205,7 +211,9 @@ contains
         ! Check correctness of full factorization.
         allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
         call check(error, maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, H))) < rtol_${kind}$)
-        if (allocated(error)) return
+        call check_test(error, 'test_arnoldi_factorization_${type[0]}$${kind}$', &
+                        & 'Arnoldi factorization not correct: A @ X[:,1:k] /= X[:,1:k+1] @ H[1:k+1,1:k]')
+
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_${type[0]}$${kind}$
@@ -213,6 +221,8 @@ contains
 
         ! Check orthonormality of the computed basis.
         call check(error, maxval(abs(G - eye(kdim))) < rtol_${kind}$)
+        call check_test(error, 'test_arnoldi_factorization_${type[0]}$${kind}$', &
+                        & 'Basis X not orthonormal: X[:,1:k].H @ X[:,1:k] /= I')
 
         return
     end subroutine test_arnoldi_factorization_${type[0]}$${kind}$
@@ -250,7 +260,8 @@ contains
         ! Check correctness of full factorization.
         allocate(Xdata(test_size, p*(kdim+1))) ; call get_data(Xdata, X)
         call check(error, maxval(abs(matmul(A%data, Xdata(:, 1:p*kdim)) - matmul(Xdata, H))) < rtol_${kind}$)
-        if (allocated(error)) return
+        call check_test(error, 'test_block_arnoldi_factorization_${type[0]}$${kind}$', &
+                        & 'Arnoldi factorization not correct: A @ X[:,1:p*k] /= X[:,1:p*(k+1)] @ H[1:p*(k+1),1:k]')
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(p*kdim, p*kdim)) ; G = zero_${type[0]}$${kind}$
@@ -258,6 +269,8 @@ contains
 
         ! Check orthonormality of the computed basis.
         call check(error, maxval(abs(G - eye(p*kdim))) < rtol_${kind}$)
+        call check_test(error, 'test_block_arnoldi_factorization_${type[0]}$${kind}$', &
+                        & 'Basis X not orthonormal: X[:,1:k].H @ X[:,1:k] /= I')
 
         return
     end subroutine test_block_arnoldi_factorization_${type[0]}$${kind}$
@@ -301,6 +314,8 @@ contains
         allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
         alpha = maxval(abs(matmul(A%data, Xdata(:, :n)) - matmul(Xdata(:, :n+1), H(:n+1, :n))))
         call check(error, alpha < rtol_${kind}$)
+        call check_test(error, 'test_krylov_schur_${type[0]}$${kind}$', &
+                        & 'Arnoldi factorization not correct: A @ X[:,1:k] /= X[:,1:k+1] @ H[1:k+1,1:k]')
 
         return
     contains
@@ -367,7 +382,8 @@ contains
 
         alpha = maxval(abs(matmul(A%data, Vdata(:, 1:kdim)) - matmul(Udata, B)))
         call check(error, alpha < rtol_${kind}$)
-        if (allocated(error)) return
+        call check_test(error, 'test_lanczos_bidiag_factorization_${type[0]}$${kind}$', &
+                              & 'Bidiagonal Lanczos factorization not correct: A @ V[:,1:k] /= U[:,1:k+1] @ B[1:k+1,1:k]')
 
         ! Compute Gram matrix associated to the left Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_${type[0]}$${kind}$
@@ -375,7 +391,8 @@ contains
 
         ! Check orthonormality of the left basis.
         call check(error, maxval(abs(G - eye(kdim))) < rtol_${kind}$)
-        if (allocated(error)) return
+        call check_test(error, 'test_lanczos_bidiag_factorization_${type[0]}$${kind}$', &
+                              & 'Left basis U not orthonormal: U[:,1:k].H @ U[:,1:k] /= I')
 
         ! Compute Gram matrix associated to the right Krylov basis.
         G = zero_${type[0]}$${kind}$
@@ -383,6 +400,8 @@ contains
 
         ! Check orthonormality of the right basis.
         call check(error, maxval(abs(G - eye(kdim))) < rtol_${kind}$)
+        call check_test(error, 'test_lanczos_bidiag_factorization_${type[0]}$${kind}$', &
+                              & 'Right basis V not orthonormal: V[:,1:k].H @ V[:,1:k] /= I')
 
         return
     end subroutine test_lanczos_bidiag_factorization_${type[0]}$${kind}$
@@ -447,7 +466,7 @@ contains
         ! Lanczos factorization.
         call lanczos_tridiagonalization(A, X, T, info, tol=atol_${kind}$)
         call check_info(info, 'lanczos_tridiagonalization', module=this_module, & 
-                        & procedure='test_lanczos_tridiag_full_factorization_${type[0]}$${kind}$')
+                        & procedure='test_lanczos_tridiag_factorization_${type[0]}$${kind}$')
 
         ! Check correctness.
         allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
@@ -455,7 +474,8 @@ contains
         ! Infinity-norm check.
         alpha = maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, T)))
         call check(error, alpha < rtol_${kind}$)
-        if (allocated(error)) return
+        call check_test(error, 'test_lanczos_tridiag_factorization_${type[0]}$${kind}$', &
+                                 & 'Tridiagonal Lanczos factorization not correct: A @ X[:,1:k] /= X[:,1:k+1] @ T[1:k+1,1:k]')
 
         ! Compute Gram matrix associated to the right Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_${type[0]}$${kind}$
@@ -463,6 +483,8 @@ contains
 
         ! Check orthonormality of the Krylov basis.
         call check(error, maxval(abs(G - eye(kdim))) < rtol_${kind}$)
+        call check_test(error, 'test_lanczos_tridiag_factorization_${type[0]}$${kind}$', &
+                                 & 'Basis X not orthonormal: X[:,1:k].H @ X[:,1:k] /= I')
 
         return
     end subroutine test_lanczos_tridiag_factorization_${type[0]}$${kind}$

--- a/test/TestKrylov.fypp
+++ b/test/TestKrylov.fypp
@@ -44,8 +44,8 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-                        new_unittest("QR factorization (correctness & orthonormality)", test_qr_factorization_${type[0]}$${kind}$), &
-                        new_unittest("Pivoting QR for a rank deficient matrix (correctness & orthonormality))", test_pivoting_qr_exact_rank_deficiency_${type[0]}$${kind}$) &
+                        new_unittest("QR factorization", test_qr_factorization_${type[0]}$${kind}$), &
+                        new_unittest("Pivoting QR for a rank deficient matrix", test_pivoting_qr_exact_rank_deficiency_${type[0]}$${kind}$) &
                     ]
         return
     end subroutine collect_qr_${type[0]}$${kind}$_testsuite
@@ -63,6 +63,8 @@ contains
         ! Miscellaneous.
         ${type}$, allocatable :: Adata(:, :), Qdata(:, :)
         ${type}$, allocatable :: G(:, :)
+        real(${kind}$) :: err
+        character*256 :: msg
 
         ! Initiliaze matrix.
         allocate(A(1:kdim)) ; call init_rand(A)
@@ -78,18 +80,22 @@ contains
         allocate(Qdata(test_size, kdim)) ; call get_data(Qdata, A)
 
         ! Check correctness.
-        call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_${kind}$)
+        err = maxval(abs(Adata - matmul(Qdata, R)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_${kind}$)
         call check_test(error, 'test_qr_factorization_${type[0]}$${kind}$', &
-                        & 'QR factorization not correct: A /= Q @ R')
+                              & info='Factorization', eq='A = Q @ R', context=msg)
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_${type[0]}$${kind}$
         call innerprod(G, A(1:kdim), A(1:kdim))
 
         ! Check orthonormality of the computed basis.
-        call check(error, norm2(abs(G - eye(kdim))) < rtol_${kind}$)
+        err = norm2(abs(G - eye(kdim)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_${kind}$)
         call check_test(error, 'test_qr_factorization_${type[0]}$${kind}$', &
-                        & 'Basis Q not orthonormal: Q.H @ Q /= I')
+                              & info='Basis orthonormality', eq='Q.H @ Q = I', context=msg)
 
         return
     end subroutine test_qr_factorization_${type[0]}$${kind}$
@@ -116,6 +122,8 @@ contains
         logical :: mask(kdim)
         ${type}$, allocatable :: Adata(:, :), Qdata(:, :)
         ${type}$, allocatable :: G(:, :)
+        real(${kind}$) :: err
+        character*256 :: msg
 
         ! Effective rank.
         rk = kdim - nzero
@@ -147,18 +155,22 @@ contains
         Adata = Adata(:, perm)
 
         ! Check correctness.
-        call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_${kind}$)
+        err = maxval(abs(Adata - matmul(Qdata, R)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_${kind}$)
         call check_test(error, 'test_pivoting_qr_exact_rank_deficiency_${type[0]}$${kind}$', &
-                        & 'QR factorization not correct: A /= Q @ R')
+                              & info='Factorization', eq='A = Q @ R', context=msg)
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_${type[0]}$${kind}$
         call innerprod(G, A(1:kdim), A(1:kdim))
 
         ! Check orthonormality of the computed basis.
-        call check(error, norm2(abs(G - eye(kdim))) < rtol_${kind}$)
+        err = norm2(abs(G - eye(kdim)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_${kind}$)
         call check_test(error, 'test_pivoting_qr_exact_rank_deficiency_${type[0]}$${kind}$', &
-                        & 'Basis Q not orthonormal: Q.H @ Q /= I')
+                              & info='Basis orthonormality', eq='Q.H @ Q = I', context=msg)
 
         return
     end subroutine test_pivoting_qr_exact_rank_deficiency_${type[0]}$${kind}$
@@ -174,8 +186,8 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-            new_unittest("Arnoldi factorization (correctness & orthonormality)", test_arnoldi_factorization_${type[0]}$${kind}$), &
-            new_unittest("Block Arnoldi factorization (correctness & orthonormality)", test_block_arnoldi_factorization_${type[0]}$${kind}$), &
+            new_unittest("Arnoldi factorization", test_arnoldi_factorization_${type[0]}$${kind}$), &
+            new_unittest("Block Arnoldi factorization", test_block_arnoldi_factorization_${type[0]}$${kind}$), &
             new_unittest("Krylov-Schur factorization", test_krylov_schur_${type[0]}$${kind}$) &
                     ]
         return
@@ -197,6 +209,8 @@ contains
         ! Miscellaneous.
         ${type}$, allocatable :: Xdata(:, :)
         ${type}$, allocatable :: G(:, :)
+        real(${kind}$) :: err
+        character*256 :: msg
            
         ! Initialize linear operator.
         A = linop_${type[0]}$${kind}$() ; call init_rand(A)
@@ -210,9 +224,11 @@ contains
 
         ! Check correctness of full factorization.
         allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
-        call check(error, maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, H))) < rtol_${kind}$)
+        err = maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, H)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_${kind}$)
         call check_test(error, 'test_arnoldi_factorization_${type[0]}$${kind}$', &
-                        & 'Arnoldi factorization not correct: A @ X[:,1:k] /= X[:,1:k+1] @ H[1:k+1,1:k]')
+                              & info='Factorization', eq='A @ X = X_ @ H_', context=msg)
 
 
         ! Compute Gram matrix associated to the Krylov basis.
@@ -220,9 +236,11 @@ contains
         call innerprod(G, X(1:kdim), X(1:kdim))
 
         ! Check orthonormality of the computed basis.
-        call check(error, maxval(abs(G - eye(kdim))) < rtol_${kind}$)
+        err = maxval(abs(G - eye(kdim)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_${kind}$)
         call check_test(error, 'test_arnoldi_factorization_${type[0]}$${kind}$', &
-                        & 'Basis X not orthonormal: X[:,1:k].H @ X[:,1:k] /= I')
+                              & info='Orthonomality', eq='X.H @ X = I', context=msg)
 
         return
     end subroutine test_arnoldi_factorization_${type[0]}$${kind}$
@@ -244,6 +262,8 @@ contains
         type(vector_${type[0]}$${kind}$), allocatable :: X0(:)
         ${type}$, allocatable :: Xdata(:, :)
         ${type}$, allocatable :: G(:, :)
+        real(${kind}$) :: err
+        character*256 :: msg
 
         ! Initialize linear operator.
         A = linop_${type[0]}$${kind}$() ; call init_rand(A)
@@ -259,18 +279,22 @@ contains
 
         ! Check correctness of full factorization.
         allocate(Xdata(test_size, p*(kdim+1))) ; call get_data(Xdata, X)
-        call check(error, maxval(abs(matmul(A%data, Xdata(:, 1:p*kdim)) - matmul(Xdata, H))) < rtol_${kind}$)
+        err = maxval(abs(matmul(A%data, Xdata(:, 1:p*kdim)) - matmul(Xdata, H)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_${kind}$)
         call check_test(error, 'test_block_arnoldi_factorization_${type[0]}$${kind}$', &
-                        & 'Arnoldi factorization not correct: A @ X[:,1:p*k] /= X[:,1:p*(k+1)] @ H[1:p*(k+1),1:k]')
+                              & info='Factorization', eq='A @ X = X_ @ H_', context=msg)
 
         ! Compute Gram matrix associated to the Krylov basis.
         allocate(G(p*kdim, p*kdim)) ; G = zero_${type[0]}$${kind}$
         call innerprod(G, X(1:p*kdim), X(1:p*kdim))
 
         ! Check orthonormality of the computed basis.
-        call check(error, maxval(abs(G - eye(p*kdim))) < rtol_${kind}$)
+        err = maxval(abs(G - eye(p*kdim)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_${kind}$)
         call check_test(error, 'test_block_arnoldi_factorization_${type[0]}$${kind}$', &
-                        & 'Basis X not orthonormal: X[:,1:k].H @ X[:,1:k] /= I')
+                              & info='Basis orthonormality', eq='X.H @ X = I', context=msg)
 
         return
     end subroutine test_block_arnoldi_factorization_${type[0]}$${kind}$
@@ -292,7 +316,8 @@ contains
         ! Miscellaneous.
         integer :: n
         ${type}$, allocatable :: Xdata(:, :)
-        real(${kind}$) :: alpha
+        real(${kind}$) :: err
+        character*256 :: msg
 
         ! Initialize matrix.
         A = linop_${type[0]}$${kind}$() ; call init_rand(A)
@@ -312,10 +337,11 @@ contains
 
         ! Check correctness.
         allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
-        alpha = maxval(abs(matmul(A%data, Xdata(:, :n)) - matmul(Xdata(:, :n+1), H(:n+1, :n))))
-        call check(error, alpha < rtol_${kind}$)
+        err = maxval(abs(matmul(A%data, Xdata(:, :n)) - matmul(Xdata(:, :n+1), H(:n+1, :n))))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_${kind}$)
         call check_test(error, 'test_krylov_schur_${type[0]}$${kind}$', &
-                        & 'Arnoldi factorization not correct: A @ X[:,1:k] /= X[:,1:k+1] @ H[1:k+1,1:k]')
+                              & info='Factorization', eq='A @ X = X_ @ H_', context=msg)
 
         return
     contains
@@ -339,7 +365,7 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-            new_unittest("Lanczos Bidiagonalization (correctness and left/right orthonormality)", test_lanczos_bidiag_factorization_${type[0]}$${kind}$) &
+            new_unittest("Lanczos Bidiagonalization", test_lanczos_bidiag_factorization_${type[0]}$${kind}$) &
                 ]
         return
     end subroutine collect_lanczos_bidiag_${type[0]}$${kind}$_testsuite
@@ -358,10 +384,11 @@ contains
         ! Information flag.
         integer :: info
         ! Miscellaneous.
-        real(${kind}$) :: alpha
         ${type}$, allocatable :: Udata(:, :), Vdata(:, :)
         ${type}$, allocatable :: G(:, :)
         type(vector_${type[0]}$${kind}$), allocatable :: X0(:)
+        real(${kind}$) :: err
+        character*256 :: msg
 
         ! Initialize linear operator.
         A = linop_${type[0]}$${kind}$() ; call init_rand(A)
@@ -380,28 +407,33 @@ contains
         allocate(Udata(test_size, kdim+1)) ; call get_data(Udata, U)
         allocate(Vdata(test_size, kdim+1)) ; call get_data(Vdata, V)
 
-        alpha = maxval(abs(matmul(A%data, Vdata(:, 1:kdim)) - matmul(Udata, B)))
-        call check(error, alpha < rtol_${kind}$)
+        err = maxval(abs(matmul(A%data, Vdata(:, 1:kdim)) - matmul(Udata, B)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_${kind}$)
         call check_test(error, 'test_lanczos_bidiag_factorization_${type[0]}$${kind}$', &
-                              & 'Bidiagonal Lanczos factorization not correct: A @ V[:,1:k] /= U[:,1:k+1] @ B[1:k+1,1:k]')
+                              & info='Factorization', eq='A @ V = U_ @ B_', context=msg)
 
         ! Compute Gram matrix associated to the left Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_${type[0]}$${kind}$
         call innerprod(G, U(1:kdim), U(1:kdim))
 
         ! Check orthonormality of the left basis.
-        call check(error, maxval(abs(G - eye(kdim))) < rtol_${kind}$)
+        err = maxval(abs(G - eye(kdim)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_${kind}$)
         call check_test(error, 'test_lanczos_bidiag_factorization_${type[0]}$${kind}$', &
-                              & 'Left basis U not orthonormal: U[:,1:k].H @ U[:,1:k] /= I')
+                              & info='Basis orthonormality (left)', eq='U.H @ U = I', context=msg)
 
         ! Compute Gram matrix associated to the right Krylov basis.
         G = zero_${type[0]}$${kind}$
         call innerprod(G, V(1:kdim), V(1:kdim))
 
         ! Check orthonormality of the right basis.
-        call check(error, maxval(abs(G - eye(kdim))) < rtol_${kind}$)
+        err = maxval(abs(G - eye(kdim)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_${kind}$)
         call check_test(error, 'test_lanczos_bidiag_factorization_${type[0]}$${kind}$', &
-                              & 'Right basis V not orthonormal: V[:,1:k].H @ V[:,1:k] /= I')
+                              & info='Basis orthonormality (right)', eq='V.H @ V = I', context=msg)
 
         return
     end subroutine test_lanczos_bidiag_factorization_${type[0]}$${kind}$
@@ -418,7 +450,7 @@ contains
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
-             new_unittest("Lanczos Tridiagonalization (correctness & orthonormality)", test_lanczos_tridiag_factorization_${type[0]}$${kind}$) &
+             new_unittest("Lanczos Tridiagonalization", test_lanczos_tridiag_factorization_${type[0]}$${kind}$) &
             ]
 
         return
@@ -444,9 +476,10 @@ contains
 
         ! Internal variables.
         ${type}$, allocatable :: Xdata(:, :)
-        real(${kind}$) :: alpha
         class(vector_${type[0]}$${kind}$), allocatable :: X0(:)
         ${type}$, allocatable :: G(:, :)
+        real(${kind}$) :: err
+        character*256 :: msg
 
         ! Initialize tridiagonal matrix.
         allocate(T(kdim+1, kdim)) ; T = zero_${type[0]}$${kind}$
@@ -472,19 +505,22 @@ contains
         allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
 
         ! Infinity-norm check.
-        alpha = maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, T)))
-        call check(error, alpha < rtol_${kind}$)
+        err = maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, T)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_${kind}$)
         call check_test(error, 'test_lanczos_tridiag_factorization_${type[0]}$${kind}$', &
-                                 & 'Tridiagonal Lanczos factorization not correct: A @ X[:,1:k] /= X[:,1:k+1] @ T[1:k+1,1:k]')
+                                 & info='Factorization', eq='A @ X = X_ @ T_', context=msg)
 
         ! Compute Gram matrix associated to the right Krylov basis.
         allocate(G(kdim, kdim)) ; G = zero_${type[0]}$${kind}$
         call innerprod(G, X(1:kdim), X(1:kdim))
 
         ! Check orthonormality of the Krylov basis.
-        call check(error, maxval(abs(G - eye(kdim))) < rtol_${kind}$)
+        err = maxval(abs(G - eye(kdim)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_${kind}$)
         call check_test(error, 'test_lanczos_tridiag_factorization_${type[0]}$${kind}$', &
-                                 & 'Basis X not orthonormal: X[:,1:k].H @ X[:,1:k] /= I')
+                                 & info='Orthonomality', eq='X.H @ X = I', context=msg)
 
         return
     end subroutine test_lanczos_tridiag_factorization_${type[0]}$${kind}$

--- a/test/TestKrylov.fypp
+++ b/test/TestKrylov.fypp
@@ -23,7 +23,7 @@ module TestKrylov
     
     private
 
-    character*128, parameter, private :: this_module = 'LightKrylov_TestKrylov'
+    character(len=128), parameter, private :: this_module = 'LightKrylov_TestKrylov'
 
     #:for kind, type in RC_KINDS_TYPES
     public :: collect_qr_${type[0]}$${kind}$_testsuite
@@ -61,33 +61,32 @@ contains
         ! Information flag.
         integer :: info
         ! Miscellaneous.
-        ${type}$, dimension(test_size, kdim) :: Adata, Qdata
-        ${type}$, dimension(kdim, kdim) :: G, Id
+        ${type}$, allocatable :: Adata(:, :), Qdata(:, :)
+        ${type}$, allocatable :: G(:, :)
 
         ! Initiliaze matrix.
         allocate(A(1:kdim)) ; call init_rand(A)
 
         ! Get data.
-        call get_data(Adata, A)
+        allocate(Adata(test_size, kdim)) ; call get_data(Adata, A)
 
         ! In-place QR factorization.
         call qr(A, R, info, tol=atol_${kind}$)
         call check_info(info, 'qr', module=this_module, procedure='test_qr_factorization_${type[0]}$${kind}$')
 
         ! Get data.
-        call get_data(Qdata, A)
+        allocate(Qdata(test_size, kdim)) ; call get_data(Qdata, A)
 
         ! Check correctness.
         call check(error, maxval(abs(Adata - matmul(Qdata, R))) < rtol_${kind}$)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the Krylov basis.
-        G = zero_${type[0]}$${kind}$
+        allocate(G(kdim, kdim)) ; G = zero_${type[0]}$${kind}$
         call innerprod(G, A(1:kdim), A(1:kdim))
 
         ! Check orthonormality of the computed basis.
-        Id = eye(kdim)
-        call check(error, norm2(abs(G - Id)) < rtol_${kind}$)
+        call check(error, norm2(abs(G - eye(kdim))) < rtol_${kind}$)
 
         return
     end subroutine test_qr_factorization_${type[0]}$${kind}$
@@ -112,8 +111,8 @@ contains
         integer :: k, idx, rk
         real(${kind}$) :: alpha
         logical :: mask(kdim)
-        ${type}$, dimension(test_size, kdim) :: Adata, Qdata
-        ${type}$, dimension(kdim, kdim) :: G, Id
+        ${type}$, allocatable :: Adata(:, :), Qdata(:, :)
+        ${type}$, allocatable :: G(:, :)
 
         ! Effective rank.
         rk = kdim - nzero
@@ -134,14 +133,14 @@ contains
         enddo
 
         ! Copy data.
-        call get_data(Adata, A)
+        allocate(Adata(test_size, kdim)) ; call get_data(Adata, A)
 
         ! In-place QR factorization.
         call qr(A, R, perm, info, tol=atol_${kind}$)
         call check_info(info, 'qr_pivot', module=this_module, procedure='test_pivoting_qr_exact_rank_deficiency_${type[0]}$${kind}$')
 
         ! Extract data
-        call get_data(Qdata, A)
+        allocate(Qdata(test_size, kdim)) ; call get_data(Qdata, A)
         Adata = Adata(:, perm)
 
         ! Check correctness.
@@ -149,12 +148,11 @@ contains
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the Krylov basis.
-        G = zero_${type[0]}$${kind}$
+        allocate(G(kdim, kdim)) ; G = zero_${type[0]}$${kind}$
         call innerprod(G, A(1:kdim), A(1:kdim))
 
         ! Check orthonormality of the computed basis.
-        Id = eye(kdim)
-        call check(error, norm2(abs(G - Id)) < rtol_${kind}$)
+        call check(error, norm2(abs(G - eye(kdim))) < rtol_${kind}$)
 
         return
     end subroutine test_pivoting_qr_exact_rank_deficiency_${type[0]}$${kind}$
@@ -187,35 +185,34 @@ contains
         type(vector_${type[0]}$${kind}$), dimension(:), allocatable :: X0
         integer, parameter :: kdim = test_size
         ! Hessenberg matrix.
-        ${type}$ :: H(kdim+1, kdim)
+        ${type}$, allocatable :: H(:, :)
         ! Information flag.
         integer :: info
         ! Miscellaneous.
-        ${type}$ :: Xdata(test_size, kdim+1)
-        ${type}$, dimension(kdim, kdim) :: G, Id
+        ${type}$, allocatable :: Xdata(:, :)
+        ${type}$, allocatable :: G(:, :)
            
         ! Initialize linear operator.
         A = linop_${type[0]}$${kind}$() ; call init_rand(A)
         ! Initialize Krylov subspace.
         allocate(X(1:kdim+1)) ; allocate (X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
-        H = zero_${type[0]}$${kind}$
+        allocate(H(kdim+1, kdim)) ; H = zero_${type[0]}$${kind}$
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, tol=atol_${kind}$)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_arnoldi_factorization_${type[0]}$${kind}$')
 
         ! Check correctness of full factorization.
-        call get_data(Xdata, X)
+        allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
         call check(error, maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, H))) < rtol_${kind}$)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the Krylov basis.
-        G = zero_${type[0]}$${kind}$
+        allocate(G(kdim, kdim)) ; G = zero_${type[0]}$${kind}$
         call innerprod(G, X(1:kdim), X(1:kdim))
 
         ! Check orthonormality of the computed basis.
-        Id = eye(kdim)
-        call check(error, maxval(abs(G - Id)) < rtol_${kind}$)
+        call check(error, maxval(abs(G - eye(kdim))) < rtol_${kind}$)
 
         return
     end subroutine test_arnoldi_factorization_${type[0]}$${kind}$
@@ -230,14 +227,13 @@ contains
         integer, parameter :: p = 2
         integer, parameter :: kdim = test_size/2
         ! Hessenberg matrix.
-        ${type}$ :: H(p*(kdim+1), p*kdim)
+        ${type}$, allocatable :: H(:, :)
         ! Information flag.
         integer :: info
         ! Miscellaneous.
         type(vector_${type[0]}$${kind}$), allocatable :: X0(:)
-        ${type}$, dimension(test_size, p*(kdim+1)) :: Xdata
-        ${type}$, dimension(p*kdim, p*kdim) :: G
-        real(${kind}$), dimension(p*kdim, p*kdim) :: Id
+        ${type}$, allocatable :: Xdata(:, :)
+        ${type}$, allocatable :: G(:, :)
 
         ! Initialize linear operator.
         A = linop_${type[0]}$${kind}$() ; call init_rand(A)
@@ -245,24 +241,23 @@ contains
         ! Initialize Krylov subspace.
         allocate(X(1:p*(kdim+1))) ; allocate(X0(1:p))
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
-        H = zero_${type[0]}$${kind}$
+        allocate(H(p*(kdim+1), p*kdim)) ; H = zero_${type[0]}$${kind}$
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, blksize=p, tol=atol_${kind}$)
         call check_info(info, 'arnoldi', module=this_module, procedure='test_block_arnoldi_factorization_${type[0]}$${kind}$')
 
         ! Check correctness of full factorization.
-        call get_data(Xdata, X)
+        allocate(Xdata(test_size, p*(kdim+1))) ; call get_data(Xdata, X)
         call check(error, maxval(abs(matmul(A%data, Xdata(:, 1:p*kdim)) - matmul(Xdata, H))) < rtol_${kind}$)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the Krylov basis.
-        G = zero_${type[0]}$${kind}$
+        allocate(G(p*kdim, p*kdim)) ; G = zero_${type[0]}$${kind}$
         call innerprod(G, X(1:p*kdim), X(1:p*kdim))
 
         ! Check orthonormality of the computed basis.
-        Id = eye(p*kdim)
-        call check(error, maxval(abs(G - Id)) < rtol_${kind}$)
+        call check(error, maxval(abs(G - eye(p*kdim))) < rtol_${kind}$)
 
         return
     end subroutine test_block_arnoldi_factorization_${type[0]}$${kind}$
@@ -277,13 +272,13 @@ contains
         ! Krylov subspace dimension.
         integer, parameter :: kdim = 100
         ! Hessenberg matrix.
-        ${type}$ :: H(kdim+1, kdim)
+        ${type}$, allocatable :: H(:, :)
         ! Information flag.
         integer :: info
 
         ! Miscellaneous.
         integer :: n
-        ${type}$ :: Xdata(test_size, kdim+1)
+        ${type}$, allocatable :: Xdata(:, :)
         real(${kind}$) :: alpha
 
         ! Initialize matrix.
@@ -293,7 +288,7 @@ contains
         ! Initialize Krylov subspace.
         allocate(X(kdim+1)) ; allocate(X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(X, X0)
-        H = zero_${type[0]}$${kind}$
+        allocate(H(kdim+1, kdim)) ; H = zero_${type[0]}$${kind}$
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, tol=atol_${kind}$)
@@ -303,7 +298,7 @@ contains
         call krylov_schur(n, X, H, select_eigs)
 
         ! Check correctness.
-        call get_data(Xdata, X)
+        allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
         alpha = maxval(abs(matmul(A%data, Xdata(:, :n)) - matmul(Xdata(:, :n+1), H(:n+1, :n))))
         call check(error, alpha < rtol_${kind}$)
 
@@ -344,13 +339,13 @@ contains
         ! Krylov subspace dimension.
         integer, parameter :: kdim = test_size
         ! Bidiagonal matrix.
-        ${type}$ :: B(kdim+1, kdim)
+        ${type}$, allocatable :: B(:, :)
         ! Information flag.
         integer :: info
         ! Miscellaneous.
         real(${kind}$) :: alpha
-        ${type}$, dimension(test_size, kdim+1) :: Udata, Vdata
-        ${type}$, dimension(kdim, kdim) :: G, Id
+        ${type}$, allocatable :: Udata(:, :), Vdata(:, :)
+        ${type}$, allocatable :: G(:, :)
         type(vector_${type[0]}$${kind}$), allocatable :: X0(:)
 
         ! Initialize linear operator.
@@ -359,7 +354,7 @@ contains
         ! Initialize Krylov subspaces.
         allocate(U(1:kdim+1)) ; allocate(V(1:kdim+1)) ; allocate(X0(1))
         call init_rand(X0) ; call initialize_krylov_subspace(U, X0)
-        call initialize_krylov_subspace(V) ; B = zero_${type[0]}$${kind}$
+        call zero_basis(V) ; allocate(B(kdim+1, kdim)) ; B = zero_${type[0]}$${kind}$
 
         ! Lanczos bidiagonalization.
         call lanczos_bidiagonalization(A, U, V, B, info, tol=atol_${kind}$)
@@ -367,20 +362,19 @@ contains
                         & procedure='test_lanczos_bidiag_factorization_${type[0]}$${kind}$')
 
         ! Check correctness.
-        call get_data(Udata, U)
-        call get_data(Vdata, V)
+        allocate(Udata(test_size, kdim+1)) ; call get_data(Udata, U)
+        allocate(Vdata(test_size, kdim+1)) ; call get_data(Vdata, V)
 
         alpha = maxval(abs(matmul(A%data, Vdata(:, 1:kdim)) - matmul(Udata, B)))
         call check(error, alpha < rtol_${kind}$)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the left Krylov basis.
-        G = zero_${type[0]}$${kind}$
+        allocate(G(kdim, kdim)) ; G = zero_${type[0]}$${kind}$
         call innerprod(G, U(1:kdim), U(1:kdim))
 
         ! Check orthonormality of the left basis.
-        Id = eye(kdim)
-        call check(error, maxval(abs(G - Id)) < rtol_${kind}$)
+        call check(error, maxval(abs(G - eye(kdim))) < rtol_${kind}$)
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the right Krylov basis.
@@ -388,7 +382,7 @@ contains
         call innerprod(G, V(1:kdim), V(1:kdim))
 
         ! Check orthonormality of the right basis.
-        call check(error, maxval(abs(G - Id)) < rtol_${kind}$)
+        call check(error, maxval(abs(G - eye(kdim))) < rtol_${kind}$)
 
         return
     end subroutine test_lanczos_bidiag_factorization_${type[0]}$${kind}$
@@ -425,18 +419,18 @@ contains
         ! Krylov subspace dimension.
         integer, parameter :: kdim = test_size
         ! Tridiagonal matrix.
-        ${type}$ :: T(kdim+1, kdim)
+        ${type}$, allocatable :: T(:, :)
         ! Information flag.
         integer :: info
 
         ! Internal variables.
-        ${type}$ :: Xdata(test_size, kdim+1)
+        ${type}$, allocatable :: Xdata(:, :)
         real(${kind}$) :: alpha
         class(vector_${type[0]}$${kind}$), allocatable :: X0(:)
-        ${type}$, dimension(kdim, kdim) :: G, Id
+        ${type}$, allocatable :: G(:, :)
 
         ! Initialize tridiagonal matrix.
-        T = zero_${type[0]}$${kind}$
+        allocate(T(kdim+1, kdim)) ; T = zero_${type[0]}$${kind}$
 
         ! Initialize operator.
         #:if type[0] == "r"
@@ -456,7 +450,7 @@ contains
                         & procedure='test_lanczos_tridiag_full_factorization_${type[0]}$${kind}$')
 
         ! Check correctness.
-        call get_data(Xdata, X)
+        allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
 
         ! Infinity-norm check.
         alpha = maxval(abs(matmul(A%data, Xdata(:, 1:kdim)) - matmul(Xdata, T)))
@@ -464,12 +458,11 @@ contains
         if (allocated(error)) return
 
         ! Compute Gram matrix associated to the right Krylov basis.
-        G = zero_${type[0]}$${kind}$
+        allocate(G(kdim, kdim)) ; G = zero_${type[0]}$${kind}$
         call innerprod(G, X(1:kdim), X(1:kdim))
 
         ! Check orthonormality of the Krylov basis.
-        Id = eye(kdim)
-        call check(error, maxval(abs(G - Id)) < rtol_${kind}$)
+        call check(error, maxval(abs(G - eye(kdim))) < rtol_${kind}$)
 
         return
     end subroutine test_lanczos_tridiag_factorization_${type[0]}$${kind}$

--- a/test/TestLinops.f90
+++ b/test/TestLinops.f90
@@ -346,7 +346,7 @@ contains
 
         ! Check result.
         call check(error, norm2(y%data - matmul(A%data, x%data)) < rtol_sp)
-        call check_test(error, 'test_matvec_rsp', 'norm2(y%data - matmul(A%data, x%data)) < rtol')
+        call check_test(error, 'test_matvec_rsp', eq='norm2(y - A @ x)')
         
         return
     end subroutine test_matvec_rsp
@@ -372,7 +372,7 @@ contains
 
         ! Check result.
         call check(error, norm2(y%data - matmul(transpose(A%data), x%data)) < rtol_sp)
-        call check_test(error, 'test_rmatvec_rsp', 'norm2(y%data - matmul(transpose(A%data), x%data)) < rtol')
+        call check_test(error, 'test_rmatvec_rsp', eq='norm2(y - A.T @ x)')
         
         return
     end subroutine test_rmatvec_rsp
@@ -406,7 +406,7 @@ contains
         ! Check result.
         alpha = norm2(y%data - matmul(transpose(A%data), x%data))
         call check(error, alpha < rtol_sp)
-        call check_test(error, 'test_adjoint_matvec_rsp', 'norm2(y%data - matmul(transpose(A%data), x%data)) < rtol')
+        call check_test(error, 'test_adjoint_matvec_rsp', eq='norm2(y - A.T @ x)')
 
         
 
@@ -442,7 +442,7 @@ contains
         ! Check result.
         alpha = norm2(y%data - matmul(A%data, x%data))
         call check(error, alpha < rtol_sp)
-        call check_test(error, 'test_adjoint_rmatvec_rsp', 'norm2(y%data - matmul(A%data, x%data)) < rtol')
+        call check_test(error, 'test_adjoint_rmatvec_rsp', eq='norm2(y - A @ x)')
 
        return
     end subroutine test_adjoint_rmatvec_rsp
@@ -480,7 +480,7 @@ contains
 
         ! Check result.
         call check(error, norm2(y%data - matmul(A%data, x%data)) < rtol_dp)
-        call check_test(error, 'test_matvec_rdp', 'norm2(y%data - matmul(A%data, x%data)) < rtol')
+        call check_test(error, 'test_matvec_rdp', eq='norm2(y - A @ x)')
         
         return
     end subroutine test_matvec_rdp
@@ -506,7 +506,7 @@ contains
 
         ! Check result.
         call check(error, norm2(y%data - matmul(transpose(A%data), x%data)) < rtol_dp)
-        call check_test(error, 'test_rmatvec_rdp', 'norm2(y%data - matmul(transpose(A%data), x%data)) < rtol')
+        call check_test(error, 'test_rmatvec_rdp', eq='norm2(y - A.T @ x)')
         
         return
     end subroutine test_rmatvec_rdp
@@ -540,7 +540,7 @@ contains
         ! Check result.
         alpha = norm2(y%data - matmul(transpose(A%data), x%data))
         call check(error, alpha < rtol_dp)
-        call check_test(error, 'test_adjoint_matvec_rdp', 'norm2(y%data - matmul(transpose(A%data), x%data)) < rtol')
+        call check_test(error, 'test_adjoint_matvec_rdp', eq='norm2(y - A.T @ x)')
 
         
 
@@ -576,7 +576,7 @@ contains
         ! Check result.
         alpha = norm2(y%data - matmul(A%data, x%data))
         call check(error, alpha < rtol_dp)
-        call check_test(error, 'test_adjoint_rmatvec_rdp', 'norm2(y%data - matmul(A%data, x%data)) < rtol')
+        call check_test(error, 'test_adjoint_rmatvec_rdp', eq='norm2(y - A @ x)')
 
        return
     end subroutine test_adjoint_rmatvec_rdp
@@ -615,7 +615,7 @@ contains
 
         ! Check result.
         call check(error, norm2(abs(y%data - matmul(A%data, x%data))) < rtol_sp)
-        call check_test(error, 'test_matvec_csp', 'norm2(abs(y%data - matmul(A%data, x%data))) < rtol')
+        call check_test(error, 'test_matvec_csp', eq='norm2(|y - A @ x|)')
         
         return
     end subroutine test_matvec_csp
@@ -642,7 +642,7 @@ contains
 
         ! Check result.
         call check(error, norm2(abs(y%data - matmul(transpose(conjg(A%data)), x%data))) < rtol_sp)
-        call check_test(error, 'test_rmatvec_csp', 'norm2(abs(y%data - matmul(transpose(A%data), x%data))) < rtol')
+        call check_test(error, 'test_rmatvec_csp', eq='norm2(|y - A.H @ x|)')
         
         return
     end subroutine test_rmatvec_csp
@@ -677,7 +677,7 @@ contains
         ! Check result.
         alpha = norm2(abs(y%data - matmul(transpose(conjg(A%data)), x%data)))
         call check(error, alpha < rtol_sp)
-        call check_test(error, 'test_adjoint_matvec_csp', 'norm2(abs(y%data - matmul(transpose(A%data), x%data))) < rtol')
+        call check_test(error, 'test_adjoint_matvec_csp', eq='norm2(|y - A.H @ x|)')
 
         
 
@@ -714,7 +714,7 @@ contains
         ! Check result.
         alpha = norm2(abs(y%data - matmul(A%data, x%data)))
         call check(error, alpha < rtol_sp)
-        call check_test(error, 'test_adjoint_rmatvec_csp', 'norm2(abs(y%data - matmul(A%data, x%data))) < rtol')
+        call check_test(error, 'test_adjoint_rmatvec_csp', eq='norm2(|y - A @ x|)')
 
        return
     end subroutine test_adjoint_rmatvec_csp
@@ -753,7 +753,7 @@ contains
 
         ! Check result.
         call check(error, norm2(abs(y%data - matmul(A%data, x%data))) < rtol_dp)
-        call check_test(error, 'test_matvec_cdp', 'norm2(abs(y%data - matmul(A%data, x%data))) < rtol')
+        call check_test(error, 'test_matvec_cdp', eq='norm2(|y - A @ x|)')
         
         return
     end subroutine test_matvec_cdp
@@ -780,7 +780,7 @@ contains
 
         ! Check result.
         call check(error, norm2(abs(y%data - matmul(transpose(conjg(A%data)), x%data))) < rtol_dp)
-        call check_test(error, 'test_rmatvec_cdp', 'norm2(abs(y%data - matmul(transpose(A%data), x%data))) < rtol')
+        call check_test(error, 'test_rmatvec_cdp', eq='norm2(|y - A.H @ x|)')
         
         return
     end subroutine test_rmatvec_cdp
@@ -815,7 +815,7 @@ contains
         ! Check result.
         alpha = norm2(abs(y%data - matmul(transpose(conjg(A%data)), x%data)))
         call check(error, alpha < rtol_dp)
-        call check_test(error, 'test_adjoint_matvec_cdp', 'norm2(abs(y%data - matmul(transpose(A%data), x%data))) < rtol')
+        call check_test(error, 'test_adjoint_matvec_cdp', eq='norm2(|y - A.H @ x|)')
 
         
 
@@ -852,7 +852,7 @@ contains
         ! Check result.
         alpha = norm2(abs(y%data - matmul(A%data, x%data)))
         call check(error, alpha < rtol_dp)
-        call check_test(error, 'test_adjoint_rmatvec_cdp', 'norm2(abs(y%data - matmul(A%data, x%data))) < rtol')
+        call check_test(error, 'test_adjoint_rmatvec_cdp', eq='norm2(|y - A @ x|)')
 
        return
     end subroutine test_adjoint_rmatvec_cdp

--- a/test/TestLinops.f90
+++ b/test/TestLinops.f90
@@ -5,6 +5,7 @@ module TestLinops
     ! LightKrylov
     use LightKrylov
     use LightKrylov_Constants
+    use LightKrylov_Logger
     
     ! Testdrive
     use testdrive, only: new_unittest, unittest_type, error_type, check
@@ -345,7 +346,8 @@ contains
 
         ! Check result.
         call check(error, norm2(y%data - matmul(A%data, x%data)) < rtol_sp)
-
+        call check_test(error, 'test_matvec_rsp', 'norm2(y%data - matmul(A%data, x%data)) < rtol')
+        
         return
     end subroutine test_matvec_rsp
 
@@ -370,6 +372,7 @@ contains
 
         ! Check result.
         call check(error, norm2(y%data - matmul(transpose(A%data), x%data)) < rtol_sp)
+        call check_test(error, 'test_rmatvec_rsp', 'norm2(y%data - matmul(transpose(A%data), x%data)) < rtol')
         
         return
     end subroutine test_rmatvec_rsp
@@ -402,8 +405,10 @@ contains
 
         ! Check result.
         alpha = norm2(y%data - matmul(transpose(A%data), x%data))
-
         call check(error, alpha < rtol_sp)
+        call check_test(error, 'test_adjoint_matvec_rsp', 'norm2(y%data - matmul(transpose(A%data), x%data)) < rtol')
+
+        
 
        return
     end subroutine test_adjoint_matvec_rsp
@@ -436,12 +441,11 @@ contains
 
         ! Check result.
         alpha = norm2(y%data - matmul(A%data, x%data))
-
         call check(error, alpha < rtol_sp)
+        call check_test(error, 'test_adjoint_rmatvec_rsp', 'norm2(y%data - matmul(A%data, x%data)) < rtol')
 
        return
     end subroutine test_adjoint_rmatvec_rsp
-
 
     subroutine collect_linop_rdp_testsuite(testsuite)
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
@@ -476,7 +480,8 @@ contains
 
         ! Check result.
         call check(error, norm2(y%data - matmul(A%data, x%data)) < rtol_dp)
-
+        call check_test(error, 'test_matvec_rdp', 'norm2(y%data - matmul(A%data, x%data)) < rtol')
+        
         return
     end subroutine test_matvec_rdp
 
@@ -501,6 +506,7 @@ contains
 
         ! Check result.
         call check(error, norm2(y%data - matmul(transpose(A%data), x%data)) < rtol_dp)
+        call check_test(error, 'test_rmatvec_rdp', 'norm2(y%data - matmul(transpose(A%data), x%data)) < rtol')
         
         return
     end subroutine test_rmatvec_rdp
@@ -533,8 +539,10 @@ contains
 
         ! Check result.
         alpha = norm2(y%data - matmul(transpose(A%data), x%data))
-
         call check(error, alpha < rtol_dp)
+        call check_test(error, 'test_adjoint_matvec_rdp', 'norm2(y%data - matmul(transpose(A%data), x%data)) < rtol')
+
+        
 
        return
     end subroutine test_adjoint_matvec_rdp
@@ -567,12 +575,11 @@ contains
 
         ! Check result.
         alpha = norm2(y%data - matmul(A%data, x%data))
-
         call check(error, alpha < rtol_dp)
+        call check_test(error, 'test_adjoint_rmatvec_rdp', 'norm2(y%data - matmul(A%data, x%data)) < rtol')
 
        return
     end subroutine test_adjoint_rmatvec_rdp
-
 
     subroutine collect_linop_csp_testsuite(testsuite)
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
@@ -608,7 +615,8 @@ contains
 
         ! Check result.
         call check(error, norm2(abs(y%data - matmul(A%data, x%data))) < rtol_sp)
-
+        call check_test(error, 'test_matvec_csp', 'norm2(abs(y%data - matmul(A%data, x%data))) < rtol')
+        
         return
     end subroutine test_matvec_csp
 
@@ -634,6 +642,7 @@ contains
 
         ! Check result.
         call check(error, norm2(abs(y%data - matmul(transpose(conjg(A%data)), x%data))) < rtol_sp)
+        call check_test(error, 'test_rmatvec_csp', 'norm2(abs(y%data - matmul(transpose(A%data), x%data))) < rtol')
         
         return
     end subroutine test_rmatvec_csp
@@ -667,8 +676,10 @@ contains
 
         ! Check result.
         alpha = norm2(abs(y%data - matmul(transpose(conjg(A%data)), x%data)))
-
         call check(error, alpha < rtol_sp)
+        call check_test(error, 'test_adjoint_matvec_csp', 'norm2(abs(y%data - matmul(transpose(A%data), x%data))) < rtol')
+
+        
 
        return
     end subroutine test_adjoint_matvec_csp
@@ -702,12 +713,11 @@ contains
 
         ! Check result.
         alpha = norm2(abs(y%data - matmul(A%data, x%data)))
-
         call check(error, alpha < rtol_sp)
+        call check_test(error, 'test_adjoint_rmatvec_csp', 'norm2(abs(y%data - matmul(A%data, x%data))) < rtol')
 
        return
     end subroutine test_adjoint_rmatvec_csp
-
 
     subroutine collect_linop_cdp_testsuite(testsuite)
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
@@ -743,7 +753,8 @@ contains
 
         ! Check result.
         call check(error, norm2(abs(y%data - matmul(A%data, x%data))) < rtol_dp)
-
+        call check_test(error, 'test_matvec_cdp', 'norm2(abs(y%data - matmul(A%data, x%data))) < rtol')
+        
         return
     end subroutine test_matvec_cdp
 
@@ -769,6 +780,7 @@ contains
 
         ! Check result.
         call check(error, norm2(abs(y%data - matmul(transpose(conjg(A%data)), x%data))) < rtol_dp)
+        call check_test(error, 'test_rmatvec_cdp', 'norm2(abs(y%data - matmul(transpose(A%data), x%data))) < rtol')
         
         return
     end subroutine test_rmatvec_cdp
@@ -802,8 +814,10 @@ contains
 
         ! Check result.
         alpha = norm2(abs(y%data - matmul(transpose(conjg(A%data)), x%data)))
-
         call check(error, alpha < rtol_dp)
+        call check_test(error, 'test_adjoint_matvec_cdp', 'norm2(abs(y%data - matmul(transpose(A%data), x%data))) < rtol')
+
+        
 
        return
     end subroutine test_adjoint_matvec_cdp
@@ -837,12 +851,11 @@ contains
 
         ! Check result.
         alpha = norm2(abs(y%data - matmul(A%data, x%data)))
-
         call check(error, alpha < rtol_dp)
+        call check_test(error, 'test_adjoint_rmatvec_cdp', 'norm2(abs(y%data - matmul(A%data, x%data))) < rtol')
 
        return
     end subroutine test_adjoint_rmatvec_cdp
-
 
 end module TestLinops
 

--- a/test/TestLinops.fypp
+++ b/test/TestLinops.fypp
@@ -184,10 +184,10 @@ contains
         ! Check result.
         #:if type[0] == "c"
         call check(error, norm2(abs(y%data - matmul(A%data, x%data))) < rtol_${kind}$)
-        call check_test(error, 'test_matvec_${type[0]}$${kind}$', 'norm2(abs(y%data - matmul(A%data, x%data))) < rtol')
+        call check_test(error, 'test_matvec_${type[0]}$${kind}$', eq='norm2(|y - A @ x|)')
         #:else
         call check(error, norm2(y%data - matmul(A%data, x%data)) < rtol_${kind}$)
-        call check_test(error, 'test_matvec_${type[0]}$${kind}$', 'norm2(y%data - matmul(A%data, x%data)) < rtol')
+        call check_test(error, 'test_matvec_${type[0]}$${kind}$', eq='norm2(y - A @ x)')
         #:endif
         
         return
@@ -222,10 +222,10 @@ contains
         ! Check result.
         #:if type[0] == "c"
         call check(error, norm2(abs(y%data - matmul(transpose(conjg(A%data)), x%data))) < rtol_${kind}$)
-        call check_test(error, 'test_rmatvec_${type[0]}$${kind}$', 'norm2(abs(y%data - matmul(transpose(A%data), x%data))) < rtol')
+        call check_test(error, 'test_rmatvec_${type[0]}$${kind}$', eq='norm2(|y - A.H @ x|)')
         #:else
         call check(error, norm2(y%data - matmul(transpose(A%data), x%data)) < rtol_${kind}$)
-        call check_test(error, 'test_rmatvec_${type[0]}$${kind}$', 'norm2(y%data - matmul(transpose(A%data), x%data)) < rtol')
+        call check_test(error, 'test_rmatvec_${type[0]}$${kind}$', eq='norm2(y - A.T @ x)')
         #:endif
         
         return
@@ -268,11 +268,11 @@ contains
         #:if type[0] == "c"
         alpha = norm2(abs(y%data - matmul(transpose(conjg(A%data)), x%data)))
         call check(error, alpha < rtol_${kind}$)
-        call check_test(error, 'test_adjoint_matvec_${type[0]}$${kind}$', 'norm2(abs(y%data - matmul(transpose(A%data), x%data))) < rtol')
+        call check_test(error, 'test_adjoint_matvec_${type[0]}$${kind}$', eq='norm2(|y - A.H @ x|)')
         #:else
         alpha = norm2(y%data - matmul(transpose(A%data), x%data))
         call check(error, alpha < rtol_${kind}$)
-        call check_test(error, 'test_adjoint_matvec_${type[0]}$${kind}$', 'norm2(y%data - matmul(transpose(A%data), x%data)) < rtol')
+        call check_test(error, 'test_adjoint_matvec_${type[0]}$${kind}$', eq='norm2(y - A.T @ x)')
         #:endif
 
         
@@ -317,11 +317,11 @@ contains
         #:if type[0] == "c"
         alpha = norm2(abs(y%data - matmul(A%data, x%data)))
         call check(error, alpha < rtol_${kind}$)
-        call check_test(error, 'test_adjoint_rmatvec_${type[0]}$${kind}$', 'norm2(abs(y%data - matmul(A%data, x%data))) < rtol')
+        call check_test(error, 'test_adjoint_rmatvec_${type[0]}$${kind}$', eq='norm2(|y - A @ x|)')
         #:else
         alpha = norm2(y%data - matmul(A%data, x%data))
         call check(error, alpha < rtol_${kind}$)
-        call check_test(error, 'test_adjoint_rmatvec_${type[0]}$${kind}$', 'norm2(y%data - matmul(A%data, x%data)) < rtol')
+        call check_test(error, 'test_adjoint_rmatvec_${type[0]}$${kind}$', eq='norm2(y - A @ x)')
         #:endif
 
        return

--- a/test/TestLinops.fypp
+++ b/test/TestLinops.fypp
@@ -7,6 +7,7 @@ module TestLinops
     ! LightKrylov
     use LightKrylov
     use LightKrylov_Constants
+    use LightKrylov_Logger
     
     ! Testdrive
     use testdrive, only: new_unittest, unittest_type, error_type, check
@@ -183,10 +184,12 @@ contains
         ! Check result.
         #:if type[0] == "c"
         call check(error, norm2(abs(y%data - matmul(A%data, x%data))) < rtol_${kind}$)
+        call check_test(error, 'test_matvec_${type[0]}$${kind}$', 'norm2(abs(y%data - matmul(A%data, x%data))) < rtol')
         #:else
         call check(error, norm2(y%data - matmul(A%data, x%data)) < rtol_${kind}$)
+        call check_test(error, 'test_matvec_${type[0]}$${kind}$', 'norm2(y%data - matmul(A%data, x%data)) < rtol')
         #:endif
-
+        
         return
     end subroutine test_matvec_${type[0]}$${kind}$
 
@@ -219,8 +222,10 @@ contains
         ! Check result.
         #:if type[0] == "c"
         call check(error, norm2(abs(y%data - matmul(transpose(conjg(A%data)), x%data))) < rtol_${kind}$)
+        call check_test(error, 'test_rmatvec_${type[0]}$${kind}$', 'norm2(abs(y%data - matmul(transpose(A%data), x%data))) < rtol')
         #:else
         call check(error, norm2(y%data - matmul(transpose(A%data), x%data)) < rtol_${kind}$)
+        call check_test(error, 'test_rmatvec_${type[0]}$${kind}$', 'norm2(y%data - matmul(transpose(A%data), x%data)) < rtol')
         #:endif
         
         return
@@ -262,11 +267,15 @@ contains
         ! Check result.
         #:if type[0] == "c"
         alpha = norm2(abs(y%data - matmul(transpose(conjg(A%data)), x%data)))
+        call check(error, alpha < rtol_${kind}$)
+        call check_test(error, 'test_adjoint_matvec_${type[0]}$${kind}$', 'norm2(abs(y%data - matmul(transpose(A%data), x%data))) < rtol')
         #:else
         alpha = norm2(y%data - matmul(transpose(A%data), x%data))
+        call check(error, alpha < rtol_${kind}$)
+        call check_test(error, 'test_adjoint_matvec_${type[0]}$${kind}$', 'norm2(y%data - matmul(transpose(A%data), x%data)) < rtol')
         #:endif
 
-        call check(error, alpha < rtol_${kind}$)
+        
 
        return
     end subroutine test_adjoint_matvec_${type[0]}$${kind}$
@@ -307,15 +316,16 @@ contains
         ! Check result.
         #:if type[0] == "c"
         alpha = norm2(abs(y%data - matmul(A%data, x%data)))
+        call check(error, alpha < rtol_${kind}$)
+        call check_test(error, 'test_adjoint_rmatvec_${type[0]}$${kind}$', 'norm2(abs(y%data - matmul(A%data, x%data))) < rtol')
         #:else
         alpha = norm2(y%data - matmul(A%data, x%data))
-        #:endif
-
         call check(error, alpha < rtol_${kind}$)
+        call check_test(error, 'test_adjoint_rmatvec_${type[0]}$${kind}$', 'norm2(y%data - matmul(A%data, x%data)) < rtol')
+        #:endif
 
        return
     end subroutine test_adjoint_rmatvec_${type[0]}$${kind}$
-
 
     #:endfor
 end module TestLinops

--- a/test/TestUtils.f90
+++ b/test/TestUtils.f90
@@ -9,7 +9,7 @@ module TestUtils
     
     private
 
-    character*128, parameter, private :: this_module = 'LightKrylov_TestUtils'
+    character(len=128), parameter, private :: this_module = 'LightKrylov_TestUtils'
 
     public :: get_data
     public :: put_data
@@ -73,8 +73,6 @@ contains
     subroutine get_data_vec_rsp(vec_out, vec_in)
         real(sp), intent(out) :: vec_out(:)
         type(vector_rsp), intent(in) :: vec_in
-        ! Internal variables.
-        integer :: k, kdim
         vec_out = vec_in%data
         return
     end subroutine get_data_vec_rsp
@@ -83,9 +81,8 @@ contains
         real(sp), intent(out) :: basis_out(:, :)
         type(vector_rsp), intent(in) :: basis_in(:)
         ! Internal variables.
-        integer :: k, kdim
-        kdim = size(basis_in)
-        do k = 1, kdim
+        integer :: k
+        do k = 1, size(basis_in)
             basis_out(:, k) = basis_in(k)%data
         enddo
         return
@@ -101,8 +98,6 @@ contains
     subroutine get_data_vec_rdp(vec_out, vec_in)
         real(dp), intent(out) :: vec_out(:)
         type(vector_rdp), intent(in) :: vec_in
-        ! Internal variables.
-        integer :: k, kdim
         vec_out = vec_in%data
         return
     end subroutine get_data_vec_rdp
@@ -111,9 +106,8 @@ contains
         real(dp), intent(out) :: basis_out(:, :)
         type(vector_rdp), intent(in) :: basis_in(:)
         ! Internal variables.
-        integer :: k, kdim
-        kdim = size(basis_in)
-        do k = 1, kdim
+        integer :: k
+        do k = 1, size(basis_in)
             basis_out(:, k) = basis_in(k)%data
         enddo
         return
@@ -129,8 +123,6 @@ contains
     subroutine get_data_vec_csp(vec_out, vec_in)
         complex(sp), intent(out) :: vec_out(:)
         type(vector_csp), intent(in) :: vec_in
-        ! Internal variables.
-        integer :: k, kdim
         vec_out = vec_in%data
         return
     end subroutine get_data_vec_csp
@@ -139,9 +131,8 @@ contains
         complex(sp), intent(out) :: basis_out(:, :)
         type(vector_csp), intent(in) :: basis_in(:)
         ! Internal variables.
-        integer :: k, kdim
-        kdim = size(basis_in)
-        do k = 1, kdim
+        integer :: k
+        do k = 1, size(basis_in)
             basis_out(:, k) = basis_in(k)%data
         enddo
         return
@@ -157,8 +148,6 @@ contains
     subroutine get_data_vec_cdp(vec_out, vec_in)
         complex(dp), intent(out) :: vec_out(:)
         type(vector_cdp), intent(in) :: vec_in
-        ! Internal variables.
-        integer :: k, kdim
         vec_out = vec_in%data
         return
     end subroutine get_data_vec_cdp
@@ -167,9 +156,8 @@ contains
         complex(dp), intent(out) :: basis_out(:, :)
         type(vector_cdp), intent(in) :: basis_in(:)
         ! Internal variables.
-        integer :: k, kdim
-        kdim = size(basis_in)
-        do k = 1, kdim
+        integer :: k
+        do k = 1, size(basis_in)
             basis_out(:, k) = basis_in(k)%data
         enddo
         return
@@ -319,8 +307,10 @@ contains
 
     subroutine init_rand_spd_linop_rsp(linop)
         type(spd_linop_rsp), intent(inout) :: linop
-        real(sp), dimension(test_size, 2*test_size) :: data
-        integer :: i
+        real(sp), allocatable :: data(:, :)
+
+        ! Allocate data.
+        allocate(data(test_size, 2*test_size))
         call random_number(data) ; data = data - 0.5_sp
         linop%data = matmul(data, transpose(data)) / 4
         return
@@ -349,8 +339,10 @@ contains
 
     subroutine init_rand_spd_linop_rdp(linop)
         type(spd_linop_rdp), intent(inout) :: linop
-        real(dp), dimension(test_size, 2*test_size) :: data
-        integer :: i
+        real(dp), allocatable :: data(:, :)
+
+        ! Allocate data.
+        allocate(data(test_size, 2*test_size))
         call random_number(data) ; data = data - 0.5_dp
         linop%data = matmul(data, transpose(data)) / 4
         return
@@ -373,7 +365,8 @@ contains
 
     subroutine init_rand_linop_csp(linop)
         type(linop_csp), intent(inout) :: linop
-        real(sp), dimension(test_size, test_size, 2) :: data
+        real(sp), allocatable :: data(:, :, :)
+        allocate(data(test_size, test_size, 2))
         call random_number(data) ; data = data - 0.5_sp
         linop%data%re = data(:, :, 1)
         linop%data%im = data(:, :, 2)
@@ -382,10 +375,15 @@ contains
 
     subroutine init_rand_hermitian_linop_csp(linop)
         type(hermitian_linop_csp), intent(inout) :: linop
-        real(sp), dimension(test_size, 2*test_size, 2) :: data
-        complex(sp), dimension(test_size, 2*test_size) :: data_c
-        complex(sp), dimension(test_size, test_size) :: matrix
-        integer :: i
+        real(sp), allocatable :: data(:, :, :)
+        complex(sp), allocatable :: data_c(:, :)
+        complex(sp), allocatable :: matrix(:, :)
+
+        ! Allocate data.
+        allocate(data(test_size, 2*test_size, 2))
+        allocate(data_c(test_size, 2*test_size))
+        allocate(matrix(test_size, test_size))
+
         call random_number(data)
         data_c%re = data(:, :, 1) - 0.5_sp
         data_c%im = data(:, :, 2) - 0.5_sp
@@ -411,7 +409,8 @@ contains
 
     subroutine init_rand_linop_cdp(linop)
         type(linop_cdp), intent(inout) :: linop
-        real(dp), dimension(test_size, test_size, 2) :: data
+        real(dp), allocatable :: data(:, :, :)
+        allocate(data(test_size, test_size, 2))
         call random_number(data) ; data = data - 0.5_dp
         linop%data%re = data(:, :, 1)
         linop%data%im = data(:, :, 2)
@@ -420,10 +419,15 @@ contains
 
     subroutine init_rand_hermitian_linop_cdp(linop)
         type(hermitian_linop_cdp), intent(inout) :: linop
-        real(dp), dimension(test_size, 2*test_size, 2) :: data
-        complex(dp), dimension(test_size, 2*test_size) :: data_c
-        complex(dp), dimension(test_size, test_size) :: matrix
-        integer :: i
+        real(dp), allocatable :: data(:, :, :)
+        complex(dp), allocatable :: data_c(:, :)
+        complex(dp), allocatable :: matrix(:, :)
+
+        ! Allocate data.
+        allocate(data(test_size, 2*test_size, 2))
+        allocate(data_c(test_size, 2*test_size))
+        allocate(matrix(test_size, test_size))
+
         call random_number(data)
         data_c%re = data(:, :, 1) - 0.5_dp
         data_c%im = data(:, :, 2) - 0.5_dp

--- a/test/TestUtils.f90
+++ b/test/TestUtils.f90
@@ -14,6 +14,7 @@ module TestUtils
     public :: get_data
     public :: put_data
     public :: init_rand
+    public :: get_err_str
 
     interface get_data
         module procedure get_data_vec_rsp
@@ -62,6 +63,11 @@ module TestUtils
         module procedure init_rand_basis_cdp
         module procedure init_rand_linop_cdp
         module procedure init_rand_hermitian_linop_cdp
+    end interface
+
+    interface get_err_str
+        module procedure get_err_str_sp
+        module procedure get_err_str_dp
     end interface
 
 contains
@@ -436,5 +442,32 @@ contains
         return
     end subroutine init_rand_hermitian_linop_cdp
 
+
+    subroutine get_err_str_sp(msg, info, err)
+      character(len=*), intent(inout) :: msg
+      character(len=*), intent(in)    :: info
+      real(sp) :: err
+
+      ! internals
+      character*8 :: value_str
+      character(len=*), parameter :: indent = repeat(" ", 4)
+
+      write(value_str, '(E8.2)') err
+      msg = indent // info // value_str // achar(10)
+       
+    end subroutine get_err_str_sp
+    subroutine get_err_str_dp(msg, info, err)
+      character(len=*), intent(inout) :: msg
+      character(len=*), intent(in)    :: info
+      real(dp) :: err
+
+      ! internals
+      character*8 :: value_str
+      character(len=*), parameter :: indent = repeat(" ", 4)
+
+      write(value_str, '(E8.2)') err
+      msg = indent // info // value_str // achar(10)
+       
+    end subroutine get_err_str_dp
 
 end module

--- a/test/TestUtils.f90
+++ b/test/TestUtils.f90
@@ -1,5 +1,7 @@
 module TestUtils
     use stdlib_io_npy, only: save_npy
+    use stdlib_linalg, only: eye, diag
+    use stdlib_stats_distribution_normal, only: normal => rvs_normal
     use LightKrylov
     use LightKrylov_Constants
     use TestVectors
@@ -307,18 +309,24 @@ contains
 
     subroutine init_rand_linop_rsp(linop)
         type(linop_rsp), intent(inout) :: linop
-        call random_number(linop%data)
+        real(sp), allocatable :: mu(:, :), var(:, :)
+        allocate(mu(test_size, test_size)) ; mu = 0.0_sp
+        allocate(var(test_size, test_size))
+        var = 1.0_sp
+        linop%data = normal(mu, var)
         return
     end subroutine init_rand_linop_rsp
 
     subroutine init_rand_spd_linop_rsp(linop)
         type(spd_linop_rsp), intent(inout) :: linop
+        real(sp), allocatable :: mu(:, :), var(:, :)
         real(sp), allocatable :: data(:, :)
+        allocate(mu(test_size, test_size)) ; mu = zero_rsp
+        allocate(var(test_size, test_size)) ; var = one_rsp
 
-        ! Allocate data.
-        allocate(data(test_size, 2*test_size))
-        call random_number(data) ; data = data - 0.5_sp
-        linop%data = matmul(data, transpose(data)) / 4
+        data = normal(mu, var)
+        linop%data = matmul(data, transpose(data))/test_size + 0.01*eye(test_size)
+
         return
     end subroutine init_rand_spd_linop_rsp
 
@@ -339,18 +347,24 @@ contains
 
     subroutine init_rand_linop_rdp(linop)
         type(linop_rdp), intent(inout) :: linop
-        call random_number(linop%data)
+        real(dp), allocatable :: mu(:, :), var(:, :)
+        allocate(mu(test_size, test_size)) ; mu = 0.0_dp
+        allocate(var(test_size, test_size))
+        var = 1.0_dp
+        linop%data = normal(mu, var)
         return
     end subroutine init_rand_linop_rdp
 
     subroutine init_rand_spd_linop_rdp(linop)
         type(spd_linop_rdp), intent(inout) :: linop
+        real(dp), allocatable :: mu(:, :), var(:, :)
         real(dp), allocatable :: data(:, :)
+        allocate(mu(test_size, test_size)) ; mu = zero_rdp
+        allocate(var(test_size, test_size)) ; var = one_rdp
 
-        ! Allocate data.
-        allocate(data(test_size, 2*test_size))
-        call random_number(data) ; data = data - 0.5_dp
-        linop%data = matmul(data, transpose(data)) / 4
+        data = normal(mu, var)
+        linop%data = matmul(data, transpose(data))/test_size + 0.01*eye(test_size)
+
         return
     end subroutine init_rand_spd_linop_rdp
 
@@ -371,30 +385,26 @@ contains
 
     subroutine init_rand_linop_csp(linop)
         type(linop_csp), intent(inout) :: linop
-        real(sp), allocatable :: data(:, :, :)
-        allocate(data(test_size, test_size, 2))
-        call random_number(data) ; data = data - 0.5_sp
-        linop%data%re = data(:, :, 1)
-        linop%data%im = data(:, :, 2)
+        complex(sp), allocatable :: mu(:, :), var(:, :)
+        allocate(mu(test_size, test_size)) ; mu = 0.0_sp
+        allocate(var(test_size, test_size))
+        var = cmplx(1.0_sp, 1.0_sp, kind=sp)
+        linop%data = normal(mu, var)
         return
     end subroutine init_rand_linop_csp
 
     subroutine init_rand_hermitian_linop_csp(linop)
         type(hermitian_linop_csp), intent(inout) :: linop
-        real(sp), allocatable :: data(:, :, :)
-        complex(sp), allocatable :: data_c(:, :)
-        complex(sp), allocatable :: matrix(:, :)
+        complex(sp), allocatable :: data(:, :)
+        complex(sp), allocatable :: mu(:, :), var(:, :)
 
-        ! Allocate data.
-        allocate(data(test_size, 2*test_size, 2))
-        allocate(data_c(test_size, 2*test_size))
-        allocate(matrix(test_size, test_size))
+        allocate(mu(test_size, test_size)) ; mu = 0.0_sp
+        allocate(var(test_size, test_size)) ; var = cmplx(1.0_sp, 1.0_sp, kind=sp)
 
-        call random_number(data)
-        data_c%re = data(:, :, 1) - 0.5_sp
-        data_c%im = data(:, :, 2) - 0.5_sp
-        matrix = matmul(data_c, transpose(conjg(data_c))) / 4
-        linop%data = matrix
+        data = normal(mu, var)
+        data = matmul(data, transpose(conjg(data)))/test_size + 0.01*eye(test_size)
+        linop%data = data
+
         return
     end subroutine init_rand_hermitian_linop_csp
 
@@ -415,30 +425,26 @@ contains
 
     subroutine init_rand_linop_cdp(linop)
         type(linop_cdp), intent(inout) :: linop
-        real(dp), allocatable :: data(:, :, :)
-        allocate(data(test_size, test_size, 2))
-        call random_number(data) ; data = data - 0.5_dp
-        linop%data%re = data(:, :, 1)
-        linop%data%im = data(:, :, 2)
+        complex(dp), allocatable :: mu(:, :), var(:, :)
+        allocate(mu(test_size, test_size)) ; mu = 0.0_dp
+        allocate(var(test_size, test_size))
+        var = cmplx(1.0_dp, 1.0_dp, kind=dp)
+        linop%data = normal(mu, var)
         return
     end subroutine init_rand_linop_cdp
 
     subroutine init_rand_hermitian_linop_cdp(linop)
         type(hermitian_linop_cdp), intent(inout) :: linop
-        real(dp), allocatable :: data(:, :, :)
-        complex(dp), allocatable :: data_c(:, :)
-        complex(dp), allocatable :: matrix(:, :)
+        complex(dp), allocatable :: data(:, :)
+        complex(dp), allocatable :: mu(:, :), var(:, :)
 
-        ! Allocate data.
-        allocate(data(test_size, 2*test_size, 2))
-        allocate(data_c(test_size, 2*test_size))
-        allocate(matrix(test_size, test_size))
+        allocate(mu(test_size, test_size)) ; mu = 0.0_dp
+        allocate(var(test_size, test_size)) ; var = cmplx(1.0_dp, 1.0_dp, kind=dp)
 
-        call random_number(data)
-        data_c%re = data(:, :, 1) - 0.5_dp
-        data_c%im = data(:, :, 2) - 0.5_dp
-        matrix = matmul(data_c, transpose(conjg(data_c))) / 4
-        linop%data = matrix
+        data = normal(mu, var)
+        data = matmul(data, transpose(conjg(data)))/test_size + 0.01*eye(test_size)
+        linop%data = data
+
         return
     end subroutine init_rand_hermitian_linop_cdp
 

--- a/test/TestUtils.fypp
+++ b/test/TestUtils.fypp
@@ -16,6 +16,7 @@ module TestUtils
     public :: get_data
     public :: put_data
     public :: init_rand
+    public :: get_err_str
 
     interface get_data
         #:for kind, type in RC_KINDS_TYPES
@@ -43,6 +44,12 @@ module TestUtils
         #:else
         module procedure init_rand_hermitian_linop_${type[0]}$${kind}$
         #:endif
+        #:endfor
+    end interface
+
+    interface get_err_str
+        #:for kind, type in REAL_KINDS_TYPES
+        module procedure get_err_str_${kind}$
         #:endfor
     end interface
 
@@ -179,6 +186,22 @@ contains
     end subroutine init_rand_hermitian_linop_${type[0]}$${kind}$
     #:endif
 
+    #:endfor
+
+    #:for kind, type in REAL_KINDS_TYPES
+    subroutine get_err_str_${kind}$(msg, info, err)
+      character(len=*), intent(inout) :: msg
+      character(len=*), intent(in)    :: info
+      real(${kind}$) :: err
+
+      ! internals
+      character*8 :: value_str
+      character(len=*), parameter :: indent = repeat(" ", 4)
+
+      write(value_str, '(E8.2)') err
+      msg = indent // info // value_str // achar(10)
+       
+    end subroutine get_err_str_${kind}$
     #:endfor
 
 end module

--- a/test/TestUtils.fypp
+++ b/test/TestUtils.fypp
@@ -2,6 +2,8 @@
 #:set RC_KINDS_TYPES = REAL_KINDS_TYPES + CMPLX_KINDS_TYPES
 module TestUtils
     use stdlib_io_npy, only: save_npy
+    use stdlib_linalg, only: eye, diag
+    use stdlib_stats_distribution_normal, only: normal => rvs_normal
     use LightKrylov
     use LightKrylov_Constants
     use TestVectors
@@ -142,46 +144,44 @@ contains
 
     subroutine init_rand_linop_${type[0]}$${kind}$(linop)
         type(linop_${type[0]}$${kind}$), intent(inout) :: linop
-        #:if type[0] == "c"
-        real(${kind}$), allocatable :: data(:, :, :)
-        allocate(data(test_size, test_size, 2))
-        call random_number(data) ; data = data - 0.5_${kind}$
-        linop%data%re = data(:, :, 1)
-        linop%data%im = data(:, :, 2)
+        ${type}$, allocatable :: mu(:, :), var(:, :)
+        allocate(mu(test_size, test_size)) ; mu = 0.0_${kind}$
+        allocate(var(test_size, test_size))
+        #:if type[0] == "r"
+        var = 1.0_${kind}$
         #:else
-        call random_number(linop%data)
+        var = cmplx(1.0_${kind}$, 1.0_${kind}$, kind=${kind}$)
         #:endif
+        linop%data = normal(mu, var)
         return
     end subroutine init_rand_linop_${type[0]}$${kind}$
 
     #:if type[0] == "r"
     subroutine init_rand_spd_linop_${type[0]}$${kind}$(linop)
         type(spd_linop_${type[0]}$${kind}$), intent(inout) :: linop
+        ${type}$, allocatable :: mu(:, :), var(:, :)
         ${type}$, allocatable :: data(:, :)
+        allocate(mu(test_size, test_size)) ; mu = zero_${type[0]}$${kind}$
+        allocate(var(test_size, test_size)) ; var = one_${type[0]}$${kind}$
 
-        ! Allocate data.
-        allocate(data(test_size, 2*test_size))
-        call random_number(data) ; data = data - 0.5_${kind}$
-        linop%data = matmul(data, transpose(data)) / 4
+        data = normal(mu, var)
+        linop%data = matmul(data, transpose(data))/test_size + 0.01*eye(test_size)
+
         return
     end subroutine init_rand_spd_linop_${type[0]}$${kind}$
     #:else
     subroutine init_rand_hermitian_linop_${type[0]}$${kind}$(linop)
         type(hermitian_linop_${type[0]}$${kind}$), intent(inout) :: linop
-        real(${kind}$), allocatable :: data(:, :, :)
-        ${type}$, allocatable :: data_c(:, :)
-        ${type}$, allocatable :: matrix(:, :)
+        ${type}$, allocatable :: data(:, :)
+        ${type}$, allocatable :: mu(:, :), var(:, :)
 
-        ! Allocate data.
-        allocate(data(test_size, 2*test_size, 2))
-        allocate(data_c(test_size, 2*test_size))
-        allocate(matrix(test_size, test_size))
+        allocate(mu(test_size, test_size)) ; mu = 0.0_${kind}$
+        allocate(var(test_size, test_size)) ; var = cmplx(1.0_${kind}$, 1.0_${kind}$, kind=${kind}$)
 
-        call random_number(data)
-        data_c%re = data(:, :, 1) - 0.5_${kind}$
-        data_c%im = data(:, :, 2) - 0.5_${kind}$
-        matrix = matmul(data_c, transpose(conjg(data_c))) / 4
-        linop%data = matrix
+        data = normal(mu, var)
+        data = matmul(data, transpose(conjg(data)))/test_size + 0.01*eye(test_size)
+        linop%data = data
+
         return
     end subroutine init_rand_hermitian_linop_${type[0]}$${kind}$
     #:endif

--- a/test/TestUtils.fypp
+++ b/test/TestUtils.fypp
@@ -11,7 +11,7 @@ module TestUtils
     
     private
 
-    character*128, parameter, private :: this_module = 'LightKrylov_TestUtils'
+    character(len=128), parameter, private :: this_module = 'LightKrylov_TestUtils'
 
     public :: get_data
     public :: put_data
@@ -56,8 +56,6 @@ contains
     subroutine get_data_vec_${type[0]}$${kind}$(vec_out, vec_in)
         ${type}$, intent(out) :: vec_out(:)
         type(vector_${type[0]}$${kind}$), intent(in) :: vec_in
-        ! Internal variables.
-        integer :: k, kdim
         vec_out = vec_in%data
         return
     end subroutine get_data_vec_${type[0]}$${kind}$
@@ -66,9 +64,8 @@ contains
         ${type}$, intent(out) :: basis_out(:, :)
         type(vector_${type[0]}$${kind}$), intent(in) :: basis_in(:)
         ! Internal variables.
-        integer :: k, kdim
-        kdim = size(basis_in)
-        do k = 1, kdim
+        integer :: k
+        do k = 1, size(basis_in)
             basis_out(:, k) = basis_in(k)%data
         enddo
         return
@@ -139,7 +136,8 @@ contains
     subroutine init_rand_linop_${type[0]}$${kind}$(linop)
         type(linop_${type[0]}$${kind}$), intent(inout) :: linop
         #:if type[0] == "c"
-        real(${kind}$), dimension(test_size, test_size, 2) :: data
+        real(${kind}$), allocatable :: data(:, :, :)
+        allocate(data(test_size, test_size, 2))
         call random_number(data) ; data = data - 0.5_${kind}$
         linop%data%re = data(:, :, 1)
         linop%data%im = data(:, :, 2)
@@ -152,8 +150,10 @@ contains
     #:if type[0] == "r"
     subroutine init_rand_spd_linop_${type[0]}$${kind}$(linop)
         type(spd_linop_${type[0]}$${kind}$), intent(inout) :: linop
-        ${type}$, dimension(test_size, 2*test_size) :: data
-        integer :: i
+        ${type}$, allocatable :: data(:, :)
+
+        ! Allocate data.
+        allocate(data(test_size, 2*test_size))
         call random_number(data) ; data = data - 0.5_${kind}$
         linop%data = matmul(data, transpose(data)) / 4
         return
@@ -161,10 +161,15 @@ contains
     #:else
     subroutine init_rand_hermitian_linop_${type[0]}$${kind}$(linop)
         type(hermitian_linop_${type[0]}$${kind}$), intent(inout) :: linop
-        real(${kind}$), dimension(test_size, 2*test_size, 2) :: data
-        ${type}$, dimension(test_size, 2*test_size) :: data_c
-        ${type}$, dimension(test_size, test_size) :: matrix
-        integer :: i
+        real(${kind}$), allocatable :: data(:, :, :)
+        ${type}$, allocatable :: data_c(:, :)
+        ${type}$, allocatable :: matrix(:, :)
+
+        ! Allocate data.
+        allocate(data(test_size, 2*test_size, 2))
+        allocate(data_c(test_size, 2*test_size))
+        allocate(matrix(test_size, test_size))
+
         call random_number(data)
         data_c%re = data(:, :, 1) - 0.5_${kind}$
         data_c%im = data(:, :, 2) - 0.5_${kind}$

--- a/test/TestVectors.f90
+++ b/test/TestVectors.f90
@@ -3,13 +3,14 @@ module TestVectors
     use LightKrylov_Logger
     use testdrive, only: new_unittest, unittest_type, error_type, check
     use stdlib_math, only: is_close, all_close
+    use stdlib_stats_distribution_normal, only: normal => rvs_normal
     use stdlib_optval, only: optval
     
     implicit none
     
     private
 
-    character*128, parameter, private :: this_module = 'LightKrylov_TestVectors'
+    character(len=128), parameter, private :: this_module = 'LightKrylov_TestVectors'
 
     integer, parameter, public :: test_size = 128
 
@@ -108,9 +109,13 @@ contains
         class(vector_rsp), intent(inout) :: self
         logical, optional, intent(in) :: ifnorm
         logical :: normalized
+        real(sp) :: mu(test_size), var(test_size)
         real(sp) :: alpha
-        call random_number(self%data)
-
+ 
+        mu = 0.0_sp
+        var = 1.0_sp
+        self%data = normal(mu, var)
+ 
         normalized = optval(ifnorm, .false.)
         if (normalized) then
             alpha = self%norm()
@@ -158,9 +163,13 @@ contains
         class(vector_rdp), intent(inout) :: self
         logical, optional, intent(in) :: ifnorm
         logical :: normalized
+        real(dp) :: mu(test_size), var(test_size)
         real(dp) :: alpha
-        call random_number(self%data)
-
+ 
+        mu = 0.0_dp
+        var = 1.0_dp
+        self%data = normal(mu, var)
+ 
         normalized = optval(ifnorm, .false.)
         if (normalized) then
             alpha = self%norm()
@@ -208,13 +217,13 @@ contains
         class(vector_csp), intent(inout) :: self
         logical, optional, intent(in) :: ifnorm
         logical :: normalized
+        complex(sp) :: mu(test_size), var(test_size)
         complex(sp) :: alpha
-        real(sp), dimension(test_size, 2) :: data
-
-        call random_number(data)
-        self%data%re = data(:, 1)
-        self%data%im = data(:, 2)
-
+ 
+        mu = 0.0_sp
+        var = cmplx(1.0_sp, 1.0_sp, kind=sp)
+        self%data = normal(mu, var)
+ 
         normalized = optval(ifnorm, .false.)
         if (normalized) then
             alpha = self%norm()
@@ -262,13 +271,13 @@ contains
         class(vector_cdp), intent(inout) :: self
         logical, optional, intent(in) :: ifnorm
         logical :: normalized
+        complex(dp) :: mu(test_size), var(test_size)
         complex(dp) :: alpha
-        real(dp), dimension(test_size, 2) :: data
-
-        call random_number(data)
-        self%data%re = data(:, 1)
-        self%data%im = data(:, 2)
-
+ 
+        mu = 0.0_dp
+        var = cmplx(1.0_dp, 1.0_dp, kind=dp)
+        self%data = normal(mu, var)
+ 
         normalized = optval(ifnorm, .false.)
         if (normalized) then
             alpha = self%norm()

--- a/test/TestVectors.f90
+++ b/test/TestVectors.f90
@@ -1,5 +1,6 @@
 module TestVectors
     use LightKrylov
+    use LightKrylov_Logger
     use testdrive, only: new_unittest, unittest_type, error_type, check
     use stdlib_math, only: is_close, all_close
     use stdlib_optval, only: optval
@@ -308,6 +309,7 @@ contains
 
         ! Check result.
         call check(error, is_close(alpha, norm2(x%data)))
+        call check_test(error, 'test_vector_rsp_norm', 'is_close(alpha, norm2(x%data))')
         
         return
     end subroutine test_vector_rsp_norm
@@ -329,6 +331,7 @@ contains
 
         ! Check correctness.
         call check(error, norm2(z%data - x%data - y%data) < rtol_sp)
+        call check_test(error, 'test_vector_rsp_add', 'norm2(z%data - x%data - y%data) < rtol')
 
         return
     end subroutine test_vector_rsp_add
@@ -350,6 +353,7 @@ contains
 
         ! Check correctness.
         call check(error, norm2(z%data - x%data + y%data) < rtol_sp)
+        call check_test(error, 'test_vector_rsp_sub', 'norm2(z%data - x%data + y%data) < rtol')
 
         return
     end subroutine test_vector_rsp_sub
@@ -371,6 +375,7 @@ contains
 
         ! Check correctness.
         call check(error, abs(alpha - dot_product(x%data, y%data)) < rtol_sp)
+        call check_test(error, 'test_vector_rsp_dot', 'abs(alpha - dot_product(x%data, y%data)) < rtol')
 
         return
     end subroutine test_vector_rsp_dot
@@ -393,6 +398,7 @@ contains
 
         ! Check correctness.
         call check(error, norm2(x%data - alpha*y%data) < rtol_sp)
+        call check_test(error, 'test_vector_rsp_scal', 'norm2(x%data - alpha*y%data) < rtol')
 
         return
     end subroutine test_vector_rsp_scal
@@ -425,6 +431,7 @@ contains
 
         ! Check result.
         call check(error, is_close(alpha, norm2(x%data)))
+        call check_test(error, 'test_vector_rdp_norm', 'is_close(alpha, norm2(x%data))')
         
         return
     end subroutine test_vector_rdp_norm
@@ -446,6 +453,7 @@ contains
 
         ! Check correctness.
         call check(error, norm2(z%data - x%data - y%data) < rtol_dp)
+        call check_test(error, 'test_vector_rdp_add', 'norm2(z%data - x%data - y%data) < rtol')
 
         return
     end subroutine test_vector_rdp_add
@@ -467,6 +475,7 @@ contains
 
         ! Check correctness.
         call check(error, norm2(z%data - x%data + y%data) < rtol_dp)
+        call check_test(error, 'test_vector_rdp_sub', 'norm2(z%data - x%data + y%data) < rtol')
 
         return
     end subroutine test_vector_rdp_sub
@@ -488,6 +497,7 @@ contains
 
         ! Check correctness.
         call check(error, abs(alpha - dot_product(x%data, y%data)) < rtol_dp)
+        call check_test(error, 'test_vector_rdp_dot', 'abs(alpha - dot_product(x%data, y%data)) < rtol')
 
         return
     end subroutine test_vector_rdp_dot
@@ -510,6 +520,7 @@ contains
 
         ! Check correctness.
         call check(error, norm2(x%data - alpha*y%data) < rtol_dp)
+        call check_test(error, 'test_vector_rdp_scal', 'norm2(x%data - alpha*y%data) < rtol')
 
         return
     end subroutine test_vector_rdp_scal
@@ -542,6 +553,7 @@ contains
 
         ! Check result.
         call check(error, is_close(alpha, sqrt(sum(x%data%re**2 + x%data%im**2))))
+        call check_test(error, 'test_vector_csp_norm', 'is_close(alpha, norm2(x%data))')
         
         return
     end subroutine test_vector_csp_norm
@@ -563,6 +575,7 @@ contains
 
         ! Check correctness.
         call check(error, sqrt(sum((z%data%re - x%data%re - y%data%re)**2 + (z%data%im - x%data%im - y%data%im)**2)) < rtol_sp)
+        call check_test(error, 'test_vector_csp_add', 'norm2(z%data - x%data - y%data) < rtol')
 
         return
     end subroutine test_vector_csp_add
@@ -584,6 +597,7 @@ contains
 
         ! Check correctness.
         call check(error, sqrt(sum((z%data%re - x%data%re + y%data%re)**2 + (z%data%im - x%data%im + y%data%im)**2)) < rtol_sp)
+        call check_test(error, 'test_vector_csp_sub', 'norm2(z%data - x%data + y%data) < rtol')
 
         return
     end subroutine test_vector_csp_sub
@@ -605,6 +619,7 @@ contains
 
         ! Check correctness.
         call check(error, abs(alpha - dot_product(x%data, y%data)) < rtol_sp)
+        call check_test(error, 'test_vector_csp_dot', 'abs(alpha - dot_product(x%data, y%data)) < rtol')
 
         return
     end subroutine test_vector_csp_dot
@@ -629,6 +644,7 @@ contains
         ! Check correctness.
         tmp = x%data - alpha*y%data
         call check(error, sqrt(sum(tmp%re**2 + tmp%im**2)) < rtol_sp)
+        call check_test(error, 'test_vector_csp_scal', 'norm2(x%data - alpha*y%data) < rtol')
 
         return
     end subroutine test_vector_csp_scal
@@ -661,6 +677,7 @@ contains
 
         ! Check result.
         call check(error, is_close(alpha, sqrt(sum(x%data%re**2 + x%data%im**2))))
+        call check_test(error, 'test_vector_cdp_norm', 'is_close(alpha, norm2(x%data))')
         
         return
     end subroutine test_vector_cdp_norm
@@ -682,6 +699,7 @@ contains
 
         ! Check correctness.
         call check(error, sqrt(sum((z%data%re - x%data%re - y%data%re)**2 + (z%data%im - x%data%im - y%data%im)**2)) < rtol_dp)
+        call check_test(error, 'test_vector_cdp_add', 'norm2(z%data - x%data - y%data) < rtol')
 
         return
     end subroutine test_vector_cdp_add
@@ -703,6 +721,7 @@ contains
 
         ! Check correctness.
         call check(error, sqrt(sum((z%data%re - x%data%re + y%data%re)**2 + (z%data%im - x%data%im + y%data%im)**2)) < rtol_dp)
+        call check_test(error, 'test_vector_cdp_sub', 'norm2(z%data - x%data + y%data) < rtol')
 
         return
     end subroutine test_vector_cdp_sub
@@ -724,6 +743,7 @@ contains
 
         ! Check correctness.
         call check(error, abs(alpha - dot_product(x%data, y%data)) < rtol_dp)
+        call check_test(error, 'test_vector_cdp_dot', 'abs(alpha - dot_product(x%data, y%data)) < rtol')
 
         return
     end subroutine test_vector_cdp_dot
@@ -748,6 +768,7 @@ contains
         ! Check correctness.
         tmp = x%data - alpha*y%data
         call check(error, sqrt(sum(tmp%re**2 + tmp%im**2)) < rtol_dp)
+        call check_test(error, 'test_vector_cdp_scal', 'norm2(x%data - alpha*y%data) < rtol')
 
         return
     end subroutine test_vector_cdp_scal

--- a/test/TestVectors.f90
+++ b/test/TestVectors.f90
@@ -309,7 +309,8 @@ contains
 
         ! Check result.
         call check(error, is_close(alpha, norm2(x%data)))
-        call check_test(error, 'test_vector_rsp_norm', 'is_close(alpha, norm2(x%data))')
+        call check_test(error, 'test_vector_rsp_norm', eq='is_close(x%norm, norm2(x))')
+        
         
         return
     end subroutine test_vector_rsp_norm
@@ -331,7 +332,7 @@ contains
 
         ! Check correctness.
         call check(error, norm2(z%data - x%data - y%data) < rtol_sp)
-        call check_test(error, 'test_vector_rsp_add', 'norm2(z%data - x%data - y%data) < rtol')
+        call check_test(error, 'test_vector_rsp_norm', eq='is_close(x%norm, norm2(z - (x+y)))')
 
         return
     end subroutine test_vector_rsp_add
@@ -353,7 +354,7 @@ contains
 
         ! Check correctness.
         call check(error, norm2(z%data - x%data + y%data) < rtol_sp)
-        call check_test(error, 'test_vector_rsp_sub', 'norm2(z%data - x%data + y%data) < rtol')
+        call check_test(error, 'test_vector_rsp_norm', eq='is_close(x%norm, norm2(z - (x-y)))')
 
         return
     end subroutine test_vector_rsp_sub
@@ -375,7 +376,7 @@ contains
 
         ! Check correctness.
         call check(error, abs(alpha - dot_product(x%data, y%data)) < rtol_sp)
-        call check_test(error, 'test_vector_rsp_dot', 'abs(alpha - dot_product(x%data, y%data)) < rtol')
+        call check_test(error, 'test_vector_rsp_dot', eq='abs(x%dot(y) - dot_product(x, y))')
 
         return
     end subroutine test_vector_rsp_dot
@@ -398,7 +399,7 @@ contains
 
         ! Check correctness.
         call check(error, norm2(x%data - alpha*y%data) < rtol_sp)
-        call check_test(error, 'test_vector_rsp_scal', 'norm2(x%data - alpha*y%data) < rtol')
+        call check_test(error, 'test_vector_rsp_scal', eq='norm2(x - alpha*y)')
 
         return
     end subroutine test_vector_rsp_scal
@@ -431,7 +432,8 @@ contains
 
         ! Check result.
         call check(error, is_close(alpha, norm2(x%data)))
-        call check_test(error, 'test_vector_rdp_norm', 'is_close(alpha, norm2(x%data))')
+        call check_test(error, 'test_vector_rdp_norm', eq='is_close(x%norm, norm2(x))')
+        
         
         return
     end subroutine test_vector_rdp_norm
@@ -453,7 +455,7 @@ contains
 
         ! Check correctness.
         call check(error, norm2(z%data - x%data - y%data) < rtol_dp)
-        call check_test(error, 'test_vector_rdp_add', 'norm2(z%data - x%data - y%data) < rtol')
+        call check_test(error, 'test_vector_rdp_norm', eq='is_close(x%norm, norm2(z - (x+y)))')
 
         return
     end subroutine test_vector_rdp_add
@@ -475,7 +477,7 @@ contains
 
         ! Check correctness.
         call check(error, norm2(z%data - x%data + y%data) < rtol_dp)
-        call check_test(error, 'test_vector_rdp_sub', 'norm2(z%data - x%data + y%data) < rtol')
+        call check_test(error, 'test_vector_rdp_norm', eq='is_close(x%norm, norm2(z - (x-y)))')
 
         return
     end subroutine test_vector_rdp_sub
@@ -497,7 +499,7 @@ contains
 
         ! Check correctness.
         call check(error, abs(alpha - dot_product(x%data, y%data)) < rtol_dp)
-        call check_test(error, 'test_vector_rdp_dot', 'abs(alpha - dot_product(x%data, y%data)) < rtol')
+        call check_test(error, 'test_vector_rdp_dot', eq='abs(x%dot(y) - dot_product(x, y))')
 
         return
     end subroutine test_vector_rdp_dot
@@ -520,7 +522,7 @@ contains
 
         ! Check correctness.
         call check(error, norm2(x%data - alpha*y%data) < rtol_dp)
-        call check_test(error, 'test_vector_rdp_scal', 'norm2(x%data - alpha*y%data) < rtol')
+        call check_test(error, 'test_vector_rdp_scal', eq='norm2(x - alpha*y)')
 
         return
     end subroutine test_vector_rdp_scal
@@ -553,7 +555,8 @@ contains
 
         ! Check result.
         call check(error, is_close(alpha, sqrt(sum(x%data%re**2 + x%data%im**2))))
-        call check_test(error, 'test_vector_csp_norm', 'is_close(alpha, norm2(x%data))')
+        call check_test(error, 'test_vector_csp_norm', eq='is_close(x%norm, sqrt(sum(Re(x)^2 + Im(x)^2)))')
+        
         
         return
     end subroutine test_vector_csp_norm
@@ -575,7 +578,7 @@ contains
 
         ! Check correctness.
         call check(error, sqrt(sum((z%data%re - x%data%re - y%data%re)**2 + (z%data%im - x%data%im - y%data%im)**2)) < rtol_sp)
-        call check_test(error, 'test_vector_csp_add', 'norm2(z%data - x%data - y%data) < rtol')
+        call check_test(error, 'test_vector_csp_norm', eq='is_close(x%norm,  sqrt(sum(Re(z - (x+y))^2 + Im(z - (x+y))^2)))')
 
         return
     end subroutine test_vector_csp_add
@@ -597,7 +600,7 @@ contains
 
         ! Check correctness.
         call check(error, sqrt(sum((z%data%re - x%data%re + y%data%re)**2 + (z%data%im - x%data%im + y%data%im)**2)) < rtol_sp)
-        call check_test(error, 'test_vector_csp_sub', 'norm2(z%data - x%data + y%data) < rtol')
+        call check_test(error, 'test_vector_csp_norm', eq='is_close(x%norm, sqrt(sum(Re(z - (x-y))^2 + Im(z - (x-y))^2)))')
 
         return
     end subroutine test_vector_csp_sub
@@ -619,7 +622,7 @@ contains
 
         ! Check correctness.
         call check(error, abs(alpha - dot_product(x%data, y%data)) < rtol_sp)
-        call check_test(error, 'test_vector_csp_dot', 'abs(alpha - dot_product(x%data, y%data)) < rtol')
+        call check_test(error, 'test_vector_csp_dot', eq='abs(x%dot(y) - dot_product(x, y))')
 
         return
     end subroutine test_vector_csp_dot
@@ -644,7 +647,7 @@ contains
         ! Check correctness.
         tmp = x%data - alpha*y%data
         call check(error, sqrt(sum(tmp%re**2 + tmp%im**2)) < rtol_sp)
-        call check_test(error, 'test_vector_csp_scal', 'norm2(x%data - alpha*y%data) < rtol')
+        call check_test(error, 'test_vector_csp_scal', eq='sqrt(sum(Re(x - alpha*y)**2 + Im(x - alpha*y)**2))')
 
         return
     end subroutine test_vector_csp_scal
@@ -677,7 +680,8 @@ contains
 
         ! Check result.
         call check(error, is_close(alpha, sqrt(sum(x%data%re**2 + x%data%im**2))))
-        call check_test(error, 'test_vector_cdp_norm', 'is_close(alpha, norm2(x%data))')
+        call check_test(error, 'test_vector_cdp_norm', eq='is_close(x%norm, sqrt(sum(Re(x)^2 + Im(x)^2)))')
+        
         
         return
     end subroutine test_vector_cdp_norm
@@ -699,7 +703,7 @@ contains
 
         ! Check correctness.
         call check(error, sqrt(sum((z%data%re - x%data%re - y%data%re)**2 + (z%data%im - x%data%im - y%data%im)**2)) < rtol_dp)
-        call check_test(error, 'test_vector_cdp_add', 'norm2(z%data - x%data - y%data) < rtol')
+        call check_test(error, 'test_vector_cdp_norm', eq='is_close(x%norm,  sqrt(sum(Re(z - (x+y))^2 + Im(z - (x+y))^2)))')
 
         return
     end subroutine test_vector_cdp_add
@@ -721,7 +725,7 @@ contains
 
         ! Check correctness.
         call check(error, sqrt(sum((z%data%re - x%data%re + y%data%re)**2 + (z%data%im - x%data%im + y%data%im)**2)) < rtol_dp)
-        call check_test(error, 'test_vector_cdp_sub', 'norm2(z%data - x%data + y%data) < rtol')
+        call check_test(error, 'test_vector_cdp_norm', eq='is_close(x%norm, sqrt(sum(Re(z - (x-y))^2 + Im(z - (x-y))^2)))')
 
         return
     end subroutine test_vector_cdp_sub
@@ -743,7 +747,7 @@ contains
 
         ! Check correctness.
         call check(error, abs(alpha - dot_product(x%data, y%data)) < rtol_dp)
-        call check_test(error, 'test_vector_cdp_dot', 'abs(alpha - dot_product(x%data, y%data)) < rtol')
+        call check_test(error, 'test_vector_cdp_dot', eq='abs(x%dot(y) - dot_product(x, y))')
 
         return
     end subroutine test_vector_cdp_dot
@@ -768,7 +772,7 @@ contains
         ! Check correctness.
         tmp = x%data - alpha*y%data
         call check(error, sqrt(sum(tmp%re**2 + tmp%im**2)) < rtol_dp)
-        call check_test(error, 'test_vector_cdp_scal', 'norm2(x%data - alpha*y%data) < rtol')
+        call check_test(error, 'test_vector_cdp_scal', eq='sqrt(sum(Re(x - alpha*y)**2 + Im(x - alpha*y)**2))')
 
         return
     end subroutine test_vector_cdp_scal

--- a/test/TestVectors.fypp
+++ b/test/TestVectors.fypp
@@ -2,6 +2,7 @@
 #:set RC_KINDS_TYPES = REAL_KINDS_TYPES + CMPLX_KINDS_TYPES
 module TestVectors
     use LightKrylov
+    use LightKrylov_Logger
     use testdrive, only: new_unittest, unittest_type, error_type, check
     use stdlib_math, only: is_close, all_close
     use stdlib_optval, only: optval
@@ -135,6 +136,7 @@ contains
         #:else
         call check(error, is_close(alpha, norm2(x%data)))
         #:endif
+        call check_test(error, 'test_vector_${type[0]}$${kind}$_norm', 'is_close(alpha, norm2(x%data))')
         
         return
     end subroutine test_vector_${type[0]}$${kind}$_norm
@@ -160,6 +162,7 @@ contains
         #:else
         call check(error, norm2(z%data - x%data - y%data) < rtol_${kind}$)
         #:endif
+        call check_test(error, 'test_vector_${type[0]}$${kind}$_add', 'norm2(z%data - x%data - y%data) < rtol')
 
         return
     end subroutine test_vector_${type[0]}$${kind}$_add
@@ -185,6 +188,7 @@ contains
         #:else
         call check(error, norm2(z%data - x%data + y%data) < rtol_${kind}$)
         #:endif
+        call check_test(error, 'test_vector_${type[0]}$${kind}$_sub', 'norm2(z%data - x%data + y%data) < rtol')
 
         return
     end subroutine test_vector_${type[0]}$${kind}$_sub
@@ -206,6 +210,7 @@ contains
 
         ! Check correctness.
         call check(error, abs(alpha - dot_product(x%data, y%data)) < rtol_${kind}$)
+        call check_test(error, 'test_vector_${type[0]}$${kind}$_dot', 'abs(alpha - dot_product(x%data, y%data)) < rtol')
 
         return
     end subroutine test_vector_${type[0]}$${kind}$_dot
@@ -240,6 +245,7 @@ contains
         #:else
         call check(error, norm2(x%data - alpha*y%data) < rtol_${kind}$)
         #:endif
+        call check_test(error, 'test_vector_${type[0]}$${kind}$_scal', 'norm2(x%data - alpha*y%data) < rtol')
 
         return
     end subroutine test_vector_${type[0]}$${kind}$_scal

--- a/test/TestVectors.fypp
+++ b/test/TestVectors.fypp
@@ -5,13 +5,14 @@ module TestVectors
     use LightKrylov_Logger
     use testdrive, only: new_unittest, unittest_type, error_type, check
     use stdlib_math, only: is_close, all_close
+    use stdlib_stats_distribution_normal, only: normal => rvs_normal
     use stdlib_optval, only: optval
     
     implicit none
     
     private
 
-    character*128, parameter, private :: this_module = 'LightKrylov_TestVectors'
+    character(len=128), parameter, private :: this_module = 'LightKrylov_TestVectors'
 
     integer, parameter, public :: test_size = 128
 
@@ -79,17 +80,17 @@ contains
         class(vector_${type[0]}$${kind}$), intent(inout) :: self
         logical, optional, intent(in) :: ifnorm
         logical :: normalized
+        ${type}$ :: mu(test_size), var(test_size)
         ${type}$ :: alpha
-        #:if type[0] == "c"
-        real(${kind}$), dimension(test_size, 2) :: data
-
-        call random_number(data)
-        self%data%re = data(:, 1)
-        self%data%im = data(:, 2)
+ 
+        mu = 0.0_${kind}$
+        #:if type[0] == "r"
+        var = 1.0_${kind}$
         #:else
-        call random_number(self%data)
+        var = cmplx(1.0_${kind}$, 1.0_${kind}$, kind=${kind}$)
         #:endif
-
+        self%data = normal(mu, var)
+ 
         normalized = optval(ifnorm, .false.)
         if (normalized) then
             alpha = self%norm()

--- a/test/TestVectors.fypp
+++ b/test/TestVectors.fypp
@@ -133,10 +133,12 @@ contains
         ! Check result.
         #:if type[0] == "c"
         call check(error, is_close(alpha, sqrt(sum(x%data%re**2 + x%data%im**2))))
+        call check_test(error, 'test_vector_${type[0]}$${kind}$_norm', eq='is_close(x%norm, sqrt(sum(Re(x)^2 + Im(x)^2)))')
         #:else
         call check(error, is_close(alpha, norm2(x%data)))
+        call check_test(error, 'test_vector_${type[0]}$${kind}$_norm', eq='is_close(x%norm, norm2(x))')
         #:endif
-        call check_test(error, 'test_vector_${type[0]}$${kind}$_norm', 'is_close(alpha, norm2(x%data))')
+        
         
         return
     end subroutine test_vector_${type[0]}$${kind}$_norm
@@ -159,10 +161,11 @@ contains
         ! Check correctness.
         #:if type[0] == "c"
         call check(error, sqrt(sum((z%data%re - x%data%re - y%data%re)**2 + (z%data%im - x%data%im - y%data%im)**2)) < rtol_${kind}$)
+        call check_test(error, 'test_vector_${type[0]}$${kind}$_norm', eq='is_close(x%norm,  sqrt(sum(Re(z - (x+y))^2 + Im(z - (x+y))^2)))')
         #:else
         call check(error, norm2(z%data - x%data - y%data) < rtol_${kind}$)
+        call check_test(error, 'test_vector_${type[0]}$${kind}$_norm', eq='is_close(x%norm, norm2(z - (x+y)))')
         #:endif
-        call check_test(error, 'test_vector_${type[0]}$${kind}$_add', 'norm2(z%data - x%data - y%data) < rtol')
 
         return
     end subroutine test_vector_${type[0]}$${kind}$_add
@@ -185,10 +188,11 @@ contains
         ! Check correctness.
         #:if type[0] == "c"
         call check(error, sqrt(sum((z%data%re - x%data%re + y%data%re)**2 + (z%data%im - x%data%im + y%data%im)**2)) < rtol_${kind}$)
+        call check_test(error, 'test_vector_${type[0]}$${kind}$_norm', eq='is_close(x%norm, sqrt(sum(Re(z - (x-y))^2 + Im(z - (x-y))^2)))')
         #:else
         call check(error, norm2(z%data - x%data + y%data) < rtol_${kind}$)
+        call check_test(error, 'test_vector_${type[0]}$${kind}$_norm', eq='is_close(x%norm, norm2(z - (x-y)))')
         #:endif
-        call check_test(error, 'test_vector_${type[0]}$${kind}$_sub', 'norm2(z%data - x%data + y%data) < rtol')
 
         return
     end subroutine test_vector_${type[0]}$${kind}$_sub
@@ -210,7 +214,7 @@ contains
 
         ! Check correctness.
         call check(error, abs(alpha - dot_product(x%data, y%data)) < rtol_${kind}$)
-        call check_test(error, 'test_vector_${type[0]}$${kind}$_dot', 'abs(alpha - dot_product(x%data, y%data)) < rtol')
+        call check_test(error, 'test_vector_${type[0]}$${kind}$_dot', eq='abs(x%dot(y) - dot_product(x, y))')
 
         return
     end subroutine test_vector_${type[0]}$${kind}$_dot
@@ -242,10 +246,11 @@ contains
         #:if type[0] == "c"
         tmp = x%data - alpha*y%data
         call check(error, sqrt(sum(tmp%re**2 + tmp%im**2)) < rtol_${kind}$)
+        call check_test(error, 'test_vector_${type[0]}$${kind}$_scal', eq='sqrt(sum(Re(x - alpha*y)**2 + Im(x - alpha*y)**2))')
         #:else
         call check(error, norm2(x%data - alpha*y%data) < rtol_${kind}$)
+        call check_test(error, 'test_vector_${type[0]}$${kind}$_scal', eq='norm2(x - alpha*y)')
         #:endif
-        call check_test(error, 'test_vector_${type[0]}$${kind}$_scal', 'norm2(x%data - alpha*y%data) < rtol')
 
         return
     end subroutine test_vector_${type[0]}$${kind}$_scal

--- a/test/Tests.f90
+++ b/test/Tests.f90
@@ -102,8 +102,12 @@ program Tester
    write(output_unit, *)
 
    do is = 1, size(testsuites)
+      write (*, *) "-------------------------------"
       write (error_unit, fmt) "Testing :", testsuites(is)%name
+      write (*, *) "-------------------------------"
+      write (*, *)
       call run_testsuite(testsuites(is)%collect, error_unit, status)
+      write (*, *)
    end do
 
    if (status > 0) then

--- a/test/Tests.f90
+++ b/test/Tests.f90
@@ -1,7 +1,7 @@
 program Tester
    ! Fortran best practice.
    use, intrinsic :: iso_fortran_env, only: error_unit, output_unit
-   use stdlib_logger, only: error_level
+   use stdlib_logger, only: error_level, none_level
    ! Unit-test utility.
    use testdrive, only: run_testsuite, new_testsuite, testsuite_type
    ! Abstract implementation of Krylov-based techniques.
@@ -26,7 +26,8 @@ program Tester
 
    ! Turn off logging during tests (unless you REALLY want it)
    !call logger%configure(level=debug_level); write(*,*) 'Logging set to debug mode.'; write(*,*) ""; write(*,*) ""
-   call logger%configure(level=error_level); write(*,*) 'Logging set to error_level.'; write(*,*) ""; write(*,*) ""
+   call logger%configure(level=none_level, time_stamp=.false.)
+   write(*,*) 'Logging set to none_level.'; write(*,*) ""; write(*,*) ""
 
    status = 0
 
@@ -101,12 +102,8 @@ program Tester
    write(output_unit, *)
 
    do is = 1, size(testsuites)
-      write (*, *) "-------------------------------"
-      write (error_unit, fmt) "Testing:", testsuites(is)%name
-      write (*, *) "-------------------------------"
-      write (*, *)
+      write (error_unit, fmt) "Testing :", testsuites(is)%name
       call run_testsuite(testsuites(is)%collect, error_unit, status)
-      write (*, *)
    end do
 
    if (status > 0) then
@@ -183,12 +180,8 @@ program Tester
    write(output_unit, *)
 
    do is = 1, size(testsuites)
-      write (*, *) "-------------------------------"
-      write (error_unit, fmt) "Testing:", testsuites(is)%name
-      write (*, *) "-------------------------------"
-      write (*, *)
+      write (error_unit, fmt) "Testing :", testsuites(is)%name
       call run_testsuite(testsuites(is)%collect, error_unit, status)
-      write (*, *)
    end do
 
    if (status > 0) then

--- a/test/Tests.f90
+++ b/test/Tests.f90
@@ -59,10 +59,7 @@ program Tester
    write(output_unit, *)
 
    do is = 1, size(testsuites)
-      write (*, *) "-------------------------------"
       write (error_unit, fmt) "Testing :", testsuites(is)%name
-      write (*, *) "-------------------------------"
-      write (*, *)
       call run_testsuite(testsuites(is)%collect, error_unit, status)
       write (*, *)
    end do
@@ -143,10 +140,7 @@ program Tester
    write(output_unit, *)
 
    do is = 1, size(testsuites)
-      write (*, *) "-------------------------------"
       write (error_unit, fmt) "Testing :", testsuites(is)%name
-      write (*, *) "-------------------------------"
-      write (*, *)
       call run_testsuite(testsuites(is)%collect, error_unit, status)
       write (*, *)
    end do

--- a/test/Tests.f90
+++ b/test/Tests.f90
@@ -17,7 +17,7 @@ program Tester
    implicit none
 
    ! Unit-test related.
-   integer :: status, is, num_tests
+   integer :: status, is
    type(testsuite_type), allocatable :: testsuites(:)
    character(len=*), parameter :: fmt = '("#", *(1x, a))'
 


### PR DESCRIPTION
added type bound procedure `get_size` returning the specific vector length to abstract vector and updated GL example accordingly. 

**NOTE: > Merged branch `update_GL_example` into current one. When this branch is merged, both the present branch and `update_GL_example` can be deleted.