### PR TITLE
Add mpi

### DIFF
--- a/example/ginzburg_landau/main.f90
+++ b/example/ginzburg_landau/main.f90
@@ -42,6 +42,9 @@ program demo
   !-----     INITIALIZATION     -----
   !----------------------------------
 
+  !> Set up logging
+  call logger_setup()
+
   !> Initialize physical parameters.
   call initialize_parameters()
 

--- a/fpm.toml
+++ b/fpm.toml
@@ -21,9 +21,6 @@ implicit-typing = false
 implicit-external = true
 source-form = "free"
 
-[preprocess]
-[preprocess.cpp]
-
 [dependencies]
 stdlib = "*"
 

--- a/fpm.toml
+++ b/fpm.toml
@@ -11,6 +11,7 @@ auto-executables = true
 auto-tests = true
 auto-examples = true
 module-naming = false
+external-modules = "mpi"
 
 [install]
 library = true
@@ -19,6 +20,9 @@ library = true
 implicit-typing = false
 implicit-external = true
 source-form = "free"
+
+[preprocess]
+[preprocess.cpp]
 
 [dependencies]
 stdlib = "*"

--- a/fpm.toml
+++ b/fpm.toml
@@ -11,7 +11,7 @@ auto-executables = true
 auto-tests = true
 auto-examples = true
 module-naming = false
-external-modules = "mpi"
+external-modules = "mpi_f08"
 
 [install]
 library = true

--- a/src/BaseKrylov.f90
+++ b/src/BaseKrylov.f90
@@ -341,11 +341,11 @@ contains
       ! Orthogonalize vector y w.r.t. to Krylov basis X in two passes of GS.
       ! first pass
       call orthogonalize_against_basis(y, X, info, if_chk_orthonormal=.false., beta=proj_coefficients)
-      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+      call check_info(info, 'orthogonalize_against_basis', module=this_module, &
                         & procedure='DGS_vector_against_basis_rsp, pass 1')
       ! second pass
       call orthogonalize_against_basis(y, X, info, if_chk_orthonormal=.false., beta=wrk)
-      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+      call check_info(info, 'orthogonalize_against_basis', module=this_module, &
                         & procedure='DGS_vector_against_basis_rsp, pass 2')
       ! combine passes
       proj_coefficients = proj_coefficients + wrk
@@ -386,12 +386,10 @@ contains
       ! Orthogonalize Krylov basis Y w.r.t. to Krylov basis X in two passes of GS.
       ! first pass
       call orthogonalize_against_basis(Y, X, info, if_chk_orthonormal=.false., beta=proj_coefficients)
-      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module,&
-          & procedure='DGS_basis_against_basis_rsp, first pass')
+      call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='DGS_basis_against_basis_rsp, first pass')
       ! second pass
       call orthogonalize_against_basis(Y, X, info, if_chk_orthonormal=.false., beta=wrk)
-      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module,&
-          & procedure='DGS_basis_against_basis_rsp, second pass')
+      call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='DGS_basis_against_basis_rsp, second pass')
       ! combine passes
       proj_coefficients = proj_coefficients + wrk
 
@@ -600,11 +598,11 @@ contains
       ! Orthogonalize vector y w.r.t. to Krylov basis X in two passes of GS.
       ! first pass
       call orthogonalize_against_basis(y, X, info, if_chk_orthonormal=.false., beta=proj_coefficients)
-      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+      call check_info(info, 'orthogonalize_against_basis', module=this_module, &
                         & procedure='DGS_vector_against_basis_rdp, pass 1')
       ! second pass
       call orthogonalize_against_basis(y, X, info, if_chk_orthonormal=.false., beta=wrk)
-      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+      call check_info(info, 'orthogonalize_against_basis', module=this_module, &
                         & procedure='DGS_vector_against_basis_rdp, pass 2')
       ! combine passes
       proj_coefficients = proj_coefficients + wrk
@@ -645,12 +643,10 @@ contains
       ! Orthogonalize Krylov basis Y w.r.t. to Krylov basis X in two passes of GS.
       ! first pass
       call orthogonalize_against_basis(Y, X, info, if_chk_orthonormal=.false., beta=proj_coefficients)
-      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module,&
-          & procedure='DGS_basis_against_basis_rdp, first pass')
+      call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='DGS_basis_against_basis_rdp, first pass')
       ! second pass
       call orthogonalize_against_basis(Y, X, info, if_chk_orthonormal=.false., beta=wrk)
-      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module,&
-          & procedure='DGS_basis_against_basis_rdp, second pass')
+      call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='DGS_basis_against_basis_rdp, second pass')
       ! combine passes
       proj_coefficients = proj_coefficients + wrk
 
@@ -859,11 +855,11 @@ contains
       ! Orthogonalize vector y w.r.t. to Krylov basis X in two passes of GS.
       ! first pass
       call orthogonalize_against_basis(y, X, info, if_chk_orthonormal=.false., beta=proj_coefficients)
-      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+      call check_info(info, 'orthogonalize_against_basis', module=this_module, &
                         & procedure='DGS_vector_against_basis_csp, pass 1')
       ! second pass
       call orthogonalize_against_basis(y, X, info, if_chk_orthonormal=.false., beta=wrk)
-      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+      call check_info(info, 'orthogonalize_against_basis', module=this_module, &
                         & procedure='DGS_vector_against_basis_csp, pass 2')
       ! combine passes
       proj_coefficients = proj_coefficients + wrk
@@ -904,12 +900,10 @@ contains
       ! Orthogonalize Krylov basis Y w.r.t. to Krylov basis X in two passes of GS.
       ! first pass
       call orthogonalize_against_basis(Y, X, info, if_chk_orthonormal=.false., beta=proj_coefficients)
-      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module,&
-          & procedure='DGS_basis_against_basis_csp, first pass')
+      call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='DGS_basis_against_basis_csp, first pass')
       ! second pass
       call orthogonalize_against_basis(Y, X, info, if_chk_orthonormal=.false., beta=wrk)
-      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module,&
-          & procedure='DGS_basis_against_basis_csp, second pass')
+      call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='DGS_basis_against_basis_csp, second pass')
       ! combine passes
       proj_coefficients = proj_coefficients + wrk
 
@@ -1118,11 +1112,11 @@ contains
       ! Orthogonalize vector y w.r.t. to Krylov basis X in two passes of GS.
       ! first pass
       call orthogonalize_against_basis(y, X, info, if_chk_orthonormal=.false., beta=proj_coefficients)
-      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+      call check_info(info, 'orthogonalize_against_basis', module=this_module, &
                         & procedure='DGS_vector_against_basis_cdp, pass 1')
       ! second pass
       call orthogonalize_against_basis(y, X, info, if_chk_orthonormal=.false., beta=wrk)
-      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+      call check_info(info, 'orthogonalize_against_basis', module=this_module, &
                         & procedure='DGS_vector_against_basis_cdp, pass 2')
       ! combine passes
       proj_coefficients = proj_coefficients + wrk
@@ -1163,12 +1157,10 @@ contains
       ! Orthogonalize Krylov basis Y w.r.t. to Krylov basis X in two passes of GS.
       ! first pass
       call orthogonalize_against_basis(Y, X, info, if_chk_orthonormal=.false., beta=proj_coefficients)
-      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module,&
-          & procedure='DGS_basis_against_basis_cdp, first pass')
+      call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='DGS_basis_against_basis_cdp, first pass')
       ! second pass
       call orthogonalize_against_basis(Y, X, info, if_chk_orthonormal=.false., beta=wrk)
-      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module,&
-          & procedure='DGS_basis_against_basis_cdp, second pass')
+      call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='DGS_basis_against_basis_cdp, second pass')
       ! combine passes
       proj_coefficients = proj_coefficients + wrk
 
@@ -1213,7 +1205,7 @@ contains
             if (j > 1) then
                 ! Double Gram-Schmidt orthogonalization
                 call double_gram_schmidt_step(Q(j), Q(1:j-1), info, if_chk_orthonormal=.false., beta=R(1:j-1,j))
-                if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='qr_no_pivoting_rsp')
+                call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='qr_no_pivoting_rsp')
             end if
 
             ! Normalize column.
@@ -1277,8 +1269,7 @@ contains
                 do i = j, kdim
                     call Q(i)%rand(.false.)
                     call orthogonalize_against_basis(Q(i), Q(1:i-1), info, if_chk_orthonormal=.false.)
-                    if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module,&
-                        & procedure='qr_with_pivoting_rsp')
+                    call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='qr_with_pivoting_rsp')
                     beta = Q(i)%norm(); call Q(i)%scal(one_rsp / beta)
                 enddo
                 info = j
@@ -1471,7 +1462,7 @@ contains
             if (j > 1) then
                 ! Double Gram-Schmidt orthogonalization
                 call double_gram_schmidt_step(Q(j), Q(1:j-1), info, if_chk_orthonormal=.false., beta=R(1:j-1,j))
-                if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='qr_no_pivoting_rdp')
+                call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='qr_no_pivoting_rdp')
             end if
 
             ! Normalize column.
@@ -1535,8 +1526,7 @@ contains
                 do i = j, kdim
                     call Q(i)%rand(.false.)
                     call orthogonalize_against_basis(Q(i), Q(1:i-1), info, if_chk_orthonormal=.false.)
-                    if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module,&
-                        & procedure='qr_with_pivoting_rdp')
+                    call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='qr_with_pivoting_rdp')
                     beta = Q(i)%norm(); call Q(i)%scal(one_rdp / beta)
                 enddo
                 info = j
@@ -1729,7 +1719,7 @@ contains
             if (j > 1) then
                 ! Double Gram-Schmidt orthogonalization
                 call double_gram_schmidt_step(Q(j), Q(1:j-1), info, if_chk_orthonormal=.false., beta=R(1:j-1,j))
-                if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='qr_no_pivoting_csp')
+                call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='qr_no_pivoting_csp')
             end if
 
             ! Normalize column.
@@ -1793,8 +1783,7 @@ contains
                 do i = j, kdim
                     call Q(i)%rand(.false.)
                     call orthogonalize_against_basis(Q(i), Q(1:i-1), info, if_chk_orthonormal=.false.)
-                    if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module,&
-                        & procedure='qr_with_pivoting_csp')
+                    call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='qr_with_pivoting_csp')
                     beta = Q(i)%norm(); call Q(i)%scal(one_csp / beta)
                 enddo
                 info = j
@@ -1987,7 +1976,7 @@ contains
             if (j > 1) then
                 ! Double Gram-Schmidt orthogonalization
                 call double_gram_schmidt_step(Q(j), Q(1:j-1), info, if_chk_orthonormal=.false., beta=R(1:j-1,j))
-                if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='qr_no_pivoting_cdp')
+                call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='qr_no_pivoting_cdp')
             end if
 
             ! Normalize column.
@@ -2051,8 +2040,7 @@ contains
                 do i = j, kdim
                     call Q(i)%rand(.false.)
                     call orthogonalize_against_basis(Q(i), Q(1:i-1), info, if_chk_orthonormal=.false.)
-                    if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module,&
-                        & procedure='qr_with_pivoting_cdp')
+                    call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='qr_with_pivoting_cdp')
                     beta = Q(i)%norm(); call Q(i)%scal(one_cdp / beta)
                 enddo
                 info = j
@@ -2284,11 +2272,11 @@ contains
 
             ! Update Hessenberg matrix via batch double Gram-Schmidt step.
             call double_gram_schmidt_step(X(kp+1:kpp), X(1:kp), info, if_chk_orthonormal=.false., beta=H(1:kp, kpm+1:kp))
-            if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='arnoldi_rsp')
+            call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='arnoldi_rsp')
 
             ! Orthogonalize current blk vectors.
             call qr(X(kp+1:kpp), H(kp+1:kpp, kpm+1:kp), info)
-            if (nid == 0) call check_info(info, 'qr', module=this_module, procedure='arnoldi_rsp')
+            call check_info(info, 'qr', module=this_module, procedure='arnoldi_rsp')
 
             ! Extract residual norm (smallest diagonal element of H matrix).
             res = zero_rsp
@@ -2372,11 +2360,11 @@ contains
 
             ! Update Hessenberg matrix via batch double Gram-Schmidt step.
             call double_gram_schmidt_step(X(kp+1:kpp), X(1:kp), info, if_chk_orthonormal=.false., beta=H(1:kp, kpm+1:kp))
-            if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='arnoldi_rdp')
+            call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='arnoldi_rdp')
 
             ! Orthogonalize current blk vectors.
             call qr(X(kp+1:kpp), H(kp+1:kpp, kpm+1:kp), info)
-            if (nid == 0) call check_info(info, 'qr', module=this_module, procedure='arnoldi_rdp')
+            call check_info(info, 'qr', module=this_module, procedure='arnoldi_rdp')
 
             ! Extract residual norm (smallest diagonal element of H matrix).
             res = zero_rdp
@@ -2460,11 +2448,11 @@ contains
 
             ! Update Hessenberg matrix via batch double Gram-Schmidt step.
             call double_gram_schmidt_step(X(kp+1:kpp), X(1:kp), info, if_chk_orthonormal=.false., beta=H(1:kp, kpm+1:kp))
-            if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='arnoldi_csp')
+            call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='arnoldi_csp')
 
             ! Orthogonalize current blk vectors.
             call qr(X(kp+1:kpp), H(kp+1:kpp, kpm+1:kp), info)
-            if (nid == 0) call check_info(info, 'qr', module=this_module, procedure='arnoldi_csp')
+            call check_info(info, 'qr', module=this_module, procedure='arnoldi_csp')
 
             ! Extract residual norm (smallest diagonal element of H matrix).
             res = zero_rsp
@@ -2548,11 +2536,11 @@ contains
 
             ! Update Hessenberg matrix via batch double Gram-Schmidt step.
             call double_gram_schmidt_step(X(kp+1:kpp), X(1:kp), info, if_chk_orthonormal=.false., beta=H(1:kp, kpm+1:kp))
-            if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='arnoldi_cdp')
+            call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='arnoldi_cdp')
 
             ! Orthogonalize current blk vectors.
             call qr(X(kp+1:kpp), H(kp+1:kpp, kpm+1:kp), info)
-            if (nid == 0) call check_info(info, 'qr', module=this_module, procedure='arnoldi_cdp')
+            call check_info(info, 'qr', module=this_module, procedure='arnoldi_cdp')
 
             ! Extract residual norm (smallest diagonal element of H matrix).
             res = zero_rdp
@@ -2629,7 +2617,7 @@ contains
             if (k > 1 ) then
             
                 call double_gram_schmidt_step(V(k), V(:k-1), info, if_chk_orthonormal=.false.)
-                if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, &
+                call check_info(info, 'double_gram_schmidt_step', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_rsp, first pass')
             end if
 
@@ -2647,7 +2635,7 @@ contains
 
             ! Full re-orthogonalization of the left Krylov subspace.
             call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.false.)
-            if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+            call check_info(info, 'orthogonalize_against_basis', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_rsp, second pass')
 
             ! Normalization step
@@ -2713,7 +2701,7 @@ contains
             if (k > 1 ) then
             
                 call double_gram_schmidt_step(V(k), V(:k-1), info, if_chk_orthonormal=.false.)
-                if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, &
+                call check_info(info, 'double_gram_schmidt_step', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_rdp, first pass')
             end if
 
@@ -2731,7 +2719,7 @@ contains
 
             ! Full re-orthogonalization of the left Krylov subspace.
             call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.false.)
-            if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+            call check_info(info, 'orthogonalize_against_basis', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_rdp, second pass')
 
             ! Normalization step
@@ -2797,7 +2785,7 @@ contains
             if (k > 1 ) then
             
                 call double_gram_schmidt_step(V(k), V(:k-1), info, if_chk_orthonormal=.false.)
-                if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, &
+                call check_info(info, 'double_gram_schmidt_step', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_csp, first pass')
             end if
 
@@ -2815,7 +2803,7 @@ contains
 
             ! Full re-orthogonalization of the left Krylov subspace.
             call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.false.)
-            if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+            call check_info(info, 'orthogonalize_against_basis', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_csp, second pass')
 
             ! Normalization step
@@ -2881,7 +2869,7 @@ contains
             if (k > 1 ) then
             
                 call double_gram_schmidt_step(V(k), V(:k-1), info, if_chk_orthonormal=.false.)
-                if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, &
+                call check_info(info, 'double_gram_schmidt_step', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_cdp, first pass')
             end if
 
@@ -2899,7 +2887,7 @@ contains
 
             ! Full re-orthogonalization of the left Krylov subspace.
             call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.false.)
-            if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+            call check_info(info, 'orthogonalize_against_basis', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_cdp, second pass')
 
             ! Normalization step
@@ -2987,8 +2975,7 @@ contains
 
         ! Full re-orthogonalization against existing basis
         call double_gram_schmidt_step(X(k+1), X(:k), info, if_chk_orthonormal=.false.)
-        if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module,&
-            & procedure='update_tridiag_matrix_rsp')
+        call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='update_tridiag_matrix_rsp')
 
         return
     end subroutine update_tridiag_matrix_rsp
@@ -3058,8 +3045,7 @@ contains
 
         ! Full re-orthogonalization against existing basis
         call double_gram_schmidt_step(X(k+1), X(:k), info, if_chk_orthonormal=.false.)
-        if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module,&
-            & procedure='update_tridiag_matrix_rdp')
+        call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='update_tridiag_matrix_rdp')
 
         return
     end subroutine update_tridiag_matrix_rdp
@@ -3129,8 +3115,7 @@ contains
 
         ! Full re-orthogonalization against existing basis
         call double_gram_schmidt_step(X(k+1), X(:k), info, if_chk_orthonormal=.false.)
-        if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module,&
-            & procedure='update_tridiag_matrix_csp')
+        call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='update_tridiag_matrix_csp')
 
         return
     end subroutine update_tridiag_matrix_csp
@@ -3200,8 +3185,7 @@ contains
 
         ! Full re-orthogonalization against existing basis
         call double_gram_schmidt_step(X(k+1), X(:k), info, if_chk_orthonormal=.false.)
-        if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module,&
-            & procedure='update_tridiag_matrix_cdp')
+        call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='update_tridiag_matrix_cdp')
 
         return
     end subroutine update_tridiag_matrix_cdp

--- a/src/BaseKrylov.f90
+++ b/src/BaseKrylov.f90
@@ -180,8 +180,6 @@ contains
         return
     end subroutine initialize_krylov_subspace_rsp
 
-<<<<<<< Updated upstream
-=======
     subroutine orthonormalize_basis_rsp(X)
       !! Orthonormalizes the `abstract_vector` basis `X`
       class(abstract_vector_rsp), intent(inout) :: X(:)
@@ -193,12 +191,11 @@ contains
 
       ! internals
       call qr(X, R, info)
-      if (nid == 0) call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_rsp')
+      call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_rsp')
       
       return
     end subroutine orthonormalize_basis_rsp
 
->>>>>>> Stashed changes
     subroutine orthogonalize_vector_against_basis_rsp(y, X, info, if_chk_orthonormal, beta)
       !! Orthonormalizes the `abstract_vector` `y` against a basis `X` of `abstract_vector`.
       class(abstract_vector_rsp), intent(inout) :: y
@@ -442,8 +439,6 @@ contains
         return
     end subroutine initialize_krylov_subspace_rdp
 
-<<<<<<< Updated upstream
-=======
     subroutine orthonormalize_basis_rdp(X)
       !! Orthonormalizes the `abstract_vector` basis `X`
       class(abstract_vector_rdp), intent(inout) :: X(:)
@@ -455,12 +450,11 @@ contains
 
       ! internals
       call qr(X, R, info)
-      if (nid == 0) call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_rdp')
+      call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_rdp')
       
       return
     end subroutine orthonormalize_basis_rdp
 
->>>>>>> Stashed changes
     subroutine orthogonalize_vector_against_basis_rdp(y, X, info, if_chk_orthonormal, beta)
       !! Orthonormalizes the `abstract_vector` `y` against a basis `X` of `abstract_vector`.
       class(abstract_vector_rdp), intent(inout) :: y
@@ -704,8 +698,6 @@ contains
         return
     end subroutine initialize_krylov_subspace_csp
 
-<<<<<<< Updated upstream
-=======
     subroutine orthonormalize_basis_csp(X)
       !! Orthonormalizes the `abstract_vector` basis `X`
       class(abstract_vector_csp), intent(inout) :: X(:)
@@ -717,12 +709,11 @@ contains
 
       ! internals
       call qr(X, R, info)
-      if (nid == 0) call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_csp')
+      call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_csp')
       
       return
     end subroutine orthonormalize_basis_csp
 
->>>>>>> Stashed changes
     subroutine orthogonalize_vector_against_basis_csp(y, X, info, if_chk_orthonormal, beta)
       !! Orthonormalizes the `abstract_vector` `y` against a basis `X` of `abstract_vector`.
       class(abstract_vector_csp), intent(inout) :: y
@@ -966,8 +957,6 @@ contains
         return
     end subroutine initialize_krylov_subspace_cdp
 
-<<<<<<< Updated upstream
-=======
     subroutine orthonormalize_basis_cdp(X)
       !! Orthonormalizes the `abstract_vector` basis `X`
       class(abstract_vector_cdp), intent(inout) :: X(:)
@@ -979,12 +968,11 @@ contains
 
       ! internals
       call qr(X, R, info)
-      if (nid == 0) call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_cdp')
+      call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_cdp')
       
       return
     end subroutine orthonormalize_basis_cdp
 
->>>>>>> Stashed changes
     subroutine orthogonalize_vector_against_basis_cdp(y, X, info, if_chk_orthonormal, beta)
       !! Orthonormalizes the `abstract_vector` `y` against a basis `X` of `abstract_vector`.
       class(abstract_vector_cdp), intent(inout) :: y

--- a/src/BaseKrylov.f90
+++ b/src/BaseKrylov.f90
@@ -2,7 +2,7 @@ module lightkrylov_BaseKrylov
     use iso_fortran_env
     use stdlib_optval, only: optval
     use stdlib_linalg, only: eye
-    use LightKrylov_constants
+    use LightKrylov_Constants
     use LightKrylov_Logger
     use LightKrylov_Utils
     use LightKrylov_AbstractVectors
@@ -11,7 +11,6 @@ module lightkrylov_BaseKrylov
     private
     
     character(len=128), parameter :: this_module = 'LightKrylov_BaseKrylov'
-
     public :: qr
     public :: apply_permutation_matrix
     public :: apply_inverse_permutation_matrix
@@ -181,6 +180,25 @@ contains
         return
     end subroutine initialize_krylov_subspace_rsp
 
+<<<<<<< Updated upstream
+=======
+    subroutine orthonormalize_basis_rsp(X)
+      !! Orthonormalizes the `abstract_vector` basis `X`
+      class(abstract_vector_rsp), intent(inout) :: X(:)
+      !! Input `abstract_vector` basis to orthogonalize against
+      
+      ! internals
+      real(sp) :: R(size(X),size(X))
+      integer :: info
+
+      ! internals
+      call qr(X, R, info)
+      if (nid == 0) call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_rsp')
+      
+      return
+    end subroutine orthonormalize_basis_rsp
+
+>>>>>>> Stashed changes
     subroutine orthogonalize_vector_against_basis_rsp(y, X, info, if_chk_orthonormal, beta)
       !! Orthonormalizes the `abstract_vector` `y` against a basis `X` of `abstract_vector`.
       class(abstract_vector_rsp), intent(inout) :: y
@@ -326,11 +344,12 @@ contains
       ! Orthogonalize vector y w.r.t. to Krylov basis X in two passes of GS.
       ! first pass
       call orthogonalize_against_basis(y, X, info, if_chk_orthonormal=.false., beta=proj_coefficients)
-      call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='DGS_vector_against_basis, first pass')
+      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+                        & procedure='DGS_vector_against_basis_rsp, pass 1')
       ! second pass
       call orthogonalize_against_basis(y, X, info, if_chk_orthonormal=.false., beta=wrk)
-      call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='DGS_vector_against_basis_rsp, second&
-          & pass')
+      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+                        & procedure='DGS_vector_against_basis_rsp, pass 2')
       ! combine passes
       proj_coefficients = proj_coefficients + wrk
 
@@ -370,10 +389,12 @@ contains
       ! Orthogonalize Krylov basis Y w.r.t. to Krylov basis X in two passes of GS.
       ! first pass
       call orthogonalize_against_basis(Y, X, info, if_chk_orthonormal=.false., beta=proj_coefficients)
-      call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='DGS_basis_against_basis_rsp, first pass')
+      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module,&
+          & procedure='DGS_basis_against_basis_rsp, first pass')
       ! second pass
       call orthogonalize_against_basis(Y, X, info, if_chk_orthonormal=.false., beta=wrk)
-      call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='DGS_basis_against_basis_rsp, second pass')
+      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module,&
+          & procedure='DGS_basis_against_basis_rsp, second pass')
       ! combine passes
       proj_coefficients = proj_coefficients + wrk
 
@@ -421,6 +442,25 @@ contains
         return
     end subroutine initialize_krylov_subspace_rdp
 
+<<<<<<< Updated upstream
+=======
+    subroutine orthonormalize_basis_rdp(X)
+      !! Orthonormalizes the `abstract_vector` basis `X`
+      class(abstract_vector_rdp), intent(inout) :: X(:)
+      !! Input `abstract_vector` basis to orthogonalize against
+      
+      ! internals
+      real(dp) :: R(size(X),size(X))
+      integer :: info
+
+      ! internals
+      call qr(X, R, info)
+      if (nid == 0) call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_rdp')
+      
+      return
+    end subroutine orthonormalize_basis_rdp
+
+>>>>>>> Stashed changes
     subroutine orthogonalize_vector_against_basis_rdp(y, X, info, if_chk_orthonormal, beta)
       !! Orthonormalizes the `abstract_vector` `y` against a basis `X` of `abstract_vector`.
       class(abstract_vector_rdp), intent(inout) :: y
@@ -566,11 +606,12 @@ contains
       ! Orthogonalize vector y w.r.t. to Krylov basis X in two passes of GS.
       ! first pass
       call orthogonalize_against_basis(y, X, info, if_chk_orthonormal=.false., beta=proj_coefficients)
-      call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='DGS_vector_against_basis, first pass')
+      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+                        & procedure='DGS_vector_against_basis_rdp, pass 1')
       ! second pass
       call orthogonalize_against_basis(y, X, info, if_chk_orthonormal=.false., beta=wrk)
-      call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='DGS_vector_against_basis_rdp, second&
-          & pass')
+      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+                        & procedure='DGS_vector_against_basis_rdp, pass 2')
       ! combine passes
       proj_coefficients = proj_coefficients + wrk
 
@@ -610,10 +651,12 @@ contains
       ! Orthogonalize Krylov basis Y w.r.t. to Krylov basis X in two passes of GS.
       ! first pass
       call orthogonalize_against_basis(Y, X, info, if_chk_orthonormal=.false., beta=proj_coefficients)
-      call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='DGS_basis_against_basis_rdp, first pass')
+      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module,&
+          & procedure='DGS_basis_against_basis_rdp, first pass')
       ! second pass
       call orthogonalize_against_basis(Y, X, info, if_chk_orthonormal=.false., beta=wrk)
-      call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='DGS_basis_against_basis_rdp, second pass')
+      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module,&
+          & procedure='DGS_basis_against_basis_rdp, second pass')
       ! combine passes
       proj_coefficients = proj_coefficients + wrk
 
@@ -661,6 +704,25 @@ contains
         return
     end subroutine initialize_krylov_subspace_csp
 
+<<<<<<< Updated upstream
+=======
+    subroutine orthonormalize_basis_csp(X)
+      !! Orthonormalizes the `abstract_vector` basis `X`
+      class(abstract_vector_csp), intent(inout) :: X(:)
+      !! Input `abstract_vector` basis to orthogonalize against
+      
+      ! internals
+      complex(sp) :: R(size(X),size(X))
+      integer :: info
+
+      ! internals
+      call qr(X, R, info)
+      if (nid == 0) call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_csp')
+      
+      return
+    end subroutine orthonormalize_basis_csp
+
+>>>>>>> Stashed changes
     subroutine orthogonalize_vector_against_basis_csp(y, X, info, if_chk_orthonormal, beta)
       !! Orthonormalizes the `abstract_vector` `y` against a basis `X` of `abstract_vector`.
       class(abstract_vector_csp), intent(inout) :: y
@@ -806,11 +868,12 @@ contains
       ! Orthogonalize vector y w.r.t. to Krylov basis X in two passes of GS.
       ! first pass
       call orthogonalize_against_basis(y, X, info, if_chk_orthonormal=.false., beta=proj_coefficients)
-      call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='DGS_vector_against_basis, first pass')
+      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+                        & procedure='DGS_vector_against_basis_csp, pass 1')
       ! second pass
       call orthogonalize_against_basis(y, X, info, if_chk_orthonormal=.false., beta=wrk)
-      call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='DGS_vector_against_basis_csp, second&
-          & pass')
+      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+                        & procedure='DGS_vector_against_basis_csp, pass 2')
       ! combine passes
       proj_coefficients = proj_coefficients + wrk
 
@@ -850,10 +913,12 @@ contains
       ! Orthogonalize Krylov basis Y w.r.t. to Krylov basis X in two passes of GS.
       ! first pass
       call orthogonalize_against_basis(Y, X, info, if_chk_orthonormal=.false., beta=proj_coefficients)
-      call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='DGS_basis_against_basis_csp, first pass')
+      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module,&
+          & procedure='DGS_basis_against_basis_csp, first pass')
       ! second pass
       call orthogonalize_against_basis(Y, X, info, if_chk_orthonormal=.false., beta=wrk)
-      call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='DGS_basis_against_basis_csp, second pass')
+      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module,&
+          & procedure='DGS_basis_against_basis_csp, second pass')
       ! combine passes
       proj_coefficients = proj_coefficients + wrk
 
@@ -901,6 +966,25 @@ contains
         return
     end subroutine initialize_krylov_subspace_cdp
 
+<<<<<<< Updated upstream
+=======
+    subroutine orthonormalize_basis_cdp(X)
+      !! Orthonormalizes the `abstract_vector` basis `X`
+      class(abstract_vector_cdp), intent(inout) :: X(:)
+      !! Input `abstract_vector` basis to orthogonalize against
+      
+      ! internals
+      complex(dp) :: R(size(X),size(X))
+      integer :: info
+
+      ! internals
+      call qr(X, R, info)
+      if (nid == 0) call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_cdp')
+      
+      return
+    end subroutine orthonormalize_basis_cdp
+
+>>>>>>> Stashed changes
     subroutine orthogonalize_vector_against_basis_cdp(y, X, info, if_chk_orthonormal, beta)
       !! Orthonormalizes the `abstract_vector` `y` against a basis `X` of `abstract_vector`.
       class(abstract_vector_cdp), intent(inout) :: y
@@ -1046,11 +1130,12 @@ contains
       ! Orthogonalize vector y w.r.t. to Krylov basis X in two passes of GS.
       ! first pass
       call orthogonalize_against_basis(y, X, info, if_chk_orthonormal=.false., beta=proj_coefficients)
-      call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='DGS_vector_against_basis, first pass')
+      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+                        & procedure='DGS_vector_against_basis_cdp, pass 1')
       ! second pass
       call orthogonalize_against_basis(y, X, info, if_chk_orthonormal=.false., beta=wrk)
-      call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='DGS_vector_against_basis_cdp, second&
-          & pass')
+      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+                        & procedure='DGS_vector_against_basis_cdp, pass 2')
       ! combine passes
       proj_coefficients = proj_coefficients + wrk
 
@@ -1090,10 +1175,12 @@ contains
       ! Orthogonalize Krylov basis Y w.r.t. to Krylov basis X in two passes of GS.
       ! first pass
       call orthogonalize_against_basis(Y, X, info, if_chk_orthonormal=.false., beta=proj_coefficients)
-      call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='DGS_basis_against_basis_cdp, first pass')
+      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module,&
+          & procedure='DGS_basis_against_basis_cdp, first pass')
       ! second pass
       call orthogonalize_against_basis(Y, X, info, if_chk_orthonormal=.false., beta=wrk)
-      call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='DGS_basis_against_basis_cdp, second pass')
+      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module,&
+          & procedure='DGS_basis_against_basis_cdp, second pass')
       ! combine passes
       proj_coefficients = proj_coefficients + wrk
 
@@ -1138,7 +1225,7 @@ contains
             if (j > 1) then
                 ! Double Gram-Schmidt orthogonalization
                 call double_gram_schmidt_step(Q(j), Q(1:j-1), info, if_chk_orthonormal=.false., beta=R(1:j-1,j))
-                call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='qr_no_pivoting_rsp')
+                if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='qr_no_pivoting_rsp')
             end if
 
             ! Normalize column.
@@ -1202,7 +1289,8 @@ contains
                 do i = j, kdim
                     call Q(i)%rand(.false.)
                     call orthogonalize_against_basis(Q(i), Q(1:i-1), info, if_chk_orthonormal=.false.)
-                    call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='qr_with_pivoting_rsp')
+                    if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module,&
+                        & procedure='qr_with_pivoting_rsp')
                     beta = Q(i)%norm(); call Q(i)%scal(one_rsp / beta)
                 enddo
                 info = j
@@ -1395,7 +1483,7 @@ contains
             if (j > 1) then
                 ! Double Gram-Schmidt orthogonalization
                 call double_gram_schmidt_step(Q(j), Q(1:j-1), info, if_chk_orthonormal=.false., beta=R(1:j-1,j))
-                call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='qr_no_pivoting_rdp')
+                if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='qr_no_pivoting_rdp')
             end if
 
             ! Normalize column.
@@ -1459,7 +1547,8 @@ contains
                 do i = j, kdim
                     call Q(i)%rand(.false.)
                     call orthogonalize_against_basis(Q(i), Q(1:i-1), info, if_chk_orthonormal=.false.)
-                    call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='qr_with_pivoting_rdp')
+                    if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module,&
+                        & procedure='qr_with_pivoting_rdp')
                     beta = Q(i)%norm(); call Q(i)%scal(one_rdp / beta)
                 enddo
                 info = j
@@ -1652,7 +1741,7 @@ contains
             if (j > 1) then
                 ! Double Gram-Schmidt orthogonalization
                 call double_gram_schmidt_step(Q(j), Q(1:j-1), info, if_chk_orthonormal=.false., beta=R(1:j-1,j))
-                call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='qr_no_pivoting_csp')
+                if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='qr_no_pivoting_csp')
             end if
 
             ! Normalize column.
@@ -1716,7 +1805,8 @@ contains
                 do i = j, kdim
                     call Q(i)%rand(.false.)
                     call orthogonalize_against_basis(Q(i), Q(1:i-1), info, if_chk_orthonormal=.false.)
-                    call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='qr_with_pivoting_csp')
+                    if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module,&
+                        & procedure='qr_with_pivoting_csp')
                     beta = Q(i)%norm(); call Q(i)%scal(one_csp / beta)
                 enddo
                 info = j
@@ -1909,7 +1999,7 @@ contains
             if (j > 1) then
                 ! Double Gram-Schmidt orthogonalization
                 call double_gram_schmidt_step(Q(j), Q(1:j-1), info, if_chk_orthonormal=.false., beta=R(1:j-1,j))
-                call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='qr_no_pivoting_cdp')
+                if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='qr_no_pivoting_cdp')
             end if
 
             ! Normalize column.
@@ -1973,7 +2063,8 @@ contains
                 do i = j, kdim
                     call Q(i)%rand(.false.)
                     call orthogonalize_against_basis(Q(i), Q(1:i-1), info, if_chk_orthonormal=.false.)
-                    call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='qr_with_pivoting_cdp')
+                    if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module,&
+                        & procedure='qr_with_pivoting_cdp')
                     beta = Q(i)%norm(); call Q(i)%scal(one_cdp / beta)
                 enddo
                 info = j
@@ -2205,11 +2296,11 @@ contains
 
             ! Update Hessenberg matrix via batch double Gram-Schmidt step.
             call double_gram_schmidt_step(X(kp+1:kpp), X(1:kp), info, if_chk_orthonormal=.false., beta=H(1:kp, kpm+1:kp))
-            call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='arnoldi_rsp')
+            if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='arnoldi_rsp')
 
             ! Orthogonalize current blk vectors.
             call qr(X(kp+1:kpp), H(kp+1:kpp, kpm+1:kp), info)
-            call check_info(info, 'qr', module=this_module, procedure='arnoldi_rsp')
+            if (nid == 0) call check_info(info, 'qr', module=this_module, procedure='arnoldi_rsp')
 
             ! Extract residual norm (smallest diagonal element of H matrix).
             res = zero_rsp
@@ -2293,11 +2384,11 @@ contains
 
             ! Update Hessenberg matrix via batch double Gram-Schmidt step.
             call double_gram_schmidt_step(X(kp+1:kpp), X(1:kp), info, if_chk_orthonormal=.false., beta=H(1:kp, kpm+1:kp))
-            call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='arnoldi_rdp')
+            if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='arnoldi_rdp')
 
             ! Orthogonalize current blk vectors.
             call qr(X(kp+1:kpp), H(kp+1:kpp, kpm+1:kp), info)
-            call check_info(info, 'qr', module=this_module, procedure='arnoldi_rdp')
+            if (nid == 0) call check_info(info, 'qr', module=this_module, procedure='arnoldi_rdp')
 
             ! Extract residual norm (smallest diagonal element of H matrix).
             res = zero_rdp
@@ -2381,11 +2472,11 @@ contains
 
             ! Update Hessenberg matrix via batch double Gram-Schmidt step.
             call double_gram_schmidt_step(X(kp+1:kpp), X(1:kp), info, if_chk_orthonormal=.false., beta=H(1:kp, kpm+1:kp))
-            call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='arnoldi_csp')
+            if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='arnoldi_csp')
 
             ! Orthogonalize current blk vectors.
             call qr(X(kp+1:kpp), H(kp+1:kpp, kpm+1:kp), info)
-            call check_info(info, 'qr', module=this_module, procedure='arnoldi_csp')
+            if (nid == 0) call check_info(info, 'qr', module=this_module, procedure='arnoldi_csp')
 
             ! Extract residual norm (smallest diagonal element of H matrix).
             res = zero_rsp
@@ -2469,11 +2560,11 @@ contains
 
             ! Update Hessenberg matrix via batch double Gram-Schmidt step.
             call double_gram_schmidt_step(X(kp+1:kpp), X(1:kp), info, if_chk_orthonormal=.false., beta=H(1:kp, kpm+1:kp))
-            call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='arnoldi_cdp')
+            if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='arnoldi_cdp')
 
             ! Orthogonalize current blk vectors.
             call qr(X(kp+1:kpp), H(kp+1:kpp, kpm+1:kp), info)
-            call check_info(info, 'qr', module=this_module, procedure='arnoldi_cdp')
+            if (nid == 0) call check_info(info, 'qr', module=this_module, procedure='arnoldi_cdp')
 
             ! Extract residual norm (smallest diagonal element of H matrix).
             res = zero_rdp
@@ -2550,7 +2641,7 @@ contains
             if (k > 1 ) then
             
                 call double_gram_schmidt_step(V(k), V(:k-1), info, if_chk_orthonormal=.false.)
-                call check_info(info, 'double_gram_schmidt_step', module=this_module, &
+                if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_rsp, first pass')
             end if
 
@@ -2568,7 +2659,7 @@ contains
 
             ! Full re-orthogonalization of the left Krylov subspace.
             call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.false.)
-            call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+            if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_rsp, second pass')
 
             ! Normalization step
@@ -2634,7 +2725,7 @@ contains
             if (k > 1 ) then
             
                 call double_gram_schmidt_step(V(k), V(:k-1), info, if_chk_orthonormal=.false.)
-                call check_info(info, 'double_gram_schmidt_step', module=this_module, &
+                if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_rdp, first pass')
             end if
 
@@ -2652,7 +2743,7 @@ contains
 
             ! Full re-orthogonalization of the left Krylov subspace.
             call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.false.)
-            call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+            if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_rdp, second pass')
 
             ! Normalization step
@@ -2718,7 +2809,7 @@ contains
             if (k > 1 ) then
             
                 call double_gram_schmidt_step(V(k), V(:k-1), info, if_chk_orthonormal=.false.)
-                call check_info(info, 'double_gram_schmidt_step', module=this_module, &
+                if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_csp, first pass')
             end if
 
@@ -2736,7 +2827,7 @@ contains
 
             ! Full re-orthogonalization of the left Krylov subspace.
             call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.false.)
-            call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+            if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_csp, second pass')
 
             ! Normalization step
@@ -2802,7 +2893,7 @@ contains
             if (k > 1 ) then
             
                 call double_gram_schmidt_step(V(k), V(:k-1), info, if_chk_orthonormal=.false.)
-                call check_info(info, 'double_gram_schmidt_step', module=this_module, &
+                if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_cdp, first pass')
             end if
 
@@ -2820,7 +2911,7 @@ contains
 
             ! Full re-orthogonalization of the left Krylov subspace.
             call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.false.)
-            call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+            if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_cdp, second pass')
 
             ! Normalization step
@@ -2908,7 +2999,8 @@ contains
 
         ! Full re-orthogonalization against existing basis
         call double_gram_schmidt_step(X(k+1), X(:k), info, if_chk_orthonormal=.false.)
-        call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='update_tridiag_matrix_rsp')
+        if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module,&
+            & procedure='update_tridiag_matrix_rsp')
 
         return
     end subroutine update_tridiag_matrix_rsp
@@ -2978,7 +3070,8 @@ contains
 
         ! Full re-orthogonalization against existing basis
         call double_gram_schmidt_step(X(k+1), X(:k), info, if_chk_orthonormal=.false.)
-        call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='update_tridiag_matrix_rdp')
+        if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module,&
+            & procedure='update_tridiag_matrix_rdp')
 
         return
     end subroutine update_tridiag_matrix_rdp
@@ -3048,7 +3141,8 @@ contains
 
         ! Full re-orthogonalization against existing basis
         call double_gram_schmidt_step(X(k+1), X(:k), info, if_chk_orthonormal=.false.)
-        call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='update_tridiag_matrix_csp')
+        if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module,&
+            & procedure='update_tridiag_matrix_csp')
 
         return
     end subroutine update_tridiag_matrix_csp
@@ -3118,7 +3212,8 @@ contains
 
         ! Full re-orthogonalization against existing basis
         call double_gram_schmidt_step(X(k+1), X(:k), info, if_chk_orthonormal=.false.)
-        call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='update_tridiag_matrix_cdp')
+        if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module,&
+            & procedure='update_tridiag_matrix_cdp')
 
         return
     end subroutine update_tridiag_matrix_cdp

--- a/src/BaseKrylov.fypp
+++ b/src/BaseKrylov.fypp
@@ -316,11 +316,11 @@ contains
       ! Orthogonalize vector y w.r.t. to Krylov basis X in two passes of GS.
       ! first pass
       call orthogonalize_against_basis(y, X, info, if_chk_orthonormal=.false., beta=proj_coefficients)
-      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+      call check_info(info, 'orthogonalize_against_basis', module=this_module, &
                         & procedure='DGS_vector_against_basis_${type[0]}$${kind}$, pass 1')
       ! second pass
       call orthogonalize_against_basis(y, X, info, if_chk_orthonormal=.false., beta=wrk)
-      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+      call check_info(info, 'orthogonalize_against_basis', module=this_module, &
                         & procedure='DGS_vector_against_basis_${type[0]}$${kind}$, pass 2')
       ! combine passes
       proj_coefficients = proj_coefficients + wrk
@@ -361,10 +361,10 @@ contains
       ! Orthogonalize Krylov basis Y w.r.t. to Krylov basis X in two passes of GS.
       ! first pass
       call orthogonalize_against_basis(Y, X, info, if_chk_orthonormal=.false., beta=proj_coefficients)
-      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='DGS_basis_against_basis_${type[0]}$${kind}$, first pass')
+      call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='DGS_basis_against_basis_${type[0]}$${kind}$, first pass')
       ! second pass
       call orthogonalize_against_basis(Y, X, info, if_chk_orthonormal=.false., beta=wrk)
-      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='DGS_basis_against_basis_${type[0]}$${kind}$, second pass')
+      call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='DGS_basis_against_basis_${type[0]}$${kind}$, second pass')
       ! combine passes
       proj_coefficients = proj_coefficients + wrk
 
@@ -411,7 +411,7 @@ contains
             if (j > 1) then
                 ! Double Gram-Schmidt orthogonalization
                 call double_gram_schmidt_step(Q(j), Q(1:j-1), info, if_chk_orthonormal=.false., beta=R(1:j-1,j))
-                if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='qr_no_pivoting_${type[0]}$${kind}$')
+                call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='qr_no_pivoting_${type[0]}$${kind}$')
             end if
 
             ! Normalize column.
@@ -475,7 +475,7 @@ contains
                 do i = j, kdim
                     call Q(i)%rand(.false.)
                     call orthogonalize_against_basis(Q(i), Q(1:i-1), info, if_chk_orthonormal=.false.)
-                    if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='qr_with_pivoting_${type[0]}$${kind}$')
+                    call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='qr_with_pivoting_${type[0]}$${kind}$')
                     beta = Q(i)%norm(); call Q(i)%scal(one_${type[0]}$${kind}$ / beta)
                 enddo
                 info = j
@@ -709,11 +709,11 @@ contains
 
             ! Update Hessenberg matrix via batch double Gram-Schmidt step.
             call double_gram_schmidt_step(X(kp+1:kpp), X(1:kp), info, if_chk_orthonormal=.false., beta=H(1:kp, kpm+1:kp))
-            if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='arnoldi_${type[0]}$${kind}$')
+            call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='arnoldi_${type[0]}$${kind}$')
 
             ! Orthogonalize current blk vectors.
             call qr(X(kp+1:kpp), H(kp+1:kpp, kpm+1:kp), info)
-            if (nid == 0) call check_info(info, 'qr', module=this_module, procedure='arnoldi_${type[0]}$${kind}$')
+            call check_info(info, 'qr', module=this_module, procedure='arnoldi_${type[0]}$${kind}$')
 
             ! Extract residual norm (smallest diagonal element of H matrix).
             res = zero_r${kind}$
@@ -792,7 +792,7 @@ contains
             if (k > 1 ) then
             
                 call double_gram_schmidt_step(V(k), V(:k-1), info, if_chk_orthonormal=.false.)
-                if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, &
+                call check_info(info, 'double_gram_schmidt_step', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_${type[0]}$${kind}$, first pass')
             end if
 
@@ -810,7 +810,7 @@ contains
 
             ! Full re-orthogonalization of the left Krylov subspace.
             call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.false.)
-            if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+            call check_info(info, 'orthogonalize_against_basis', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_${type[0]}$${kind}$, second pass')
 
             ! Normalization step
@@ -904,7 +904,7 @@ contains
 
         ! Full re-orthogonalization against existing basis
         call double_gram_schmidt_step(X(k+1), X(:k), info, if_chk_orthonormal=.false.)
-        if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='update_tridiag_matrix_${type[0]}$${kind}$')
+        call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='update_tridiag_matrix_${type[0]}$${kind}$')
 
         return
     end subroutine update_tridiag_matrix_${type[0]}$${kind}$

--- a/src/BaseKrylov.fypp
+++ b/src/BaseKrylov.fypp
@@ -4,7 +4,7 @@ module lightkrylov_BaseKrylov
     use iso_fortran_env
     use stdlib_optval, only: optval
     use stdlib_linalg, only: eye
-    use LightKrylov_constants
+    use LightKrylov_Constants
     use LightKrylov_Logger
     use LightKrylov_Utils
     use LightKrylov_AbstractVectors
@@ -13,7 +13,6 @@ module lightkrylov_BaseKrylov
     private
     
     character(len=128), parameter :: this_module = 'LightKrylov_BaseKrylov'
-
     public :: qr
     public :: apply_permutation_matrix
     public :: apply_inverse_permutation_matrix
@@ -155,6 +154,22 @@ contains
 
         return
     end subroutine initialize_krylov_subspace_${type[0]}$${kind}$
+
+    subroutine orthonormalize_basis_${type[0]}$${kind}$(X)
+      !! Orthonormalizes the `abstract_vector` basis `X`
+      class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: X(:)
+      !! Input `abstract_vector` basis to orthogonalize against
+      
+      ! internals
+      ${type}$ :: R(size(X),size(X))
+      integer :: info
+
+      ! internals
+      call qr(X, R, info)
+      call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_${type[0]}$${kind}$')
+      
+      return
+    end subroutine orthonormalize_basis_${type[0]}$${kind}$
 
     subroutine orthogonalize_vector_against_basis_${type[0]}$${kind}$(y, X, info, if_chk_orthonormal, beta)
       !! Orthonormalizes the `abstract_vector` `y` against a basis `X` of `abstract_vector`.
@@ -301,10 +316,12 @@ contains
       ! Orthogonalize vector y w.r.t. to Krylov basis X in two passes of GS.
       ! first pass
       call orthogonalize_against_basis(y, X, info, if_chk_orthonormal=.false., beta=proj_coefficients)
-      call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='DGS_vector_against_basis, first pass')
+      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+                        & procedure='DGS_vector_against_basis_${type[0]}$${kind}$, pass 1')
       ! second pass
       call orthogonalize_against_basis(y, X, info, if_chk_orthonormal=.false., beta=wrk)
-      call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='DGS_vector_against_basis_${type[0]}$${kind}$, second pass')
+      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+                        & procedure='DGS_vector_against_basis_${type[0]}$${kind}$, pass 2')
       ! combine passes
       proj_coefficients = proj_coefficients + wrk
 
@@ -344,10 +361,10 @@ contains
       ! Orthogonalize Krylov basis Y w.r.t. to Krylov basis X in two passes of GS.
       ! first pass
       call orthogonalize_against_basis(Y, X, info, if_chk_orthonormal=.false., beta=proj_coefficients)
-      call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='DGS_basis_against_basis_${type[0]}$${kind}$, first pass')
+      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='DGS_basis_against_basis_${type[0]}$${kind}$, first pass')
       ! second pass
       call orthogonalize_against_basis(Y, X, info, if_chk_orthonormal=.false., beta=wrk)
-      call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='DGS_basis_against_basis_${type[0]}$${kind}$, second pass')
+      if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='DGS_basis_against_basis_${type[0]}$${kind}$, second pass')
       ! combine passes
       proj_coefficients = proj_coefficients + wrk
 
@@ -394,7 +411,7 @@ contains
             if (j > 1) then
                 ! Double Gram-Schmidt orthogonalization
                 call double_gram_schmidt_step(Q(j), Q(1:j-1), info, if_chk_orthonormal=.false., beta=R(1:j-1,j))
-                call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='qr_no_pivoting_${type[0]}$${kind}$')
+                if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='qr_no_pivoting_${type[0]}$${kind}$')
             end if
 
             ! Normalize column.
@@ -458,7 +475,7 @@ contains
                 do i = j, kdim
                     call Q(i)%rand(.false.)
                     call orthogonalize_against_basis(Q(i), Q(1:i-1), info, if_chk_orthonormal=.false.)
-                    call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='qr_with_pivoting_${type[0]}$${kind}$')
+                    if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='qr_with_pivoting_${type[0]}$${kind}$')
                     beta = Q(i)%norm(); call Q(i)%scal(one_${type[0]}$${kind}$ / beta)
                 enddo
                 info = j
@@ -692,11 +709,11 @@ contains
 
             ! Update Hessenberg matrix via batch double Gram-Schmidt step.
             call double_gram_schmidt_step(X(kp+1:kpp), X(1:kp), info, if_chk_orthonormal=.false., beta=H(1:kp, kpm+1:kp))
-            call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='arnoldi_${type[0]}$${kind}$')
+            if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='arnoldi_${type[0]}$${kind}$')
 
             ! Orthogonalize current blk vectors.
             call qr(X(kp+1:kpp), H(kp+1:kpp, kpm+1:kp), info)
-            call check_info(info, 'qr', module=this_module, procedure='arnoldi_${type[0]}$${kind}$')
+            if (nid == 0) call check_info(info, 'qr', module=this_module, procedure='arnoldi_${type[0]}$${kind}$')
 
             ! Extract residual norm (smallest diagonal element of H matrix).
             res = zero_r${kind}$
@@ -775,7 +792,7 @@ contains
             if (k > 1 ) then
             
                 call double_gram_schmidt_step(V(k), V(:k-1), info, if_chk_orthonormal=.false.)
-                call check_info(info, 'double_gram_schmidt_step', module=this_module, &
+                if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_${type[0]}$${kind}$, first pass')
             end if
 
@@ -793,7 +810,7 @@ contains
 
             ! Full re-orthogonalization of the left Krylov subspace.
             call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.false.)
-            call check_info(info, 'orthogonalize_against_basis', module=this_module, &
+            if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module, &
                                     & procedure='lanczos_bidiagonalization_${type[0]}$${kind}$, second pass')
 
             ! Normalization step
@@ -887,7 +904,7 @@ contains
 
         ! Full re-orthogonalization against existing basis
         call double_gram_schmidt_step(X(k+1), X(:k), info, if_chk_orthonormal=.false.)
-        call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='update_tridiag_matrix_${type[0]}$${kind}$')
+        if (nid == 0) call check_info(info, 'orthogonalize_against_basis', module=this_module, procedure='update_tridiag_matrix_${type[0]}$${kind}$')
 
         return
     end subroutine update_tridiag_matrix_${type[0]}$${kind}$

--- a/src/Constants.f90
+++ b/src/Constants.f90
@@ -37,7 +37,7 @@ module LightKrylov_Constants
     complex(dp), parameter, public :: zero_cdp   = cmplx(0.0_dp, 0.0_dp, kind=dp)
 
     ! MPI subroutines
-    public :: mpi_setup, mpi_close
+    public :: comm_setup, comm_close
     
     ! Getter/setter
     public :: set_io_rank
@@ -46,7 +46,7 @@ module LightKrylov_Constants
     
 contains
 
-   subroutine mpi_setup()
+   subroutine comm_setup()
       integer :: ierr
       character(len=128) :: msg
 #ifdef MPI
@@ -63,9 +63,9 @@ contains
 #endif
       call set_io_rank(0)
       return
-   end subroutine mpi_setup
+   end subroutine comm_setup
 
-   subroutine mpi_close
+   subroutine comm_close
       integer :: ierr
       character(len=128) :: msg
 #ifdef MPI
@@ -76,7 +76,7 @@ contains
       ierr = 0
 #endif
       return
-   end subroutine mpi_close
+   end subroutine comm_close
 
    subroutine set_io_rank(rk)
       integer, intent(in) :: rk

--- a/src/Constants.f90
+++ b/src/Constants.f90
@@ -1,6 +1,14 @@
 module lightkrylov_constants
+#ifdef MPI
+    use mpi
+#endif
     implicit none
     private
+#ifdef MPI
+    integer , parameter, public :: nid = myrank
+#else
+    integer , parameter, public :: nid = 0
+#endif
 
     integer , parameter, public :: sp = selected_real_kind(6, 37)
     !! Definition of the single precision data type.

--- a/src/Constants.f90
+++ b/src/Constants.f90
@@ -47,6 +47,7 @@ module LightKrylov_Constants
 contains
 
    subroutine comm_setup()
+      ! internal
       integer :: ierr
       logical :: mpi_is_initialized
       character(len=128) :: msg
@@ -54,19 +55,19 @@ contains
       ! check if MPI has already been initialized and if not, initialize
       call MPI_Initialized(mpi_is_initialized, ierr)
       if (.not. mpi_is_initialized) then
-         call logger%log_message('Set up parallel run with MPI.', module='LightKrylov', procedure='comm_setup')
+         call logger%log_debug('Set up parallel run with MPI.', module='LightKrylov', procedure='comm_setup')
          call MPI_Init(ierr)
          if (ierr /= MPI_SUCCESS) call stop_error("Error initializing MPI", module='LightKrylov',procedure='mpi_init')
       else
-         call logger%log_message('MPI already initialized.', module='LightKrylov', procedure='comm_setup')
+         call logger%log_debug('MPI already initialized.', module='LightKrylov', procedure='comm_setup')
       end if
       call MPI_Comm_rank(MPI_COMM_WORLD, nid, ierr)
       call MPI_Comm_size(MPI_COMM_WORLD, comm_size, ierr)
       write(msg, '(A,I4,A,I4)') 'rank', nid, ', comm_size = ', comm_size
-      call logger%log_message(trim(msg), module='LightKrylov', procedure='comm_setup')
+      call logger%log_debug(trim(msg), module='LightKrylov', procedure='comm_setup')
 #else
       write(msg, *) 'Setup serial run'
-      call logger%log_message(trim(msg), module='LightKrylov', procedure='comm_setup')
+      call logger%log_debug(trim(msg), module='LightKrylov', procedure='comm_setup')
 #endif
       call set_io_rank(0)
       return

--- a/src/Constants.f90
+++ b/src/Constants.f90
@@ -1,13 +1,15 @@
 module LightKrylov_Constants
+    use stdlib_logger, only: logger => global_logger
+    use LightKrylov_Logger
 #ifdef MPI
     use mpi_f08
 #endif
     implicit none
     private
 
-    integer, private :: nio = 1
-    integer, private :: nid = 1
+    integer, private :: nid = 0
     integer, private :: comm_size = 1
+    integer, private :: nio = 0
 
     integer , parameter, public :: sp = selected_real_kind(6, 37)
     !! Definition of the single precision data type.
@@ -34,10 +36,9 @@ module LightKrylov_Constants
     complex(sp), parameter, public :: one_im_cdp = cmplx(0.0_dp, 1.0_dp, kind=dp)
     complex(dp), parameter, public :: zero_cdp   = cmplx(0.0_dp, 0.0_dp, kind=dp)
 
-#ifdef MPI
     ! MPI subroutines
-    public :: mpi_initialize, mpi_close
-#endif
+    public :: mpi_setup, mpi_close
+    
     ! Getter/setter
     public :: set_io_rank
     public :: io_rank
@@ -45,34 +46,49 @@ module LightKrylov_Constants
     
 contains
 
-#ifdef MPI
-   subroutine mpi_initialize()
+   subroutine mpi_setup()
       integer :: ierr
+      character(len=128) :: msg
+#ifdef MPI
       ! Initialize MPI
       call MPI_Init(ierr)
-      if (ierr /= MPI_SUCCESS) then
-         print *, "Error initializing MPI"
-         STOP 1
-      end if
+      if (ierr /= MPI_SUCCESS) call stop_error("Error initializing MPI", module='LightKrylov',procedure='mpi_initialize')
       call MPI_Comm_rank(MPI_COMM_WORLD, nid, ierr)
       call MPI_Comm_size(MPI_COMM_WORLD, comm_size, ierr)
-   end subroutine mpi_initialize
+      write(msg, '(A,I4,A,I4)') 'Setup parallel run: rank', nid, ', comm_size = ', comm_size
+      call logger%log_message(trim(msg), module='LightKrylov', procedure='mpi_setup')
+#else
+      write(msg, *) 'Setup serial run'
+      call logger%log_message(trim(msg), module='LightKrylov', procedure='mpi_setup')
+#endif
+      call set_io_rank(0)
+      return
+   end subroutine mpi_setup
 
    subroutine mpi_close
       integer :: ierr
+      character(len=128) :: msg
+#ifdef MPI
       ! Finalize MPI
       call MPI_Finalize(ierr)
-      if (ierr /= MPI_SUCCESS) then
-          print *, "Error finalizing MPI"
-          STOP 1
-      end if
-   end subroutine mpi_close
+      if (ierr /= MPI_SUCCESS) call stop_error("Error finalizing MPI", module='LightKrylov',procedure='mpi_destroy')
+#else
+      ierr = 0
 #endif
+      return
+   end subroutine mpi_close
 
    subroutine set_io_rank(rk)
       integer, intent(in) :: rk
-      if (rk > comm_size) print *, 'Invalid I/O rank specified in set_io_rank'
-      nio = rk
+      character(len=128) :: msg
+      if (rk > comm_size) then
+         write(msg, *) 'Invalid I/O rank specified!'
+         if (io_rank()) call logger%log_message(trim(msg), module='LightKrylov', procedure='set_io_rank')
+      else
+         nio = rk
+         write(msg, '(A,I4)') 'I/O rank --> rank ', nio
+         if (io_rank()) call logger%log_message(trim(msg), module='LightKrylov', procedure='set_io_rank')
+      end if
    end 
 
    logical function io_rank() result(is_io)

--- a/src/Constants.f90
+++ b/src/Constants.f90
@@ -1,101 +1,50 @@
 module LightKrylov_Constants
-    use stdlib_logger, only: logger => global_logger
-    use LightKrylov_Logger
-#ifdef MPI
-    use mpi_f08
-#endif
-    implicit none
-    private
+   implicit none
+   private
 
-    integer, private :: nid = 0
-    integer, private :: comm_size = 1
-    integer, private :: nio = 0
+   integer, private :: nid = 0
+   integer, private :: comm_size = 1
+   integer, private :: nio = 0
 
-    integer , parameter, public :: sp = selected_real_kind(6, 37)
-    !! Definition of the single precision data type.
-    real(sp), parameter, public :: atol_sp = 10.0_sp ** -precision(1.0_sp)
-    !! Definition of the absolute tolerance for single precision computations.
-    real(sp), parameter, public :: rtol_sp = sqrt(atol_sp)
-    !! Definition of the relative tolerance for single precision computations.
+   integer , parameter, public :: sp = selected_real_kind(6, 37)
+   !! Definition of the single precision data type.
+   real(sp), parameter, public :: atol_sp = 10.0_sp ** -precision(1.0_sp)
+   !! Definition of the absolute tolerance for single precision computations.
+   real(sp), parameter, public :: rtol_sp = sqrt(atol_sp)
+   !! Definition of the relative tolerance for single precision computations.
 
-    integer , parameter, public :: dp = selected_real_kind(15, 307)
-    !! Definition of the double precision data type.
-    real(dp), parameter, public :: atol_dp = 10.0_dp ** -precision(1.0_dp)
-    !! Definition of the absolute tolerance for double precision computations.
-    real(dp), parameter, public :: rtol_dp = sqrt(atol_dp)
-    !! Definition of the relative tolerance for double precision computations.
+   integer , parameter, public :: dp = selected_real_kind(15, 307)
+   !! Definition of the double precision data type.
+   real(dp), parameter, public :: atol_dp = 10.0_dp ** -precision(1.0_dp)
+   !! Definition of the absolute tolerance for double precision computations.
+   real(dp), parameter, public :: rtol_dp = sqrt(atol_dp)
+   !! Definition of the relative tolerance for double precision computations.
 
-    real(sp), parameter, public :: one_rsp  = 1.0_sp
-    real(sp), parameter, public :: zero_rsp = 0.0_sp
-    real(dp), parameter, public :: one_rdp  = 1.0_dp
-    real(dp), parameter, public :: zero_rdp = 0.0_dp
-    complex(sp), parameter, public :: one_csp    = cmplx(1.0_sp, 0.0_sp, kind=sp)
-    complex(sp), parameter, public :: one_im_csp = cmplx(0.0_sp, 1.0_sp, kind=sp)
-    complex(sp), parameter, public :: zero_csp   = cmplx(0.0_sp, 0.0_sp, kind=sp)
-    complex(dp), parameter, public :: one_cdp    = cmplx(1.0_dp, 0.0_dp, kind=dp)
-    complex(sp), parameter, public :: one_im_cdp = cmplx(0.0_dp, 1.0_dp, kind=dp)
-    complex(dp), parameter, public :: zero_cdp   = cmplx(0.0_dp, 0.0_dp, kind=dp)
+   real(sp), parameter, public :: one_rsp  = 1.0_sp
+   real(sp), parameter, public :: zero_rsp = 0.0_sp
+   real(dp), parameter, public :: one_rdp  = 1.0_dp
+   real(dp), parameter, public :: zero_rdp = 0.0_dp
+   complex(sp), parameter, public :: one_csp    = cmplx(1.0_sp, 0.0_sp, kind=sp)
+   complex(sp), parameter, public :: one_im_csp = cmplx(0.0_sp, 1.0_sp, kind=sp)
+   complex(sp), parameter, public :: zero_csp   = cmplx(0.0_sp, 0.0_sp, kind=sp)
+   complex(dp), parameter, public :: one_cdp    = cmplx(1.0_dp, 0.0_dp, kind=dp)
+   complex(sp), parameter, public :: one_im_cdp = cmplx(0.0_dp, 1.0_dp, kind=dp)
+   complex(dp), parameter, public :: zero_cdp   = cmplx(0.0_dp, 0.0_dp, kind=dp)
 
-    ! MPI subroutines
-    public :: comm_setup, comm_close
-    
-    ! Getter/setter
-    public :: set_io_rank
-    public :: io_rank
-    public :: get_rank
+   ! Getter/setter routines
+   public :: get_rank
+   public :: set_io_rank
+   public :: io_rank
     
 contains
 
-   subroutine comm_setup()
-      ! internal
-      integer :: ierr
-      logical :: mpi_is_initialized
-      character(len=128) :: msg
-#ifdef MPI
-      ! check if MPI has already been initialized and if not, initialize
-      call MPI_Initialized(mpi_is_initialized, ierr)
-      if (.not. mpi_is_initialized) then
-         call logger%log_debug('Set up parallel run with MPI.', module='LightKrylov', procedure='comm_setup')
-         call MPI_Init(ierr)
-         if (ierr /= MPI_SUCCESS) call stop_error("Error initializing MPI", module='LightKrylov',procedure='mpi_init')
-      else
-         call logger%log_debug('MPI already initialized.', module='LightKrylov', procedure='comm_setup')
-      end if
-      call MPI_Comm_rank(MPI_COMM_WORLD, nid, ierr)
-      call MPI_Comm_size(MPI_COMM_WORLD, comm_size, ierr)
-      write(msg, '(A,I4,A,I4)') 'rank', nid, ', comm_size = ', comm_size
-      call logger%log_debug(trim(msg), module='LightKrylov', procedure='comm_setup')
-#else
-      write(msg, *) 'Setup serial run'
-      call logger%log_debug(trim(msg), module='LightKrylov', procedure='comm_setup')
-#endif
-      call set_io_rank(0)
-      return
-   end subroutine comm_setup
-
-   subroutine comm_close()
-      integer :: ierr
-#ifdef MPI
-      character(len=128) :: msg
-      ! Finalize MPI
-      call MPI_Finalize(ierr)
-      if (ierr /= MPI_SUCCESS) call stop_error("Error finalizing MPI", module='LightKrylov',procedure='comm_close')
-#else
-      ierr = 0
-#endif
-      return
-   end subroutine comm_close
-
    subroutine set_io_rank(rk)
       integer, intent(in) :: rk
-      character(len=128) :: msg
-      if (rk > comm_size) then
-         write(msg, *) 'Invalid I/O rank specified!'
-         if (io_rank()) call logger%log_message(trim(msg), module='LightKrylov', procedure='set_io_rank')
+      if (rk > comm_size .or. rk < 0) then
+         if (io_rank()) print *, 'Invalid I/O rank specified!', rk
       else
          nio = rk
-         write(msg, '(A,I4)') 'I/O rank --> rank ', nio
-         if (io_rank()) call logger%log_message(trim(msg), module='LightKrylov', procedure='set_io_rank')
+         if (io_rank()) print *, 'I/O rank --> rank ', nio
       end if
    end 
 

--- a/src/Constants.f90
+++ b/src/Constants.f90
@@ -65,7 +65,7 @@ contains
       return
    end subroutine comm_setup
 
-   subroutine comm_close
+   subroutine comm_close()
       integer :: ierr
 #ifdef MPI
       character(len=128) :: msg

--- a/src/Constants.f90
+++ b/src/Constants.f90
@@ -1,14 +1,11 @@
-module lightkrylov_constants
-#ifdef MPI
-    use mpi
-#endif
+module LightKrylov_Constants
+    use mpi_f08
     implicit none
     private
-#ifdef MPI
-    integer , parameter, public :: nid = myrank
-#else
-    integer , parameter, public :: nid = 0
-#endif
+
+    integer, private :: nio = 1
+    integer, private :: nid = 1
+    integer, private :: comm_size = 1
 
     integer , parameter, public :: sp = selected_real_kind(6, 37)
     !! Definition of the single precision data type.
@@ -35,4 +32,50 @@ module lightkrylov_constants
     complex(sp), parameter, public :: one_im_cdp = cmplx(0.0_dp, 1.0_dp, kind=dp)
     complex(dp), parameter, public :: zero_cdp   = cmplx(0.0_dp, 0.0_dp, kind=dp)
 
-end module lightkrylov_constants
+    ! MPI subroutines
+    public :: mpi_initialize, mpi_close
+    ! Getter/setter
+    public :: set_io_rank
+    public :: io_rank
+    public :: get_rank
+    
+contains
+
+   subroutine mpi_initialize()
+      integer :: ierr
+      ! Initialize MPI
+      call MPI_Init(ierr)
+      if (ierr /= MPI_SUCCESS) then
+         print *, "Error initializing MPI"
+         STOP 1
+      end if
+      call MPI_Comm_rank(MPI_COMM_WORLD, nid, ierr)
+      call MPI_Comm_size(MPI_COMM_WORLD, comm_size, ierr)
+   end subroutine mpi_initialize
+
+   subroutine mpi_close
+      integer :: ierr
+      ! Finalize MPI
+      call MPI_Finalize(ierr)
+      if (ierr /= MPI_SUCCESS) then
+          print *, "Error finalizing MPI"
+          STOP 1
+      end if
+   end subroutine mpi_close
+
+   subroutine set_io_rank(rk)
+      integer, intent(in) :: rk
+      if (rk > comm_size) print *, 'Invalid I/O rank specified in set_io_rank'
+      nio = rk
+   end 
+
+   logical function io_rank() result(is_io)
+      is_io = .false.      
+      if (nid == nio) is_io = .true.
+   end function io_rank
+
+   integer function get_rank() result(rank)
+      rank = nid
+   end function get_rank
+
+end module LightKrylov_Constants

--- a/src/Constants.f90
+++ b/src/Constants.f90
@@ -1,5 +1,7 @@
 module LightKrylov_Constants
+#ifdef MPI
     use mpi_f08
+#endif
     implicit none
     private
 
@@ -32,8 +34,10 @@ module LightKrylov_Constants
     complex(sp), parameter, public :: one_im_cdp = cmplx(0.0_dp, 1.0_dp, kind=dp)
     complex(dp), parameter, public :: zero_cdp   = cmplx(0.0_dp, 0.0_dp, kind=dp)
 
+#ifdef MPI
     ! MPI subroutines
     public :: mpi_initialize, mpi_close
+#endif
     ! Getter/setter
     public :: set_io_rank
     public :: io_rank
@@ -41,6 +45,7 @@ module LightKrylov_Constants
     
 contains
 
+#ifdef MPI
    subroutine mpi_initialize()
       integer :: ierr
       ! Initialize MPI
@@ -62,6 +67,7 @@ contains
           STOP 1
       end if
    end subroutine mpi_close
+#endif
 
    subroutine set_io_rank(rk)
       integer, intent(in) :: rk

--- a/src/Constants.f90
+++ b/src/Constants.f90
@@ -52,7 +52,7 @@ contains
 #ifdef MPI
       ! Initialize MPI
       call MPI_Init(ierr)
-      if (ierr /= MPI_SUCCESS) call stop_error("Error initializing MPI", module='LightKrylov',procedure='mpi_initialize')
+      if (ierr /= MPI_SUCCESS) call stop_error("Error initializing MPI", module='LightKrylov',procedure='mpi_init')
       call MPI_Comm_rank(MPI_COMM_WORLD, nid, ierr)
       call MPI_Comm_size(MPI_COMM_WORLD, comm_size, ierr)
       write(msg, '(A,I4,A,I4)') 'Setup parallel run: rank', nid, ', comm_size = ', comm_size
@@ -71,7 +71,7 @@ contains
 #ifdef MPI
       ! Finalize MPI
       call MPI_Finalize(ierr)
-      if (ierr /= MPI_SUCCESS) call stop_error("Error finalizing MPI", module='LightKrylov',procedure='mpi_destroy')
+      if (ierr /= MPI_SUCCESS) call stop_error("Error finalizing MPI", module='LightKrylov',procedure='mpi_finalize')
 #else
       ierr = 0
 #endif

--- a/src/Constants.f90
+++ b/src/Constants.f90
@@ -32,11 +32,24 @@ module LightKrylov_Constants
    complex(dp), parameter, public :: zero_cdp   = cmplx(0.0_dp, 0.0_dp, kind=dp)
 
    ! Getter/setter routines
-   public :: get_rank
+   public :: set_comm_size
+   public :: set_rank
    public :: set_io_rank
+   public :: get_rank
+   public :: get_comm_size
    public :: io_rank
     
 contains
+
+   subroutine set_rank(rank)
+      integer :: rank
+      nid = rank
+   end subroutine set_rank
+
+   subroutine set_comm_size(c_size)
+      integer :: c_size
+      comm_size = c_size
+   end subroutine set_comm_size
 
    subroutine set_io_rank(rk)
       integer, intent(in) :: rk
@@ -46,15 +59,19 @@ contains
          nio = rk
          if (io_rank()) print *, 'I/O rank --> rank ', nio
       end if
-   end 
+   end
+
+   integer function get_rank() result(rank)
+      rank = nid
+   end function get_rank
+   
+   integer function get_comm_size() result(c_size)
+      c_size = comm_size
+   end function get_comm_size
 
    logical function io_rank() result(is_io)
       is_io = .false.      
       if (nid == nio) is_io = .true.
    end function io_rank
-
-   integer function get_rank() result(rank)
-      rank = nid
-   end function get_rank
 
 end module LightKrylov_Constants

--- a/src/Constants.f90
+++ b/src/Constants.f90
@@ -67,8 +67,8 @@ contains
 
    subroutine comm_close
       integer :: ierr
-      character(len=128) :: msg
 #ifdef MPI
+      character(len=128) :: msg
       ! Finalize MPI
       call MPI_Finalize(ierr)
       if (ierr /= MPI_SUCCESS) call stop_error("Error finalizing MPI", module='LightKrylov',procedure='mpi_finalize')

--- a/src/ExpmLib.f90
+++ b/src/ExpmLib.f90
@@ -8,17 +8,16 @@ module lightkrylov_expmlib
     use stdlib_linalg, only: eye
 
     ! LightKrylov.
-    use lightkrylov_constants
+    use LightKrylov_Constants
     use LightKrylov_Logger
-    use lightkrylov_utils
-    use lightkrylov_AbstractVectors
-    use lightkrylov_AbstractLinops
-    use lightkrylov_BaseKrylov
+    use LightKrylov_Utils
+    use LightKrylov_AbstractVectors
+    use LightKrylov_AbstractLinops
+    use LightKrylov_BaseKrylov
 
     implicit none
     
     character(len=128), parameter, private :: this_module = 'LightKrylov_ExpmLib'
-
     public :: abstract_exptA_rsp
     public :: abstract_exptA_rdp
     public :: abstract_exptA_csp
@@ -270,7 +269,7 @@ contains
 
                 ! Compute k-th step Arnoldi factorization.
                 call arnoldi(A, X, H, info, kstart=k, kend=k, transpose=transpose)
-                call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_vec_rsp')
+                if (nid == 0) call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_vec_rsp')
 
                 ! Compute approximation.
                 if (info == k) then
@@ -404,7 +403,7 @@ contains
 
                 ! Compute the k-th step of the Arnoldi factorization.
                 call arnoldi(A, X, H, info, kstart=k, kend=k, transpose=transpose, blksize=p)
-                call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_mat_rsp')
+                if (nid == 0) call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_mat_rsp')
 
 
                 if (info == kp) then
@@ -500,7 +499,7 @@ contains
         verbose = .false.
 
         call kexpm(vec_out, A, vec_in, tau, tol, info, trans=trans, verbosity=verbose, kdim=kdim)
-        call check_info(info, 'kexpm', module=this_module, procedure='k_exptA_rsp')
+        if (nid == 0) call check_info(info, 'kexpm', module=this_module, procedure='k_exptA_rsp')
 
         return
     end subroutine k_exptA_rsp
@@ -638,7 +637,7 @@ contains
 
                 ! Compute k-th step Arnoldi factorization.
                 call arnoldi(A, X, H, info, kstart=k, kend=k, transpose=transpose)
-                call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_vec_rdp')
+                if (nid == 0) call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_vec_rdp')
 
                 ! Compute approximation.
                 if (info == k) then
@@ -772,7 +771,7 @@ contains
 
                 ! Compute the k-th step of the Arnoldi factorization.
                 call arnoldi(A, X, H, info, kstart=k, kend=k, transpose=transpose, blksize=p)
-                call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_mat_rdp')
+                if (nid == 0) call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_mat_rdp')
 
 
                 if (info == kp) then
@@ -868,7 +867,7 @@ contains
         verbose = .false.
 
         call kexpm(vec_out, A, vec_in, tau, tol, info, trans=trans, verbosity=verbose, kdim=kdim)
-        call check_info(info, 'kexpm', module=this_module, procedure='k_exptA_rdp')
+        if (nid == 0) call check_info(info, 'kexpm', module=this_module, procedure='k_exptA_rdp')
 
         return
     end subroutine k_exptA_rdp
@@ -1006,7 +1005,7 @@ contains
 
                 ! Compute k-th step Arnoldi factorization.
                 call arnoldi(A, X, H, info, kstart=k, kend=k, transpose=transpose)
-                call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_vec_csp')
+                if (nid == 0) call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_vec_csp')
 
                 ! Compute approximation.
                 if (info == k) then
@@ -1140,7 +1139,7 @@ contains
 
                 ! Compute the k-th step of the Arnoldi factorization.
                 call arnoldi(A, X, H, info, kstart=k, kend=k, transpose=transpose, blksize=p)
-                call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_mat_csp')
+                if (nid == 0) call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_mat_csp')
 
 
                 if (info == kp) then
@@ -1236,7 +1235,7 @@ contains
         verbose = .false.
 
         call kexpm(vec_out, A, vec_in, tau, tol, info, trans=trans, verbosity=verbose, kdim=kdim)
-        call check_info(info, 'kexpm', module=this_module, procedure='k_exptA_csp')
+        if (nid == 0) call check_info(info, 'kexpm', module=this_module, procedure='k_exptA_csp')
 
         return
     end subroutine k_exptA_csp
@@ -1374,7 +1373,7 @@ contains
 
                 ! Compute k-th step Arnoldi factorization.
                 call arnoldi(A, X, H, info, kstart=k, kend=k, transpose=transpose)
-                call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_vec_cdp')
+                if (nid == 0) call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_vec_cdp')
 
                 ! Compute approximation.
                 if (info == k) then
@@ -1508,7 +1507,7 @@ contains
 
                 ! Compute the k-th step of the Arnoldi factorization.
                 call arnoldi(A, X, H, info, kstart=k, kend=k, transpose=transpose, blksize=p)
-                call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_mat_cdp')
+                if (nid == 0) call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_mat_cdp')
 
 
                 if (info == kp) then
@@ -1604,7 +1603,7 @@ contains
         verbose = .false.
 
         call kexpm(vec_out, A, vec_in, tau, tol, info, trans=trans, verbosity=verbose, kdim=kdim)
-        call check_info(info, 'kexpm', module=this_module, procedure='k_exptA_cdp')
+        if (nid == 0) call check_info(info, 'kexpm', module=this_module, procedure='k_exptA_cdp')
 
         return
     end subroutine k_exptA_cdp

--- a/src/ExpmLib.f90
+++ b/src/ExpmLib.f90
@@ -269,7 +269,7 @@ contains
 
                 ! Compute k-th step Arnoldi factorization.
                 call arnoldi(A, X, H, info, kstart=k, kend=k, transpose=transpose)
-                if (nid == 0) call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_vec_rsp')
+                call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_vec_rsp')
 
                 ! Compute approximation.
                 if (info == k) then
@@ -403,7 +403,7 @@ contains
 
                 ! Compute the k-th step of the Arnoldi factorization.
                 call arnoldi(A, X, H, info, kstart=k, kend=k, transpose=transpose, blksize=p)
-                if (nid == 0) call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_mat_rsp')
+                call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_mat_rsp')
 
 
                 if (info == kp) then
@@ -499,7 +499,7 @@ contains
         verbose = .false.
 
         call kexpm(vec_out, A, vec_in, tau, tol, info, trans=trans, verbosity=verbose, kdim=kdim)
-        if (nid == 0) call check_info(info, 'kexpm', module=this_module, procedure='k_exptA_rsp')
+        call check_info(info, 'kexpm', module=this_module, procedure='k_exptA_rsp')
 
         return
     end subroutine k_exptA_rsp
@@ -637,7 +637,7 @@ contains
 
                 ! Compute k-th step Arnoldi factorization.
                 call arnoldi(A, X, H, info, kstart=k, kend=k, transpose=transpose)
-                if (nid == 0) call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_vec_rdp')
+                call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_vec_rdp')
 
                 ! Compute approximation.
                 if (info == k) then
@@ -771,7 +771,7 @@ contains
 
                 ! Compute the k-th step of the Arnoldi factorization.
                 call arnoldi(A, X, H, info, kstart=k, kend=k, transpose=transpose, blksize=p)
-                if (nid == 0) call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_mat_rdp')
+                call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_mat_rdp')
 
 
                 if (info == kp) then
@@ -867,7 +867,7 @@ contains
         verbose = .false.
 
         call kexpm(vec_out, A, vec_in, tau, tol, info, trans=trans, verbosity=verbose, kdim=kdim)
-        if (nid == 0) call check_info(info, 'kexpm', module=this_module, procedure='k_exptA_rdp')
+        call check_info(info, 'kexpm', module=this_module, procedure='k_exptA_rdp')
 
         return
     end subroutine k_exptA_rdp
@@ -1005,7 +1005,7 @@ contains
 
                 ! Compute k-th step Arnoldi factorization.
                 call arnoldi(A, X, H, info, kstart=k, kend=k, transpose=transpose)
-                if (nid == 0) call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_vec_csp')
+                call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_vec_csp')
 
                 ! Compute approximation.
                 if (info == k) then
@@ -1139,7 +1139,7 @@ contains
 
                 ! Compute the k-th step of the Arnoldi factorization.
                 call arnoldi(A, X, H, info, kstart=k, kend=k, transpose=transpose, blksize=p)
-                if (nid == 0) call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_mat_csp')
+                call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_mat_csp')
 
 
                 if (info == kp) then
@@ -1235,7 +1235,7 @@ contains
         verbose = .false.
 
         call kexpm(vec_out, A, vec_in, tau, tol, info, trans=trans, verbosity=verbose, kdim=kdim)
-        if (nid == 0) call check_info(info, 'kexpm', module=this_module, procedure='k_exptA_csp')
+        call check_info(info, 'kexpm', module=this_module, procedure='k_exptA_csp')
 
         return
     end subroutine k_exptA_csp
@@ -1373,7 +1373,7 @@ contains
 
                 ! Compute k-th step Arnoldi factorization.
                 call arnoldi(A, X, H, info, kstart=k, kend=k, transpose=transpose)
-                if (nid == 0) call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_vec_cdp')
+                call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_vec_cdp')
 
                 ! Compute approximation.
                 if (info == k) then
@@ -1507,7 +1507,7 @@ contains
 
                 ! Compute the k-th step of the Arnoldi factorization.
                 call arnoldi(A, X, H, info, kstart=k, kend=k, transpose=transpose, blksize=p)
-                if (nid == 0) call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_mat_cdp')
+                call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_mat_cdp')
 
 
                 if (info == kp) then
@@ -1603,7 +1603,7 @@ contains
         verbose = .false.
 
         call kexpm(vec_out, A, vec_in, tau, tol, info, trans=trans, verbosity=verbose, kdim=kdim)
-        if (nid == 0) call check_info(info, 'kexpm', module=this_module, procedure='k_exptA_cdp')
+        call check_info(info, 'kexpm', module=this_module, procedure='k_exptA_cdp')
 
         return
     end subroutine k_exptA_cdp

--- a/src/ExpmLib.fypp
+++ b/src/ExpmLib.fypp
@@ -210,7 +210,7 @@ contains
 
                 ! Compute k-th step Arnoldi factorization.
                 call arnoldi(A, X, H, info, kstart=k, kend=k, transpose=transpose)
-                if (nid == 0) call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_vec_${type[0]}$${kind}$')
+                call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_vec_${type[0]}$${kind}$')
 
                 ! Compute approximation.
                 if (info == k) then
@@ -344,7 +344,7 @@ contains
 
                 ! Compute the k-th step of the Arnoldi factorization.
                 call arnoldi(A, X, H, info, kstart=k, kend=k, transpose=transpose, blksize=p)
-                if (nid == 0) call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_mat_${type[0]}$${kind}$')
+                call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_mat_${type[0]}$${kind}$')
 
 
                 if (info == kp) then
@@ -440,7 +440,7 @@ contains
         verbose = .false.
 
         call kexpm(vec_out, A, vec_in, tau, tol, info, trans=trans, verbosity=verbose, kdim=kdim)
-        if (nid == 0) call check_info(info, 'kexpm', module=this_module, procedure='k_exptA_${type[0]}$${kind}$')
+        call check_info(info, 'kexpm', module=this_module, procedure='k_exptA_${type[0]}$${kind}$')
 
         return
     end subroutine k_exptA_${type[0]}$${kind}$

--- a/src/ExpmLib.fypp
+++ b/src/ExpmLib.fypp
@@ -10,17 +10,16 @@ module lightkrylov_expmlib
     use stdlib_linalg, only: eye
 
     ! LightKrylov.
-    use lightkrylov_constants
+    use LightKrylov_Constants
     use LightKrylov_Logger
-    use lightkrylov_utils
-    use lightkrylov_AbstractVectors
-    use lightkrylov_AbstractLinops
-    use lightkrylov_BaseKrylov
+    use LightKrylov_Utils
+    use LightKrylov_AbstractVectors
+    use LightKrylov_AbstractLinops
+    use LightKrylov_BaseKrylov
 
     implicit none
     
     character(len=128), parameter, private :: this_module = 'LightKrylov_ExpmLib'
-
     #:for kind, type in RC_KINDS_TYPES
     public :: abstract_exptA_${type[0]}$${kind}$
     #:endfor
@@ -211,7 +210,7 @@ contains
 
                 ! Compute k-th step Arnoldi factorization.
                 call arnoldi(A, X, H, info, kstart=k, kend=k, transpose=transpose)
-                call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_vec_${type[0]}$${kind}$')
+                if (nid == 0) call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_vec_${type[0]}$${kind}$')
 
                 ! Compute approximation.
                 if (info == k) then
@@ -345,7 +344,7 @@ contains
 
                 ! Compute the k-th step of the Arnoldi factorization.
                 call arnoldi(A, X, H, info, kstart=k, kend=k, transpose=transpose, blksize=p)
-                call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_mat_${type[0]}$${kind}$')
+                if (nid == 0) call check_info(info, 'arnoldi', module=this_module, procedure='kexpm_mat_${type[0]}$${kind}$')
 
 
                 if (info == kp) then
@@ -441,7 +440,7 @@ contains
         verbose = .false.
 
         call kexpm(vec_out, A, vec_in, tau, tol, info, trans=trans, verbosity=verbose, kdim=kdim)
-        call check_info(info, 'kexpm', module=this_module, procedure='k_exptA_${type[0]}$${kind}$')
+        if (nid == 0) call check_info(info, 'kexpm', module=this_module, procedure='k_exptA_${type[0]}$${kind}$')
 
         return
     end subroutine k_exptA_${type[0]}$${kind}$

--- a/src/IterativeSolvers.f90
+++ b/src/IterativeSolvers.f90
@@ -8,12 +8,12 @@ module lightkrylov_IterativeSolvers
     use stdlib_linalg, only: lstsq, svd
     use stdlib_stats, only: median
 
-    use lightkrylov_constants
+    use LightKrylov_Constants
     Use LightKrylov_Logger
-    use lightkrylov_Utils
-    use lightkrylov_AbstractVectors
-    use lightkrylov_AbstractLinops
-    use lightkrylov_BaseKrylov
+    use LightKrylov_Utils
+    use LightKrylov_AbstractVectors
+    use LightKrylov_AbstractLinops
+    use LightKrylov_BaseKrylov
 
     implicit none
     private
@@ -327,7 +327,7 @@ contains
            arnoldi_factorization: do k = kstart, kdim_
                 ! Arnoldi step.
                 call arnoldi(A, Xwrk, H, info, kstart=k, kend=k, verbosity=verbosity, transpose=transpose)
-                call check_info(info, 'arnoldi', module=this_module, procedure='eigs_rsp')
+                if (nid == 0) call check_info(info, 'arnoldi', module=this_module, procedure='eigs_rsp')
 
                 ! Spectral decomposition of the k x k Hessenberg matrix.
                 eigvals_wrk = 0.0_sp ; eigvecs_wrk = 0.0_sp
@@ -457,7 +457,7 @@ contains
            arnoldi_factorization: do k = kstart, kdim_
                 ! Arnoldi step.
                 call arnoldi(A, Xwrk, H, info, kstart=k, kend=k, verbosity=verbosity, transpose=transpose)
-                call check_info(info, 'arnoldi', module=this_module, procedure='eigs_rdp')
+                if (nid == 0) call check_info(info, 'arnoldi', module=this_module, procedure='eigs_rdp')
 
                 ! Spectral decomposition of the k x k Hessenberg matrix.
                 eigvals_wrk = 0.0_dp ; eigvecs_wrk = 0.0_dp
@@ -586,7 +586,7 @@ contains
            arnoldi_factorization: do k = kstart, kdim_
                 ! Arnoldi step.
                 call arnoldi(A, Xwrk, H, info, kstart=k, kend=k, verbosity=verbosity, transpose=transpose)
-                call check_info(info, 'arnoldi', module=this_module, procedure='eigs_csp')
+                if (nid == 0) call check_info(info, 'arnoldi', module=this_module, procedure='eigs_csp')
 
                 ! Spectral decomposition of the k x k Hessenberg matrix.
                 eigvals_wrk = 0.0_sp ; eigvecs_wrk = 0.0_sp
@@ -706,7 +706,7 @@ contains
            arnoldi_factorization: do k = kstart, kdim_
                 ! Arnoldi step.
                 call arnoldi(A, Xwrk, H, info, kstart=k, kend=k, verbosity=verbosity, transpose=transpose)
-                call check_info(info, 'arnoldi', module=this_module, procedure='eigs_cdp')
+                if (nid == 0) call check_info(info, 'arnoldi', module=this_module, procedure='eigs_cdp')
 
                 ! Spectral decomposition of the k x k Hessenberg matrix.
                 eigvals_wrk = 0.0_dp ; eigvecs_wrk = 0.0_dp
@@ -817,7 +817,7 @@ contains
         lanczos : do k = 1, kdim_
             ! Symmetric Lanczos step.
             call lanczos_tridiagonalization(A, Xwrk, T, info, kstart=k, kend=k, verbosity=verbose)
-            call check_info(info, 'lanczos_tridiagonalization', module=this_module, procedure='eighs_rsp')
+            if (nid == 0) call check_info(info, 'lanczos_tridiagonalization', module=this_module, procedure='eighs_rsp')
 
 
             ! Spectral decomposition of the k x k tridiagonal matrix.
@@ -916,7 +916,7 @@ contains
         lanczos : do k = 1, kdim_
             ! Symmetric Lanczos step.
             call lanczos_tridiagonalization(A, Xwrk, T, info, kstart=k, kend=k, verbosity=verbose)
-            call check_info(info, 'lanczos_tridiagonalization', module=this_module, procedure='eighs_rdp')
+            if (nid == 0) call check_info(info, 'lanczos_tridiagonalization', module=this_module, procedure='eighs_rdp')
 
 
             ! Spectral decomposition of the k x k tridiagonal matrix.
@@ -1015,7 +1015,7 @@ contains
         lanczos : do k = 1, kdim_
             ! Symmetric Lanczos step.
             call lanczos_tridiagonalization(A, Xwrk, T, info, kstart=k, kend=k, verbosity=verbose)
-            call check_info(info, 'lanczos_tridiagonalization', module=this_module, procedure='eighs_csp')
+            if (nid == 0) call check_info(info, 'lanczos_tridiagonalization', module=this_module, procedure='eighs_csp')
 
 
             ! Spectral decomposition of the k x k tridiagonal matrix.
@@ -1114,7 +1114,7 @@ contains
         lanczos : do k = 1, kdim_
             ! Symmetric Lanczos step.
             call lanczos_tridiagonalization(A, Xwrk, T, info, kstart=k, kend=k, verbosity=verbose)
-            call check_info(info, 'lanczos_tridiagonalization', module=this_module, procedure='eighs_cdp')
+            if (nid == 0) call check_info(info, 'lanczos_tridiagonalization', module=this_module, procedure='eighs_cdp')
 
 
             ! Spectral decomposition of the k x k tridiagonal matrix.
@@ -1219,7 +1219,7 @@ contains
         lanczos : do k = 1, kdim_
             ! Lanczos bidiag. step.
             call lanczos_bidiagonalization(A, Uwrk, Vwrk, B, info, kstart=k, kend=k, verbosity=verbosity, tol=tol)
-            call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='svds_rsp')
+            if (nid == 0) call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='svds_rsp')
 
             ! SVD of the k x k bidiagonal matrix and residual computation.
             svdvals_wrk = 0.0_sp ; umat = 0.0_sp ; vmat = 0.0_sp
@@ -1313,7 +1313,7 @@ contains
         lanczos : do k = 1, kdim_
             ! Lanczos bidiag. step.
             call lanczos_bidiagonalization(A, Uwrk, Vwrk, B, info, kstart=k, kend=k, verbosity=verbosity, tol=tol)
-            call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='svds_rdp')
+            if (nid == 0) call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='svds_rdp')
 
             ! SVD of the k x k bidiagonal matrix and residual computation.
             svdvals_wrk = 0.0_dp ; umat = 0.0_dp ; vmat = 0.0_dp
@@ -1407,7 +1407,7 @@ contains
         lanczos : do k = 1, kdim_
             ! Lanczos bidiag. step.
             call lanczos_bidiagonalization(A, Uwrk, Vwrk, B, info, kstart=k, kend=k, verbosity=verbosity, tol=tol)
-            call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='svds_csp')
+            if (nid == 0) call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='svds_csp')
 
             ! SVD of the k x k bidiagonal matrix and residual computation.
             svdvals_wrk = 0.0_sp ; umat = 0.0_sp ; vmat = 0.0_sp
@@ -1501,7 +1501,7 @@ contains
         lanczos : do k = 1, kdim_
             ! Lanczos bidiag. step.
             call lanczos_bidiagonalization(A, Uwrk, Vwrk, B, info, kstart=k, kend=k, verbosity=verbosity, tol=tol)
-            call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='svds_cdp')
+            if (nid == 0) call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='svds_cdp')
 
             ! SVD of the k x k bidiagonal matrix and residual computation.
             svdvals_wrk = 0.0_dp ; umat = 0.0_dp ; vmat = 0.0_dp
@@ -1651,7 +1651,7 @@ contains
 
                 ! Double Gram-Schmid orthogonalization
                 call double_gram_schmidt_step(V(k+1), V(:k), info, if_chk_orthonormal=.false., beta=H(1:k, k))
-                call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='gmres_rsp')
+                if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='gmres_rsp')
 
                 ! Update Hessenberg matrix and normalize residual Krylov vector.
                 H(k+1, k) = V(k+1)%norm()
@@ -1807,7 +1807,7 @@ contains
 
                 ! Double Gram-Schmid orthogonalization
                 call double_gram_schmidt_step(V(k+1), V(:k), info, if_chk_orthonormal=.false., beta=H(1:k, k))
-                call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='gmres_rdp')
+                if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='gmres_rdp')
 
                 ! Update Hessenberg matrix and normalize residual Krylov vector.
                 H(k+1, k) = V(k+1)%norm()
@@ -1963,7 +1963,7 @@ contains
 
                 ! Double Gram-Schmid orthogonalization
                 call double_gram_schmidt_step(V(k+1), V(:k), info, if_chk_orthonormal=.false., beta=H(1:k, k))
-                call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='gmres_csp')
+                if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='gmres_csp')
 
                 ! Update Hessenberg matrix and normalize residual Krylov vector.
                 H(k+1, k) = V(k+1)%norm()
@@ -2119,7 +2119,7 @@ contains
 
                 ! Double Gram-Schmid orthogonalization
                 call double_gram_schmidt_step(V(k+1), V(:k), info, if_chk_orthonormal=.false., beta=H(1:k, k))
-                call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='gmres_cdp')
+                if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='gmres_cdp')
 
                 ! Update Hessenberg matrix and normalize residual Krylov vector.
                 H(k+1, k) = V(k+1)%norm()

--- a/src/IterativeSolvers.f90
+++ b/src/IterativeSolvers.f90
@@ -327,7 +327,7 @@ contains
            arnoldi_factorization: do k = kstart, kdim_
                 ! Arnoldi step.
                 call arnoldi(A, Xwrk, H, info, kstart=k, kend=k, verbosity=verbosity, transpose=transpose)
-                if (nid == 0) call check_info(info, 'arnoldi', module=this_module, procedure='eigs_rsp')
+                call check_info(info, 'arnoldi', module=this_module, procedure='eigs_rsp')
 
                 ! Spectral decomposition of the k x k Hessenberg matrix.
                 eigvals_wrk = 0.0_sp ; eigvecs_wrk = 0.0_sp
@@ -457,7 +457,7 @@ contains
            arnoldi_factorization: do k = kstart, kdim_
                 ! Arnoldi step.
                 call arnoldi(A, Xwrk, H, info, kstart=k, kend=k, verbosity=verbosity, transpose=transpose)
-                if (nid == 0) call check_info(info, 'arnoldi', module=this_module, procedure='eigs_rdp')
+                call check_info(info, 'arnoldi', module=this_module, procedure='eigs_rdp')
 
                 ! Spectral decomposition of the k x k Hessenberg matrix.
                 eigvals_wrk = 0.0_dp ; eigvecs_wrk = 0.0_dp
@@ -586,7 +586,7 @@ contains
            arnoldi_factorization: do k = kstart, kdim_
                 ! Arnoldi step.
                 call arnoldi(A, Xwrk, H, info, kstart=k, kend=k, verbosity=verbosity, transpose=transpose)
-                if (nid == 0) call check_info(info, 'arnoldi', module=this_module, procedure='eigs_csp')
+                call check_info(info, 'arnoldi', module=this_module, procedure='eigs_csp')
 
                 ! Spectral decomposition of the k x k Hessenberg matrix.
                 eigvals_wrk = 0.0_sp ; eigvecs_wrk = 0.0_sp
@@ -706,7 +706,7 @@ contains
            arnoldi_factorization: do k = kstart, kdim_
                 ! Arnoldi step.
                 call arnoldi(A, Xwrk, H, info, kstart=k, kend=k, verbosity=verbosity, transpose=transpose)
-                if (nid == 0) call check_info(info, 'arnoldi', module=this_module, procedure='eigs_cdp')
+                call check_info(info, 'arnoldi', module=this_module, procedure='eigs_cdp')
 
                 ! Spectral decomposition of the k x k Hessenberg matrix.
                 eigvals_wrk = 0.0_dp ; eigvecs_wrk = 0.0_dp
@@ -817,7 +817,7 @@ contains
         lanczos : do k = 1, kdim_
             ! Symmetric Lanczos step.
             call lanczos_tridiagonalization(A, Xwrk, T, info, kstart=k, kend=k, verbosity=verbose)
-            if (nid == 0) call check_info(info, 'lanczos_tridiagonalization', module=this_module, procedure='eighs_rsp')
+            call check_info(info, 'lanczos_tridiagonalization', module=this_module, procedure='eighs_rsp')
 
 
             ! Spectral decomposition of the k x k tridiagonal matrix.
@@ -916,7 +916,7 @@ contains
         lanczos : do k = 1, kdim_
             ! Symmetric Lanczos step.
             call lanczos_tridiagonalization(A, Xwrk, T, info, kstart=k, kend=k, verbosity=verbose)
-            if (nid == 0) call check_info(info, 'lanczos_tridiagonalization', module=this_module, procedure='eighs_rdp')
+            call check_info(info, 'lanczos_tridiagonalization', module=this_module, procedure='eighs_rdp')
 
 
             ! Spectral decomposition of the k x k tridiagonal matrix.
@@ -1015,7 +1015,7 @@ contains
         lanczos : do k = 1, kdim_
             ! Symmetric Lanczos step.
             call lanczos_tridiagonalization(A, Xwrk, T, info, kstart=k, kend=k, verbosity=verbose)
-            if (nid == 0) call check_info(info, 'lanczos_tridiagonalization', module=this_module, procedure='eighs_csp')
+            call check_info(info, 'lanczos_tridiagonalization', module=this_module, procedure='eighs_csp')
 
 
             ! Spectral decomposition of the k x k tridiagonal matrix.
@@ -1114,7 +1114,7 @@ contains
         lanczos : do k = 1, kdim_
             ! Symmetric Lanczos step.
             call lanczos_tridiagonalization(A, Xwrk, T, info, kstart=k, kend=k, verbosity=verbose)
-            if (nid == 0) call check_info(info, 'lanczos_tridiagonalization', module=this_module, procedure='eighs_cdp')
+            call check_info(info, 'lanczos_tridiagonalization', module=this_module, procedure='eighs_cdp')
 
 
             ! Spectral decomposition of the k x k tridiagonal matrix.
@@ -1219,7 +1219,7 @@ contains
         lanczos : do k = 1, kdim_
             ! Lanczos bidiag. step.
             call lanczos_bidiagonalization(A, Uwrk, Vwrk, B, info, kstart=k, kend=k, verbosity=verbosity, tol=tol)
-            if (nid == 0) call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='svds_rsp')
+            call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='svds_rsp')
 
             ! SVD of the k x k bidiagonal matrix and residual computation.
             svdvals_wrk = 0.0_sp ; umat = 0.0_sp ; vmat = 0.0_sp
@@ -1313,7 +1313,7 @@ contains
         lanczos : do k = 1, kdim_
             ! Lanczos bidiag. step.
             call lanczos_bidiagonalization(A, Uwrk, Vwrk, B, info, kstart=k, kend=k, verbosity=verbosity, tol=tol)
-            if (nid == 0) call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='svds_rdp')
+            call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='svds_rdp')
 
             ! SVD of the k x k bidiagonal matrix and residual computation.
             svdvals_wrk = 0.0_dp ; umat = 0.0_dp ; vmat = 0.0_dp
@@ -1407,7 +1407,7 @@ contains
         lanczos : do k = 1, kdim_
             ! Lanczos bidiag. step.
             call lanczos_bidiagonalization(A, Uwrk, Vwrk, B, info, kstart=k, kend=k, verbosity=verbosity, tol=tol)
-            if (nid == 0) call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='svds_csp')
+            call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='svds_csp')
 
             ! SVD of the k x k bidiagonal matrix and residual computation.
             svdvals_wrk = 0.0_sp ; umat = 0.0_sp ; vmat = 0.0_sp
@@ -1501,7 +1501,7 @@ contains
         lanczos : do k = 1, kdim_
             ! Lanczos bidiag. step.
             call lanczos_bidiagonalization(A, Uwrk, Vwrk, B, info, kstart=k, kend=k, verbosity=verbosity, tol=tol)
-            if (nid == 0) call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='svds_cdp')
+            call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='svds_cdp')
 
             ! SVD of the k x k bidiagonal matrix and residual computation.
             svdvals_wrk = 0.0_dp ; umat = 0.0_dp ; vmat = 0.0_dp
@@ -1651,7 +1651,7 @@ contains
 
                 ! Double Gram-Schmid orthogonalization
                 call double_gram_schmidt_step(V(k+1), V(:k), info, if_chk_orthonormal=.false., beta=H(1:k, k))
-                if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='gmres_rsp')
+                call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='gmres_rsp')
 
                 ! Update Hessenberg matrix and normalize residual Krylov vector.
                 H(k+1, k) = V(k+1)%norm()
@@ -1807,7 +1807,7 @@ contains
 
                 ! Double Gram-Schmid orthogonalization
                 call double_gram_schmidt_step(V(k+1), V(:k), info, if_chk_orthonormal=.false., beta=H(1:k, k))
-                if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='gmres_rdp')
+                call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='gmres_rdp')
 
                 ! Update Hessenberg matrix and normalize residual Krylov vector.
                 H(k+1, k) = V(k+1)%norm()
@@ -1963,7 +1963,7 @@ contains
 
                 ! Double Gram-Schmid orthogonalization
                 call double_gram_schmidt_step(V(k+1), V(:k), info, if_chk_orthonormal=.false., beta=H(1:k, k))
-                if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='gmres_csp')
+                call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='gmres_csp')
 
                 ! Update Hessenberg matrix and normalize residual Krylov vector.
                 H(k+1, k) = V(k+1)%norm()
@@ -2119,7 +2119,7 @@ contains
 
                 ! Double Gram-Schmid orthogonalization
                 call double_gram_schmidt_step(V(k+1), V(:k), info, if_chk_orthonormal=.false., beta=H(1:k, k))
-                if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='gmres_cdp')
+                call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='gmres_cdp')
 
                 ! Update Hessenberg matrix and normalize residual Krylov vector.
                 H(k+1, k) = V(k+1)%norm()

--- a/src/IterativeSolvers.fypp
+++ b/src/IterativeSolvers.fypp
@@ -224,7 +224,7 @@ contains
            arnoldi_factorization: do k = kstart, kdim_
                 ! Arnoldi step.
                 call arnoldi(A, Xwrk, H, info, kstart=k, kend=k, verbosity=verbosity, transpose=transpose)
-                if (nid == 0) call check_info(info, 'arnoldi', module=this_module, procedure='eigs_${type[0]}$${kind}$')
+                call check_info(info, 'arnoldi', module=this_module, procedure='eigs_${type[0]}$${kind}$')
 
                 ! Spectral decomposition of the k x k Hessenberg matrix.
                 eigvals_wrk = 0.0_${kind}$ ; eigvecs_wrk = 0.0_${kind}$
@@ -354,7 +354,7 @@ contains
         lanczos : do k = 1, kdim_
             ! Symmetric Lanczos step.
             call lanczos_tridiagonalization(A, Xwrk, T, info, kstart=k, kend=k, verbosity=verbose)
-            if (nid == 0) call check_info(info, 'lanczos_tridiagonalization', module=this_module, procedure='eighs_${type[0]}$${kind}$')
+            call check_info(info, 'lanczos_tridiagonalization', module=this_module, procedure='eighs_${type[0]}$${kind}$')
 
 
             ! Spectral decomposition of the k x k tridiagonal matrix.
@@ -461,7 +461,7 @@ contains
         lanczos : do k = 1, kdim_
             ! Lanczos bidiag. step.
             call lanczos_bidiagonalization(A, Uwrk, Vwrk, B, info, kstart=k, kend=k, verbosity=verbosity, tol=tol)
-            if (nid == 0) call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='svds_${type[0]}$${kind}$')
+            call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='svds_${type[0]}$${kind}$')
 
             ! SVD of the k x k bidiagonal matrix and residual computation.
             svdvals_wrk = 0.0_${kind}$ ; umat = 0.0_${kind}$ ; vmat = 0.0_${kind}$
@@ -617,7 +617,7 @@ contains
 
                 ! Double Gram-Schmid orthogonalization
                 call double_gram_schmidt_step(V(k+1), V(:k), info, if_chk_orthonormal=.false., beta=H(1:k, k))
-                if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='gmres_${type[0]}$${kind}$')
+                call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='gmres_${type[0]}$${kind}$')
 
                 ! Update Hessenberg matrix and normalize residual Krylov vector.
                 H(k+1, k) = V(k+1)%norm()

--- a/src/IterativeSolvers.fypp
+++ b/src/IterativeSolvers.fypp
@@ -10,12 +10,12 @@ module lightkrylov_IterativeSolvers
     use stdlib_linalg, only: lstsq, svd
     use stdlib_stats, only: median
 
-    use lightkrylov_constants
+    use LightKrylov_Constants
     Use LightKrylov_Logger
-    use lightkrylov_Utils
-    use lightkrylov_AbstractVectors
-    use lightkrylov_AbstractLinops
-    use lightkrylov_BaseKrylov
+    use LightKrylov_Utils
+    use LightKrylov_AbstractVectors
+    use LightKrylov_AbstractLinops
+    use LightKrylov_BaseKrylov
 
     implicit none
     private
@@ -224,7 +224,7 @@ contains
            arnoldi_factorization: do k = kstart, kdim_
                 ! Arnoldi step.
                 call arnoldi(A, Xwrk, H, info, kstart=k, kend=k, verbosity=verbosity, transpose=transpose)
-                call check_info(info, 'arnoldi', module=this_module, procedure='eigs_${type[0]}$${kind}$')
+                if (nid == 0) call check_info(info, 'arnoldi', module=this_module, procedure='eigs_${type[0]}$${kind}$')
 
                 ! Spectral decomposition of the k x k Hessenberg matrix.
                 eigvals_wrk = 0.0_${kind}$ ; eigvecs_wrk = 0.0_${kind}$
@@ -354,7 +354,7 @@ contains
         lanczos : do k = 1, kdim_
             ! Symmetric Lanczos step.
             call lanczos_tridiagonalization(A, Xwrk, T, info, kstart=k, kend=k, verbosity=verbose)
-            call check_info(info, 'lanczos_tridiagonalization', module=this_module, procedure='eighs_${type[0]}$${kind}$')
+            if (nid == 0) call check_info(info, 'lanczos_tridiagonalization', module=this_module, procedure='eighs_${type[0]}$${kind}$')
 
 
             ! Spectral decomposition of the k x k tridiagonal matrix.
@@ -461,7 +461,7 @@ contains
         lanczos : do k = 1, kdim_
             ! Lanczos bidiag. step.
             call lanczos_bidiagonalization(A, Uwrk, Vwrk, B, info, kstart=k, kend=k, verbosity=verbosity, tol=tol)
-            call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='svds_${type[0]}$${kind}$')
+            if (nid == 0) call check_info(info, 'lanczos_bidiagonalization', module=this_module, procedure='svds_${type[0]}$${kind}$')
 
             ! SVD of the k x k bidiagonal matrix and residual computation.
             svdvals_wrk = 0.0_${kind}$ ; umat = 0.0_${kind}$ ; vmat = 0.0_${kind}$
@@ -617,7 +617,7 @@ contains
 
                 ! Double Gram-Schmid orthogonalization
                 call double_gram_schmidt_step(V(k+1), V(:k), info, if_chk_orthonormal=.false., beta=H(1:k, k))
-                call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='gmres_${type[0]}$${kind}$')
+                if (nid == 0) call check_info(info, 'double_gram_schmidt_step', module=this_module, procedure='gmres_${type[0]}$${kind}$')
 
                 ! Update Hessenberg matrix and normalize residual Krylov vector.
                 H(k+1, k) = V(k+1)%norm()

--- a/src/LightKrylov.f90
+++ b/src/LightKrylov.f90
@@ -23,6 +23,9 @@ module LightKrylov
     ! Constants exports.
     public :: sp, atol_sp, rtol_sp
     public :: dp, atol_dp, rtol_dp
+    ! MPI and I/Ω
+    public :: mpi_setup, mpi_close
+    public :: get_rank, set_io_rank, io_rank
 
     ! Utils exports.
     public :: gmres_sp_opts

--- a/src/LightKrylov.f90
+++ b/src/LightKrylov.f90
@@ -110,10 +110,10 @@ contains
       write (*, *) "              |___/                     |___/              "
 
       write (*, *)
-      write (*, *) "Developped by: Jean-Christophe Loiseau"
-      write (*, *) "               J. Simon Kern"
-      write (*, *) "               Arts & Métiers Institute of Technology, 2023."
-      write (*, *) "               jean-christophe.loiseau@ensam.eu"
+      write (*, *) "Developed by: Jean-Christophe Loiseau"
+      write (*, *) "              J. Simon Kern"
+      write (*, *) "              Arts & Métiers Institute of Technology, 2023."
+      write (*, *) "              jean-christophe.loiseau@ensam.eu"
       write (*, *)
 
       write (*, *) "Version -- beta 0.1.0"

--- a/src/LightKrylov.f90
+++ b/src/LightKrylov.f90
@@ -23,8 +23,8 @@ module LightKrylov
     ! Constants exports.
     public :: sp, atol_sp, rtol_sp
     public :: dp, atol_dp, rtol_dp
-    ! MPI and I/Ω
-    public :: mpi_setup, mpi_close
+    ! MPI and I/O
+    public :: comm_setup, comm_close
     public :: get_rank, set_io_rank, io_rank
 
     ! Utils exports.

--- a/src/LightKrylov.f90
+++ b/src/LightKrylov.f90
@@ -23,9 +23,6 @@ module LightKrylov
     ! Constants exports.
     public :: sp, atol_sp, rtol_sp
     public :: dp, atol_dp, rtol_dp
-    ! MPI and I/O
-    public :: comm_setup, comm_close
-    public :: get_rank, set_io_rank, io_rank
 
     ! Utils exports.
     public :: gmres_sp_opts

--- a/src/LightKrylov.fypp
+++ b/src/LightKrylov.fypp
@@ -25,8 +25,8 @@ module LightKrylov
     ! Constants exports.
     public :: sp, atol_sp, rtol_sp
     public :: dp, atol_dp, rtol_dp
-    ! MPI and I/Ω
-    public :: mpi_setup, mpi_close
+    ! MPI and I/O
+    public :: comm_setup, comm_close
     public :: get_rank, set_io_rank, io_rank
 
     ! Utils exports.

--- a/src/LightKrylov.fypp
+++ b/src/LightKrylov.fypp
@@ -25,9 +25,6 @@ module LightKrylov
     ! Constants exports.
     public :: sp, atol_sp, rtol_sp
     public :: dp, atol_dp, rtol_dp
-    ! MPI and I/O
-    public :: comm_setup, comm_close
-    public :: get_rank, set_io_rank, io_rank
 
     ! Utils exports.
     #:for kind in REAL_KINDS

--- a/src/LightKrylov.fypp
+++ b/src/LightKrylov.fypp
@@ -25,6 +25,9 @@ module LightKrylov
     ! Constants exports.
     public :: sp, atol_sp, rtol_sp
     public :: dp, atol_dp, rtol_dp
+    ! MPI and I/Ω
+    public :: mpi_setup, mpi_close
+    public :: get_rank, set_io_rank, io_rank
 
     ! Utils exports.
     #:for kind in REAL_KINDS

--- a/src/LightKrylov.fypp
+++ b/src/LightKrylov.fypp
@@ -97,10 +97,10 @@ contains
       write (*, *) "              |___/                     |___/              "
 
       write (*, *)
-      write (*, *) "Developped by: Jean-Christophe Loiseau"
-      write (*, *) "               J. Simon Kern"
-      write (*, *) "               Arts & Métiers Institute of Technology, 2023."
-      write (*, *) "               jean-christophe.loiseau@ensam.eu"
+      write (*, *) "Developed by: Jean-Christophe Loiseau"
+      write (*, *) "              J. Simon Kern"
+      write (*, *) "              Arts & Métiers Institute of Technology, 2023."
+      write (*, *) "              jean-christophe.loiseau@ensam.eu"
       write (*, *)
 
       write (*, *) "Version -- beta 0.1.0"

--- a/src/Logger.f90
+++ b/src/Logger.f90
@@ -91,7 +91,7 @@ contains
 
    subroutine comm_setup()
       ! internal
-      integer :: ierr
+      integer :: ierr, nid, comm_size
       logical :: mpi_is_initialized
       character(len=128) :: msg
 #ifdef MPI
@@ -104,12 +104,14 @@ contains
       else
          call logger%log_debug('MPI already initialized.', module='LightKrylov', procedure='comm_setup')
       end if
-      call MPI_Comm_rank(MPI_COMM_WORLD, nid, ierr)
-      call MPI_Comm_size(MPI_COMM_WORLD, comm_size, ierr)
+      call MPI_Comm_rank(MPI_COMM_WORLD, nid, ierr); call set_rank(nid)
+      call MPI_Comm_size(MPI_COMM_WORLD, comm_size, ierr); call set_comm_size(comm_size)
       write(msg, '(A,I4,A,I4)') 'rank', nid, ', comm_size = ', comm_size
       call logger%log_debug(trim(msg), module='LightKrylov', procedure='comm_setup')
 #else
       write(msg, *) 'Setup serial run'
+      call set_rank(0)
+      call set_comm_size(1)
       call logger%log_debug(trim(msg), module='LightKrylov', procedure='comm_setup')
 #endif
       return

--- a/src/Logger.f90
+++ b/src/Logger.f90
@@ -6,6 +6,9 @@ module LightKrylov_Logger
    use stdlib_strings, only : chomp, replace_all
    ! Testdrive
    use testdrive, only: error_type, test_failed
+   ! LightKrylov
+   use LightKrylov_Constants
+
    implicit none
    private
 
@@ -26,7 +29,7 @@ contains
       !! The name of the module in which the call happens
       character(len=*), optional,  intent(in)  :: procedure
       !! The name of the procedure in which the call happens
-      call check_info(-1, origin='', module=module, procedure=procedure, info_msg=msg)
+      if (nid == 0) call check_info(-1, origin='', module=module, procedure=procedure, info_msg=msg)
       return
    end subroutine stop_error
 

--- a/src/Logger.f90
+++ b/src/Logger.f90
@@ -6,8 +6,6 @@ module LightKrylov_Logger
    use stdlib_strings, only : chomp, replace_all
    ! Testdrive
    use testdrive, only: error_type, test_failed
-   ! LightKrylov
-   use LightKrylov_Constants
 
    implicit none
    private
@@ -29,7 +27,7 @@ contains
       !! The name of the module in which the call happens
       character(len=*), optional,  intent(in)  :: procedure
       !! The name of the procedure in which the call happens
-      if (nid == 0) call check_info(-1, origin='', module=module, procedure=procedure, info_msg=msg)
+      call check_info(-1, origin="STOP_ERROR", module=module, procedure=procedure, info_msg=msg)
       return
    end subroutine stop_error
 
@@ -339,6 +337,12 @@ contains
                call logger%log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
+         !
+         !  stop error
+         !
+         else if (trim(origin) == 'STOP_ERROR') then
+            call logger%log_error(trim(origin), module=module, procedure=procedure, stat=info, errmsg=trim(str))
+            ierr = -1
          !
          !   Default
          !

--- a/src/Logger.f90
+++ b/src/Logger.f90
@@ -1,24 +1,132 @@
 module LightKrylov_Logger
+#ifdef MPI
+   use mpi_f08
+#endif
+   ! Fortran Standard Library
    use stdlib_optval, only : optval
-   use stdlib_logger
    use stdlib_logger, only: logger => global_logger
    use stdlib_ascii, only : to_lower
    use stdlib_strings, only : chomp, replace_all
    ! Testdrive
    use testdrive, only: error_type, test_failed
+   ! LightKrylov
+   use LightKrylov_Constants
 
    implicit none
    private
 
-   logical, parameter :: exit_on_error = .true.
-   logical, parameter :: exit_on_test_error = .true.
+   character(len=128), parameter, private :: this_module = 'LightKrylov_Logger'
+
+   logical, parameter, private :: exit_on_error = .true.
+   logical, parameter, private :: exit_on_test_error = .true.
 
    public :: stop_error
    public :: check_info
    public :: check_test
    public :: logger
 
+   public :: logger_setup
+
+   ! MPI subroutines
+   public :: comm_setup
+   public :: comm_close
+
 contains
+
+   subroutine logger_setup(logfile, nio, log_level, log_stdout, log_timestamp)
+      !! Wrapper to set up MPI if needed and initialize log files
+      character(len=*), optional, intent(in) :: logfile
+      !! name of the dedicated LightKrylov logfile
+      integer, optional, intent(in)          :: nio
+      !! I/O rank for logging
+      integer, optional, intent(in)          :: log_level
+      !! set logging level
+      !! 0   : all_level
+      !! 10  : debug_level
+      !! 20  : information_level
+      !! 30  : warning_level	
+      !! 40  : error_level	
+      !! 100 : none_level
+      logical, optional, intent(in)          :: log_stdout
+      !! duplicate log messages to stdout?
+      logical, optional, intent(in)          :: log_timestamp
+      !! add timestamp to log messages
+
+      ! internals
+      character(len=:), allocatable :: logfile_
+      integer                       :: nio_
+      integer                       :: log_level_
+      logical                       :: log_stdout_
+      logical                       :: log_timestamp_
+      ! misc
+      integer :: stat, iunit
+
+      logfile_       = optval(logfile, 'lightkrylov.log')
+      nio_           = optval(nio, 0)
+      log_level_     = optval(log_level, 20)
+      log_level_     = max(0, min(log_level_, 100))
+      log_stdout_    = optval(log_stdout, .true.)
+      log_timestamp_ = optval(log_timestamp, .true.)
+
+      ! set log level
+      call logger%configure(level=log_level_, time_stamp=log_timestamp_) 
+
+      ! set up LightKrylov log file
+      call logger%add_log_file(logfile_, unit=iunit, stat=stat)
+      if (stat /= 0) call stop_error('Unable to open logfile '//trim(logfile_)//'.', module=this_module, procedure='logger_setup')
+
+      ! Set up comms
+      call comm_setup()
+
+      ! Set I/O rank
+      if (nio_/=0) call set_io_rank(nio_)
+
+      ! log to stdout
+      if (log_stdout_) then
+         call logger%add_log_unit(6, stat=stat)
+         if (stat /= 0) call stop_error('Unable to add stdout to logger.', module=this_module, procedure='logger_setup')
+      end if
+      return
+   end subroutine logger_setup
+
+   subroutine comm_setup()
+      ! internal
+      integer :: ierr
+      logical :: mpi_is_initialized
+      character(len=128) :: msg
+#ifdef MPI
+      ! check if MPI has already been initialized and if not, initialize
+      call MPI_Initialized(mpi_is_initialized, ierr)
+      if (.not. mpi_is_initialized) then
+         call logger%log_debug('Set up parallel run with MPI.', module='LightKrylov', procedure='comm_setup')
+         call MPI_Init(ierr)
+         if (ierr /= MPI_SUCCESS) call stop_error("Error initializing MPI", module='LightKrylov',procedure='mpi_init')
+      else
+         call logger%log_debug('MPI already initialized.', module='LightKrylov', procedure='comm_setup')
+      end if
+      call MPI_Comm_rank(MPI_COMM_WORLD, nid, ierr)
+      call MPI_Comm_size(MPI_COMM_WORLD, comm_size, ierr)
+      write(msg, '(A,I4,A,I4)') 'rank', nid, ', comm_size = ', comm_size
+      call logger%log_debug(trim(msg), module='LightKrylov', procedure='comm_setup')
+#else
+      write(msg, *) 'Setup serial run'
+      call logger%log_debug(trim(msg), module='LightKrylov', procedure='comm_setup')
+#endif
+      return
+   end subroutine comm_setup
+
+   subroutine comm_close()
+      integer :: ierr
+#ifdef MPI
+      character(len=128) :: msg
+      ! Finalize MPI
+      call MPI_Finalize(ierr)
+      if (ierr /= MPI_SUCCESS) call stop_error("Error finalizing MPI", module='LightKrylov',procedure='comm_close')
+#else
+      ierr = 0
+#endif
+      return
+   end subroutine comm_close
 
    subroutine stop_error(msg, module, procedure)
       character(len=*),            intent(in)  :: msg

--- a/src/Utils.f90
+++ b/src/Utils.f90
@@ -3,7 +3,6 @@ module lightkrylov_utils
     !-----     Standard Fortran Library     -----
     !--------------------------------------------
     use iso_fortran_env, only: output_unit
-    use LightKrylov_Logger
     use stdlib_linalg, only: is_hermitian, is_symmetric, diag
     ! Matrix inversion.
     use stdlib_linalg_lapack, only: getrf, getri
@@ -16,6 +15,7 @@ module lightkrylov_utils
     !-----     LightKrylov     -----
     !-------------------------------
     ! Various constants.
+    use LightKrylov_Logger
     use LightKrylov_Constants
 
     implicit none
@@ -354,11 +354,11 @@ contains
         ! Compute A = LU (in-place).
         n = size(A, 1) ; call assert_shape(A, [n, n], "inv", "A")
         call getrf(n, n, A, n, ipiv, info)
-        call check_info(info, 'GETREF', module=this_module, procedure='inv_rsp')
+        if (nid == 0) call check_info(info, 'GETREF', module=this_module, procedure='inv_rsp')
 
         ! Compute inv(A) (in-place).
         call getri(n, A, n, ipiv, work, n, info)
-        call check_info(info, 'GETRI', module=this_module, procedure='inv_rsp')
+        if (nid == 0) call check_info(info, 'GETRI', module=this_module, procedure='inv_rsp')
 
         return
     end subroutine inv_rsp
@@ -383,7 +383,7 @@ contains
 
         ! Eigendecomposition.
         call geev(jobvl, jobvr, n, a_tilde, lda, wr, wi, vl, ldvl, vecs, ldvr, work, lwork, info)
-        call check_info(info, 'GEEV', module=this_module, procedure='eig_rsp')
+        if (nid == 0) call check_info(info, 'GEEV', module=this_module, procedure='eig_rsp')
 
         ! Reconstruct eigenvalues
         vals = one_csp*wr + one_im_csp*wi
@@ -413,7 +413,7 @@ contains
 
         ! Eigendecomposition.
         call syev(jobz, uplo, n, a_tilde, lda, vals, work, lwork, info)
-        call check_info(info, 'SYEV', module=this_module, procedure='eigh_rsp')
+        if (nid == 0) call check_info(info, 'SYEV', module=this_module, procedure='eigh_rsp')
 
         ! Extract eigenvectors
         vecs = a_tilde
@@ -443,7 +443,7 @@ contains
 
         allocate(wr(size(eigvals)), wi(size(eigvals)))
         call gees(jobvs, sort, dummy_select, n, A, lda, sdim, wr, wi, Z, ldvs, work, lwork, bwork, info)
-        call check_info(info, 'GEES', module=this_module, procedure='schur_rsp')
+        if (nid == 0) call check_info(info, 'GEES', module=this_module, procedure='schur_rsp')
 
         ! Reconstruct eigenvalues
         eigvals = cmplx(wr, wi, kind=sp)
@@ -481,7 +481,7 @@ contains
 
         liwork = 1
         call trsen(job, compq, selected, n, T, ldt, Q, ldq, wr, wi, m, s, sep, work, lwork, iwork, liwork, info)
-        call check_info(info, 'TRSEN', module=this_module, procedure='ordschur_rsp')
+        if (nid == 0) call check_info(info, 'TRSEN', module=this_module, procedure='ordschur_rsp')
 
         return
     end subroutine ordschur_rsp
@@ -546,11 +546,11 @@ contains
         ! Compute A = LU (in-place).
         n = size(A, 1) ; call assert_shape(A, [n, n], "inv", "A")
         call getrf(n, n, A, n, ipiv, info)
-        call check_info(info, 'GETREF', module=this_module, procedure='inv_rdp')
+        if (nid == 0) call check_info(info, 'GETREF', module=this_module, procedure='inv_rdp')
 
         ! Compute inv(A) (in-place).
         call getri(n, A, n, ipiv, work, n, info)
-        call check_info(info, 'GETRI', module=this_module, procedure='inv_rdp')
+        if (nid == 0) call check_info(info, 'GETRI', module=this_module, procedure='inv_rdp')
 
         return
     end subroutine inv_rdp
@@ -575,7 +575,7 @@ contains
 
         ! Eigendecomposition.
         call geev(jobvl, jobvr, n, a_tilde, lda, wr, wi, vl, ldvl, vecs, ldvr, work, lwork, info)
-        call check_info(info, 'GEEV', module=this_module, procedure='eig_rdp')
+        if (nid == 0) call check_info(info, 'GEEV', module=this_module, procedure='eig_rdp')
 
         ! Reconstruct eigenvalues
         vals = one_cdp*wr + one_im_cdp*wi
@@ -605,7 +605,7 @@ contains
 
         ! Eigendecomposition.
         call syev(jobz, uplo, n, a_tilde, lda, vals, work, lwork, info)
-        call check_info(info, 'SYEV', module=this_module, procedure='eigh_rdp')
+        if (nid == 0) call check_info(info, 'SYEV', module=this_module, procedure='eigh_rdp')
 
         ! Extract eigenvectors
         vecs = a_tilde
@@ -635,7 +635,7 @@ contains
 
         allocate(wr(size(eigvals)), wi(size(eigvals)))
         call gees(jobvs, sort, dummy_select, n, A, lda, sdim, wr, wi, Z, ldvs, work, lwork, bwork, info)
-        call check_info(info, 'GEES', module=this_module, procedure='schur_rdp')
+        if (nid == 0) call check_info(info, 'GEES', module=this_module, procedure='schur_rdp')
 
         ! Reconstruct eigenvalues
         eigvals = cmplx(wr, wi, kind=dp)
@@ -673,7 +673,7 @@ contains
 
         liwork = 1
         call trsen(job, compq, selected, n, T, ldt, Q, ldq, wr, wi, m, s, sep, work, lwork, iwork, liwork, info)
-        call check_info(info, 'TRSEN', module=this_module, procedure='ordschur_rdp')
+        if (nid == 0) call check_info(info, 'TRSEN', module=this_module, procedure='ordschur_rdp')
 
         return
     end subroutine ordschur_rdp
@@ -738,11 +738,11 @@ contains
         ! Compute A = LU (in-place).
         n = size(A, 1) ; call assert_shape(A, [n, n], "inv", "A")
         call getrf(n, n, A, n, ipiv, info)
-        call check_info(info, 'GETREF', module=this_module, procedure='inv_csp')
+        if (nid == 0) call check_info(info, 'GETREF', module=this_module, procedure='inv_csp')
 
         ! Compute inv(A) (in-place).
         call getri(n, A, n, ipiv, work, n, info)
-        call check_info(info, 'GETRI', module=this_module, procedure='inv_csp')
+        if (nid == 0) call check_info(info, 'GETRI', module=this_module, procedure='inv_csp')
 
         return
     end subroutine inv_csp
@@ -768,7 +768,7 @@ contains
 
         ! Eigendecomposition.
         call geev(jobvl, jobvr, n, a_tilde, lda, vals, vl, ldvl, vecs, ldvr, work, lwork, rwork, info)
-        call check_info(info, 'GEEV', module=this_module, procedure='eig_csp')
+        if (nid == 0) call check_info(info, 'GEEV', module=this_module, procedure='eig_csp')
 
 
         return
@@ -798,7 +798,7 @@ contains
 
         ! Eigendecomposition.
         call heev(jobz, uplo, n, a_tilde, lda, vals, work, lwork, rwork, info)
-        call check_info(info, 'HEEV', module=this_module, procedure='eigh_csp')
+        if (nid == 0) call check_info(info, 'HEEV', module=this_module, procedure='eigh_csp')
 
         ! Extract eigenvectors
         vecs = a_tilde
@@ -827,7 +827,7 @@ contains
         allocate(bwork(n)) ; allocate(work(lwork)) ;  allocate(rwork(n)) 
 
         call gees(jobvs, sort, dummy_select, n, A, lda, sdim, eigvals, Z, ldvs, work, lwork, rwork, bwork, info)
-        call check_info(info, 'GEES', module=this_module, procedure='schur_csp')
+        if (nid == 0) call check_info(info, 'GEES', module=this_module, procedure='schur_csp')
 
 
         return
@@ -860,7 +860,7 @@ contains
         n = size(T, 2) ; ldt = n ; ldq = n ; lwork = max(1, n)
 
         call trsen(job, compq, selected, n, T, ldt, Q, ldq, w, m, s, sep, work, lwork, info)
-        call check_info(info, 'TRSEN', module=this_module, procedure='ordschur_csp')
+        if (nid == 0) call check_info(info, 'TRSEN', module=this_module, procedure='ordschur_csp')
 
         return
     end subroutine ordschur_csp
@@ -925,11 +925,11 @@ contains
         ! Compute A = LU (in-place).
         n = size(A, 1) ; call assert_shape(A, [n, n], "inv", "A")
         call getrf(n, n, A, n, ipiv, info)
-        call check_info(info, 'GETREF', module=this_module, procedure='inv_cdp')
+        if (nid == 0) call check_info(info, 'GETREF', module=this_module, procedure='inv_cdp')
 
         ! Compute inv(A) (in-place).
         call getri(n, A, n, ipiv, work, n, info)
-        call check_info(info, 'GETRI', module=this_module, procedure='inv_cdp')
+        if (nid == 0) call check_info(info, 'GETRI', module=this_module, procedure='inv_cdp')
 
         return
     end subroutine inv_cdp
@@ -955,7 +955,7 @@ contains
 
         ! Eigendecomposition.
         call geev(jobvl, jobvr, n, a_tilde, lda, vals, vl, ldvl, vecs, ldvr, work, lwork, rwork, info)
-        call check_info(info, 'GEEV', module=this_module, procedure='eig_cdp')
+        if (nid == 0) call check_info(info, 'GEEV', module=this_module, procedure='eig_cdp')
 
 
         return
@@ -985,7 +985,7 @@ contains
 
         ! Eigendecomposition.
         call heev(jobz, uplo, n, a_tilde, lda, vals, work, lwork, rwork, info)
-        call check_info(info, 'HEEV', module=this_module, procedure='eigh_cdp')
+        if (nid == 0) call check_info(info, 'HEEV', module=this_module, procedure='eigh_cdp')
 
         ! Extract eigenvectors
         vecs = a_tilde
@@ -1014,7 +1014,7 @@ contains
         allocate(bwork(n)) ; allocate(work(lwork)) ;  allocate(rwork(n)) 
 
         call gees(jobvs, sort, dummy_select, n, A, lda, sdim, eigvals, Z, ldvs, work, lwork, rwork, bwork, info)
-        call check_info(info, 'GEES', module=this_module, procedure='schur_cdp')
+        if (nid == 0) call check_info(info, 'GEES', module=this_module, procedure='schur_cdp')
 
 
         return
@@ -1047,7 +1047,7 @@ contains
         n = size(T, 2) ; ldt = n ; ldq = n ; lwork = max(1, n)
 
         call trsen(job, compq, selected, n, T, ldt, Q, ldq, w, m, s, sep, work, lwork, info)
-        call check_info(info, 'TRSEN', module=this_module, procedure='ordschur_cdp')
+        if (nid == 0) call check_info(info, 'TRSEN', module=this_module, procedure='ordschur_cdp')
 
         return
     end subroutine ordschur_cdp

--- a/src/Utils.f90
+++ b/src/Utils.f90
@@ -354,11 +354,11 @@ contains
         ! Compute A = LU (in-place).
         n = size(A, 1) ; call assert_shape(A, [n, n], "inv", "A")
         call getrf(n, n, A, n, ipiv, info)
-        if (nid == 0) call check_info(info, 'GETREF', module=this_module, procedure='inv_rsp')
+        call check_info(info, 'GETREF', module=this_module, procedure='inv_rsp')
 
         ! Compute inv(A) (in-place).
         call getri(n, A, n, ipiv, work, n, info)
-        if (nid == 0) call check_info(info, 'GETRI', module=this_module, procedure='inv_rsp')
+        call check_info(info, 'GETRI', module=this_module, procedure='inv_rsp')
 
         return
     end subroutine inv_rsp
@@ -383,7 +383,7 @@ contains
 
         ! Eigendecomposition.
         call geev(jobvl, jobvr, n, a_tilde, lda, wr, wi, vl, ldvl, vecs, ldvr, work, lwork, info)
-        if (nid == 0) call check_info(info, 'GEEV', module=this_module, procedure='eig_rsp')
+        call check_info(info, 'GEEV', module=this_module, procedure='eig_rsp')
 
         ! Reconstruct eigenvalues
         vals = one_csp*wr + one_im_csp*wi
@@ -413,7 +413,7 @@ contains
 
         ! Eigendecomposition.
         call syev(jobz, uplo, n, a_tilde, lda, vals, work, lwork, info)
-        if (nid == 0) call check_info(info, 'SYEV', module=this_module, procedure='eigh_rsp')
+        call check_info(info, 'SYEV', module=this_module, procedure='eigh_rsp')
 
         ! Extract eigenvectors
         vecs = a_tilde
@@ -443,7 +443,7 @@ contains
 
         allocate(wr(size(eigvals)), wi(size(eigvals)))
         call gees(jobvs, sort, dummy_select, n, A, lda, sdim, wr, wi, Z, ldvs, work, lwork, bwork, info)
-        if (nid == 0) call check_info(info, 'GEES', module=this_module, procedure='schur_rsp')
+        call check_info(info, 'GEES', module=this_module, procedure='schur_rsp')
 
         ! Reconstruct eigenvalues
         eigvals = cmplx(wr, wi, kind=sp)
@@ -481,7 +481,7 @@ contains
 
         liwork = 1
         call trsen(job, compq, selected, n, T, ldt, Q, ldq, wr, wi, m, s, sep, work, lwork, iwork, liwork, info)
-        if (nid == 0) call check_info(info, 'TRSEN', module=this_module, procedure='ordschur_rsp')
+        call check_info(info, 'TRSEN', module=this_module, procedure='ordschur_rsp')
 
         return
     end subroutine ordschur_rsp
@@ -546,11 +546,11 @@ contains
         ! Compute A = LU (in-place).
         n = size(A, 1) ; call assert_shape(A, [n, n], "inv", "A")
         call getrf(n, n, A, n, ipiv, info)
-        if (nid == 0) call check_info(info, 'GETREF', module=this_module, procedure='inv_rdp')
+        call check_info(info, 'GETREF', module=this_module, procedure='inv_rdp')
 
         ! Compute inv(A) (in-place).
         call getri(n, A, n, ipiv, work, n, info)
-        if (nid == 0) call check_info(info, 'GETRI', module=this_module, procedure='inv_rdp')
+        call check_info(info, 'GETRI', module=this_module, procedure='inv_rdp')
 
         return
     end subroutine inv_rdp
@@ -575,7 +575,7 @@ contains
 
         ! Eigendecomposition.
         call geev(jobvl, jobvr, n, a_tilde, lda, wr, wi, vl, ldvl, vecs, ldvr, work, lwork, info)
-        if (nid == 0) call check_info(info, 'GEEV', module=this_module, procedure='eig_rdp')
+        call check_info(info, 'GEEV', module=this_module, procedure='eig_rdp')
 
         ! Reconstruct eigenvalues
         vals = one_cdp*wr + one_im_cdp*wi
@@ -605,7 +605,7 @@ contains
 
         ! Eigendecomposition.
         call syev(jobz, uplo, n, a_tilde, lda, vals, work, lwork, info)
-        if (nid == 0) call check_info(info, 'SYEV', module=this_module, procedure='eigh_rdp')
+        call check_info(info, 'SYEV', module=this_module, procedure='eigh_rdp')
 
         ! Extract eigenvectors
         vecs = a_tilde
@@ -635,7 +635,7 @@ contains
 
         allocate(wr(size(eigvals)), wi(size(eigvals)))
         call gees(jobvs, sort, dummy_select, n, A, lda, sdim, wr, wi, Z, ldvs, work, lwork, bwork, info)
-        if (nid == 0) call check_info(info, 'GEES', module=this_module, procedure='schur_rdp')
+        call check_info(info, 'GEES', module=this_module, procedure='schur_rdp')
 
         ! Reconstruct eigenvalues
         eigvals = cmplx(wr, wi, kind=dp)
@@ -673,7 +673,7 @@ contains
 
         liwork = 1
         call trsen(job, compq, selected, n, T, ldt, Q, ldq, wr, wi, m, s, sep, work, lwork, iwork, liwork, info)
-        if (nid == 0) call check_info(info, 'TRSEN', module=this_module, procedure='ordschur_rdp')
+        call check_info(info, 'TRSEN', module=this_module, procedure='ordschur_rdp')
 
         return
     end subroutine ordschur_rdp
@@ -738,11 +738,11 @@ contains
         ! Compute A = LU (in-place).
         n = size(A, 1) ; call assert_shape(A, [n, n], "inv", "A")
         call getrf(n, n, A, n, ipiv, info)
-        if (nid == 0) call check_info(info, 'GETREF', module=this_module, procedure='inv_csp')
+        call check_info(info, 'GETREF', module=this_module, procedure='inv_csp')
 
         ! Compute inv(A) (in-place).
         call getri(n, A, n, ipiv, work, n, info)
-        if (nid == 0) call check_info(info, 'GETRI', module=this_module, procedure='inv_csp')
+        call check_info(info, 'GETRI', module=this_module, procedure='inv_csp')
 
         return
     end subroutine inv_csp
@@ -768,7 +768,7 @@ contains
 
         ! Eigendecomposition.
         call geev(jobvl, jobvr, n, a_tilde, lda, vals, vl, ldvl, vecs, ldvr, work, lwork, rwork, info)
-        if (nid == 0) call check_info(info, 'GEEV', module=this_module, procedure='eig_csp')
+        call check_info(info, 'GEEV', module=this_module, procedure='eig_csp')
 
 
         return
@@ -798,7 +798,7 @@ contains
 
         ! Eigendecomposition.
         call heev(jobz, uplo, n, a_tilde, lda, vals, work, lwork, rwork, info)
-        if (nid == 0) call check_info(info, 'HEEV', module=this_module, procedure='eigh_csp')
+        call check_info(info, 'HEEV', module=this_module, procedure='eigh_csp')
 
         ! Extract eigenvectors
         vecs = a_tilde
@@ -827,7 +827,7 @@ contains
         allocate(bwork(n)) ; allocate(work(lwork)) ;  allocate(rwork(n)) 
 
         call gees(jobvs, sort, dummy_select, n, A, lda, sdim, eigvals, Z, ldvs, work, lwork, rwork, bwork, info)
-        if (nid == 0) call check_info(info, 'GEES', module=this_module, procedure='schur_csp')
+        call check_info(info, 'GEES', module=this_module, procedure='schur_csp')
 
 
         return
@@ -860,7 +860,7 @@ contains
         n = size(T, 2) ; ldt = n ; ldq = n ; lwork = max(1, n)
 
         call trsen(job, compq, selected, n, T, ldt, Q, ldq, w, m, s, sep, work, lwork, info)
-        if (nid == 0) call check_info(info, 'TRSEN', module=this_module, procedure='ordschur_csp')
+        call check_info(info, 'TRSEN', module=this_module, procedure='ordschur_csp')
 
         return
     end subroutine ordschur_csp
@@ -925,11 +925,11 @@ contains
         ! Compute A = LU (in-place).
         n = size(A, 1) ; call assert_shape(A, [n, n], "inv", "A")
         call getrf(n, n, A, n, ipiv, info)
-        if (nid == 0) call check_info(info, 'GETREF', module=this_module, procedure='inv_cdp')
+        call check_info(info, 'GETREF', module=this_module, procedure='inv_cdp')
 
         ! Compute inv(A) (in-place).
         call getri(n, A, n, ipiv, work, n, info)
-        if (nid == 0) call check_info(info, 'GETRI', module=this_module, procedure='inv_cdp')
+        call check_info(info, 'GETRI', module=this_module, procedure='inv_cdp')
 
         return
     end subroutine inv_cdp
@@ -955,7 +955,7 @@ contains
 
         ! Eigendecomposition.
         call geev(jobvl, jobvr, n, a_tilde, lda, vals, vl, ldvl, vecs, ldvr, work, lwork, rwork, info)
-        if (nid == 0) call check_info(info, 'GEEV', module=this_module, procedure='eig_cdp')
+        call check_info(info, 'GEEV', module=this_module, procedure='eig_cdp')
 
 
         return
@@ -985,7 +985,7 @@ contains
 
         ! Eigendecomposition.
         call heev(jobz, uplo, n, a_tilde, lda, vals, work, lwork, rwork, info)
-        if (nid == 0) call check_info(info, 'HEEV', module=this_module, procedure='eigh_cdp')
+        call check_info(info, 'HEEV', module=this_module, procedure='eigh_cdp')
 
         ! Extract eigenvectors
         vecs = a_tilde
@@ -1014,7 +1014,7 @@ contains
         allocate(bwork(n)) ; allocate(work(lwork)) ;  allocate(rwork(n)) 
 
         call gees(jobvs, sort, dummy_select, n, A, lda, sdim, eigvals, Z, ldvs, work, lwork, rwork, bwork, info)
-        if (nid == 0) call check_info(info, 'GEES', module=this_module, procedure='schur_cdp')
+        call check_info(info, 'GEES', module=this_module, procedure='schur_cdp')
 
 
         return
@@ -1047,7 +1047,7 @@ contains
         n = size(T, 2) ; ldt = n ; ldq = n ; lwork = max(1, n)
 
         call trsen(job, compq, selected, n, T, ldt, Q, ldq, w, m, s, sep, work, lwork, info)
-        if (nid == 0) call check_info(info, 'TRSEN', module=this_module, procedure='ordschur_cdp')
+        call check_info(info, 'TRSEN', module=this_module, procedure='ordschur_cdp')
 
         return
     end subroutine ordschur_cdp

--- a/src/Utils.fypp
+++ b/src/Utils.fypp
@@ -196,11 +196,11 @@ contains
         ! Compute A = LU (in-place).
         n = size(A, 1) ; call assert_shape(A, [n, n], "inv", "A")
         call getrf(n, n, A, n, ipiv, info)
-        if (nid == 0) call check_info(info, 'GETREF', module=this_module, procedure='inv_${type[0]}$${kind}$')
+        call check_info(info, 'GETREF', module=this_module, procedure='inv_${type[0]}$${kind}$')
 
         ! Compute inv(A) (in-place).
         call getri(n, A, n, ipiv, work, n, info)
-        if (nid == 0) call check_info(info, 'GETRI', module=this_module, procedure='inv_${type[0]}$${kind}$')
+        call check_info(info, 'GETRI', module=this_module, procedure='inv_${type[0]}$${kind}$')
 
         return
     end subroutine inv_${type[0]}$${kind}$
@@ -243,7 +243,7 @@ contains
         #:else
         call geev(jobvl, jobvr, n, a_tilde, lda, wr, wi, vl, ldvl, vecs, ldvr, work, lwork, info)
         #:endif
-        if (nid == 0) call check_info(info, 'GEEV', module=this_module, procedure='eig_${type[0]}$${kind}$')
+        call check_info(info, 'GEEV', module=this_module, procedure='eig_${type[0]}$${kind}$')
 
         #:if type[0] == "r"
         ! Reconstruct eigenvalues
@@ -284,10 +284,10 @@ contains
         ! Eigendecomposition.
         #:if type[0] == "r"
         call syev(jobz, uplo, n, a_tilde, lda, vals, work, lwork, info)
-        if (nid == 0) call check_info(info, 'SYEV', module=this_module, procedure='eigh_${type[0]}$${kind}$')
+        call check_info(info, 'SYEV', module=this_module, procedure='eigh_${type[0]}$${kind}$')
         #:else
         call heev(jobz, uplo, n, a_tilde, lda, vals, work, lwork, rwork, info)
-        if (nid == 0) call check_info(info, 'HEEV', module=this_module, procedure='eigh_${type[0]}$${kind}$')
+        call check_info(info, 'HEEV', module=this_module, procedure='eigh_${type[0]}$${kind}$')
         #:endif
 
         ! Extract eigenvectors
@@ -326,7 +326,7 @@ contains
         #:else
         call gees(jobvs, sort, dummy_select, n, A, lda, sdim, eigvals, Z, ldvs, work, lwork, rwork, bwork, info)
         #:endif
-        if (nid == 0) call check_info(info, 'GEES', module=this_module, procedure='schur_${type[0]}$${kind}$')
+        call check_info(info, 'GEES', module=this_module, procedure='schur_${type[0]}$${kind}$')
 
         #:if type[0] == "r"
         ! Reconstruct eigenvalues
@@ -383,7 +383,7 @@ contains
         #:else
         call trsen(job, compq, selected, n, T, ldt, Q, ldq, w, m, s, sep, work, lwork, info)
         #:endif
-        if (nid == 0) call check_info(info, 'TRSEN', module=this_module, procedure='ordschur_${type[0]}$${kind}$')
+        call check_info(info, 'TRSEN', module=this_module, procedure='ordschur_${type[0]}$${kind}$')
 
         return
     end subroutine ordschur_${type[0]}$${kind}$

--- a/src/Utils.fypp
+++ b/src/Utils.fypp
@@ -5,7 +5,6 @@ module lightkrylov_utils
     !-----     Standard Fortran Library     -----
     !--------------------------------------------
     use iso_fortran_env, only: output_unit
-    use LightKrylov_Logger
     use stdlib_linalg, only: is_hermitian, is_symmetric, diag
     ! Matrix inversion.
     use stdlib_linalg_lapack, only: getrf, getri
@@ -18,6 +17,7 @@ module lightkrylov_utils
     !-----     LightKrylov     -----
     !-------------------------------
     ! Various constants.
+    use LightKrylov_Logger
     use LightKrylov_Constants
 
     implicit none
@@ -196,11 +196,11 @@ contains
         ! Compute A = LU (in-place).
         n = size(A, 1) ; call assert_shape(A, [n, n], "inv", "A")
         call getrf(n, n, A, n, ipiv, info)
-        call check_info(info, 'GETREF', module=this_module, procedure='inv_${type[0]}$${kind}$')
+        if (nid == 0) call check_info(info, 'GETREF', module=this_module, procedure='inv_${type[0]}$${kind}$')
 
         ! Compute inv(A) (in-place).
         call getri(n, A, n, ipiv, work, n, info)
-        call check_info(info, 'GETRI', module=this_module, procedure='inv_${type[0]}$${kind}$')
+        if (nid == 0) call check_info(info, 'GETRI', module=this_module, procedure='inv_${type[0]}$${kind}$')
 
         return
     end subroutine inv_${type[0]}$${kind}$
@@ -243,7 +243,7 @@ contains
         #:else
         call geev(jobvl, jobvr, n, a_tilde, lda, wr, wi, vl, ldvl, vecs, ldvr, work, lwork, info)
         #:endif
-        call check_info(info, 'GEEV', module=this_module, procedure='eig_${type[0]}$${kind}$')
+        if (nid == 0) call check_info(info, 'GEEV', module=this_module, procedure='eig_${type[0]}$${kind}$')
 
         #:if type[0] == "r"
         ! Reconstruct eigenvalues
@@ -284,10 +284,10 @@ contains
         ! Eigendecomposition.
         #:if type[0] == "r"
         call syev(jobz, uplo, n, a_tilde, lda, vals, work, lwork, info)
-        call check_info(info, 'SYEV', module=this_module, procedure='eigh_${type[0]}$${kind}$')
+        if (nid == 0) call check_info(info, 'SYEV', module=this_module, procedure='eigh_${type[0]}$${kind}$')
         #:else
         call heev(jobz, uplo, n, a_tilde, lda, vals, work, lwork, rwork, info)
-        call check_info(info, 'HEEV', module=this_module, procedure='eigh_${type[0]}$${kind}$')
+        if (nid == 0) call check_info(info, 'HEEV', module=this_module, procedure='eigh_${type[0]}$${kind}$')
         #:endif
 
         ! Extract eigenvectors
@@ -326,7 +326,7 @@ contains
         #:else
         call gees(jobvs, sort, dummy_select, n, A, lda, sdim, eigvals, Z, ldvs, work, lwork, rwork, bwork, info)
         #:endif
-        call check_info(info, 'GEES', module=this_module, procedure='schur_${type[0]}$${kind}$')
+        if (nid == 0) call check_info(info, 'GEES', module=this_module, procedure='schur_${type[0]}$${kind}$')
 
         #:if type[0] == "r"
         ! Reconstruct eigenvalues
@@ -383,7 +383,7 @@ contains
         #:else
         call trsen(job, compq, selected, n, T, ldt, Q, ldq, w, m, s, sep, work, lwork, info)
         #:endif
-        call check_info(info, 'TRSEN', module=this_module, procedure='ordschur_${type[0]}$${kind}$')
+        if (nid == 0) call check_info(info, 'TRSEN', module=this_module, procedure='ordschur_${type[0]}$${kind}$')
 
         return
     end subroutine ordschur_${type[0]}$${kind}$

--- a/test/TestExpmlib.f90
+++ b/test/TestExpmlib.f90
@@ -4,7 +4,7 @@ module TestExpmlib
     use stdlib_math, only: is_close, all_close
     use stdlib_linalg, only: eye, diag
     use stdlib_io_npy, only: save_npy
-   ! Testdrive
+    ! Testdrive
     use testdrive, only: new_unittest, unittest_type, error_type, check
     ! LightKrylov
     use LightKrylov

--- a/test/TestExpmlib.fypp
+++ b/test/TestExpmlib.fypp
@@ -6,7 +6,7 @@ module TestExpmlib
     use stdlib_math, only: is_close, all_close
     use stdlib_linalg, only: eye, diag
     use stdlib_io_npy, only: save_npy
-   ! Testdrive
+    ! Testdrive
     use testdrive, only: new_unittest, unittest_type, error_type, check
     ! LightKrylov
     use LightKrylov


### PR DESCRIPTION
The present simple implementation makes `LightKrylov` aware of parallelism.
 
 * `LightKrylov_Constants` provides MPI initialisation and finalisation routines
 * The rank, I/O rank and communicator size are private variables in `LightKrylov_Constants`, namely `nid`, `nio` and `comm_size`, respectively. They are accessible via getter/setter routines only. The variables `nid`, `comm_size` and `nio` are then set to the default values are `nid=0`, `comm_size=1` and `nio=0`.
 * The user can choose to use any rank for I/O via `set_io_rank`.

The implementation is based on `mpi_f08` which must be present and linked as an external module in `fpm.toml`. From what I see, there is no 'serial' version of the library in the sense that it would be natively compatible with serial compilation. Therefore, I have added preprocessor macros that disable the MPI related code and imports in serial cases and instead generate dummy MPI routines. The implementation details are invisible to the user who only has to take care to pass the right compiler flags, in particular "-DMPI"

`LightKrylov` can now initialize the MPI communicator itself or, if it has already been initialized by the main program, access the standard communicator.
 
 closes #108

