### PR TITLE
Wrappers for basis orthogonalization/normalization 

### DIFF
--- a/src/BaseKrylov.f90
+++ b/src/BaseKrylov.f90
@@ -17,6 +17,7 @@ module lightkrylov_BaseKrylov
     public :: apply_inverse_permutation_matrix
     public :: arnoldi
     public :: initialize_krylov_subspace
+    public :: is_orthonormal
     public :: orthonormalize_basis
     public :: orthogonalize_against_basis
     public :: lanczos_bidiagonalization
@@ -78,6 +79,13 @@ module lightkrylov_BaseKrylov
         module procedure initialize_krylov_subspace_rdp
         module procedure initialize_krylov_subspace_csp
         module procedure initialize_krylov_subspace_cdp
+    end interface
+
+    interface is_orthonormal
+        module procedure is_orthonormal_rsp
+        module procedure is_orthonormal_rdp
+        module procedure is_orthonormal_csp
+        module procedure is_orthonormal_cdp
     end interface
 
     interface orthonormalize_basis
@@ -152,6 +160,47 @@ contains
     !-------------------------------------
     !-----     UTILITY FUNCTIONS     -----
     !-------------------------------------
+
+    logical function is_orthonormal_rsp(X) result(ortho)
+        class(abstract_vector_rsp), intent(in) :: X(:)
+        real(sp), dimension(size(X), size(X)) :: G
+        ortho = .true.
+        call innerprod(G, X, X)
+        if (norm2(abs(G - eye(size(X)))) > rtol_sp) then
+            ! The basis is not orthonormal. Cannot orthonormalize.
+            ortho = .false.
+        end if
+    end function
+    logical function is_orthonormal_rdp(X) result(ortho)
+        class(abstract_vector_rdp), intent(in) :: X(:)
+        real(dp), dimension(size(X), size(X)) :: G
+        ortho = .true.
+        call innerprod(G, X, X)
+        if (norm2(abs(G - eye(size(X)))) > rtol_sp) then
+            ! The basis is not orthonormal. Cannot orthonormalize.
+            ortho = .false.
+        end if
+    end function
+    logical function is_orthonormal_csp(X) result(ortho)
+        class(abstract_vector_csp), intent(in) :: X(:)
+        complex(sp), dimension(size(X), size(X)) :: G
+        ortho = .true.
+        call innerprod(G, X, X)
+        if (norm2(abs(G - eye(size(X)))) > rtol_sp) then
+            ! The basis is not orthonormal. Cannot orthonormalize.
+            ortho = .false.
+        end if
+    end function
+    logical function is_orthonormal_cdp(X) result(ortho)
+        class(abstract_vector_cdp), intent(in) :: X(:)
+        complex(dp), dimension(size(X), size(X)) :: G
+        ortho = .true.
+        call innerprod(G, X, X)
+        if (norm2(abs(G - eye(size(X)))) > rtol_sp) then
+            ! The basis is not orthonormal. Cannot orthonormalize.
+            ortho = .false.
+        end if
+    end function
 
     subroutine initialize_krylov_subspace_rsp(X, X0)
         class(abstract_vector_rsp), intent(inout) :: X(:)

--- a/src/BaseKrylov.f90
+++ b/src/BaseKrylov.f90
@@ -17,6 +17,7 @@ module lightkrylov_BaseKrylov
     public :: apply_inverse_permutation_matrix
     public :: arnoldi
     public :: initialize_krylov_subspace
+    public :: orthonormalize_basis
     public :: orthogonalize_against_basis
     public :: lanczos_bidiagonalization
     public :: lanczos_tridiagonalization

--- a/src/BaseKrylov.fypp
+++ b/src/BaseKrylov.fypp
@@ -19,6 +19,7 @@ module lightkrylov_BaseKrylov
     public :: apply_inverse_permutation_matrix
     public :: arnoldi
     public :: initialize_krylov_subspace
+    public :: is_orthonormal
     public :: orthonormalize_basis
     public :: orthogonalize_against_basis
     public :: lanczos_bidiagonalization
@@ -65,6 +66,12 @@ module lightkrylov_BaseKrylov
     interface initialize_krylov_subspace
         #:for kind, type in RC_KINDS_TYPES
         module procedure initialize_krylov_subspace_${type[0]}$${kind}$
+        #:endfor
+    end interface
+
+    interface is_orthonormal
+        #:for kind, type in RC_KINDS_TYPES
+        module procedure is_orthonormal_${type[0]}$${kind}$
         #:endfor
     end interface
 
@@ -125,6 +132,19 @@ contains
     !-------------------------------------
     !-----     UTILITY FUNCTIONS     -----
     !-------------------------------------
+
+    #:for kind, type in RC_KINDS_TYPES
+    logical function is_orthonormal_${type[0]}$${kind}$(X) result(ortho)
+        class(abstract_vector_${type[0]}$${kind}$), intent(in) :: X(:)
+        ${type}$, dimension(size(X), size(X)) :: G
+        ortho = .true.
+        call innerprod(G, X, X)
+        if (norm2(abs(G - eye(size(X)))) > rtol_sp) then
+            ! The basis is not orthonormal. Cannot orthonormalize.
+            ortho = .false.
+        end if
+    end function
+    #:endfor
 
     #:for kind, type in RC_KINDS_TYPES
     subroutine initialize_krylov_subspace_${type[0]}$${kind}$(X, X0)

--- a/src/BaseKrylov.fypp
+++ b/src/BaseKrylov.fypp
@@ -19,6 +19,7 @@ module lightkrylov_BaseKrylov
     public :: apply_inverse_permutation_matrix
     public :: arnoldi
     public :: initialize_krylov_subspace
+    public :: orthonormalize_basis
     public :: orthogonalize_against_basis
     public :: lanczos_bidiagonalization
     public :: lanczos_tridiagonalization

--- a/src/BaseKrylov.fypp
+++ b/src/BaseKrylov.fypp
@@ -67,6 +67,12 @@ module lightkrylov_BaseKrylov
         #:endfor
     end interface
 
+    interface orthonormalize_basis
+        #:for kind, type in RC_KINDS_TYPES
+        module procedure orthonormalize_basis_${type[0]}$${kind}$
+        #:endfor
+    end interface
+
     interface orthogonalize_against_basis
         #:for kind, type in RC_KINDS_TYPES
         module procedure orthogonalize_vector_against_basis_${type[0]}$${kind}$
@@ -126,9 +132,7 @@ contains
 
         ! Internal variables.
         class(abstract_vector_${type[0]}$${kind}$), allocatable :: Q(:)
-        ${type}$, allocatable :: R(:, :)
-        integer, allocatable :: perm(:)
-        integer :: i, p, info
+        integer :: p
 
         ! Zero-out X.
         call zero_basis(X)
@@ -136,28 +140,34 @@ contains
         ! Deals with optional args.
         if(present(X0)) then
             p = size(X0)
-
             ! Initialize.
-            allocate(Q(1:p), source=X0(1:p))
-            do i = 1, p
-                call Q(i)%zero()
-                call Q(i)%add(X0(i))
-            enddo
-    
+            allocate(Q(p), source=X0)   
             ! Orthonormalize.
-            allocate(R(p, p)) ; R = zero_r${kind}$
-            allocate(perm(p)) ; perm = 0
-            call qr(Q, R, perm, info)
-            do i = 1, p
-                call X(i)%add(Q(i))
-            enddo
+            call orthonormalize_basis(Q)
+            call copy_basis(X(:p), Q)
         endif
 
         return
     end subroutine initialize_krylov_subspace_${type[0]}$${kind}$
 
+    subroutine orthonormalize_basis_${type[0]}$${kind}$(X)
+      !! Orthonormalizes the `abstract_vector` basis `X`
+      class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: X(:)
+      !! Input `abstract_vector` basis to orthogonalize against
+      
+      ! internals
+      ${type}$ :: R(size(X),size(X))
+      integer :: info
+
+      ! internals
+      call qr(X, R, info)
+      call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_${type[0]}$${kind}$')
+      
+      return
+    end subroutine orthonormalize_basis_${type[0]}$${kind}$
+
     subroutine orthogonalize_vector_against_basis_${type[0]}$${kind}$(y, X, info, if_chk_orthonormal, beta)
-      !! Orthonormalizes the `abstract_vector` `y` against a basis `X` of `abstract_vector`.
+      !! Orthogonalizes the `abstract_vector` `y` against a basis `X` of `abstract_vector`.
       class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: y
       !! Input `abstract_vector` to orthogonalize
       class(abstract_vector_${type[0]}$${kind}$), intent(in)    :: X(:)
@@ -214,7 +224,7 @@ contains
     end subroutine orthogonalize_vector_against_basis_${type[0]}$${kind}$
 
     subroutine orthogonalize_basis_against_basis_${type[0]}$${kind}$(Y, X, info, if_chk_orthonormal, beta)
-      !! Orthonormalizes the `abstract_vector` basis `Y` against a basis `X` of `abstract_vector`.
+      !! Orthogonalizes the `abstract_vector` basis `Y` against a basis `X` of `abstract_vector`.
       class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: Y(:)
       !! Input `abstract_vector` basis to orthogonalize
       class(abstract_vector_${type[0]}$${kind}$), intent(in)    :: X(:)

--- a/src/Constants.f90
+++ b/src/Constants.f90
@@ -47,6 +47,7 @@ module LightKrylov_Constants
 contains
 
    subroutine comm_setup()
+      ! internal
       integer :: ierr
       logical :: mpi_is_initialized
       character(len=128) :: msg
@@ -54,19 +55,19 @@ contains
       ! check if MPI has already been initialized and if not, initialize
       call MPI_Initialized(mpi_is_initialized, ierr)
       if (.not. mpi_is_initialized) then
-         call logger%log_message('Set up parallel run with MPI.', module='LightKrylov', procedure='comm_setup')
+         call logger%log_debug('Set up parallel run with MPI.', module='LightKrylov', procedure='comm_setup')
          call MPI_Init(ierr)
          if (ierr /= MPI_SUCCESS) call stop_error("Error initializing MPI", module='LightKrylov',procedure='mpi_init')
       else
-         call logger%log_message('MPI already initialized.', module='LightKrylov', procedure='comm_setup')
+         call logger%log_debug('MPI already initialized.', module='LightKrylov', procedure='comm_setup')
       end if
       call MPI_Comm_rank(MPI_COMM_WORLD, nid, ierr)
       call MPI_Comm_size(MPI_COMM_WORLD, comm_size, ierr)
       write(msg, '(A,I4,A,I4)') 'rank', nid, ', comm_size = ', comm_size
-      call logger%log_message(trim(msg), module='LightKrylov', procedure='comm_setup')
+      call logger%log_debug(trim(msg), module='LightKrylov', procedure='comm_setup')
 #else
       write(msg, *) 'Setup serial run'
-      call logger%log_message(trim(msg), module='LightKrylov', procedure='comm_setup')
+      call logger%log_debug(trim(msg), module='LightKrylov', procedure='comm_setup')
 #endif
       call set_io_rank(0)
       return

--- a/src/ExpmLib.f90
+++ b/src/ExpmLib.f90
@@ -163,10 +163,10 @@ contains
         allocate(wrk(n))
 
         ! Compute the L-infinity norm.
-        a_norm = norml_rsp(A)
+        a_norm = norml(A)
 
         ! Determine scaling factor for the matrix.
-        ee = int(log2_rsp(a_norm)) + 1
+        ee = int(log2(a_norm)) + 1
         s = max(0, ee+1)
 
         ! Scale the input matrix & initialize polynomial.
@@ -531,10 +531,10 @@ contains
         allocate(wrk(n))
 
         ! Compute the L-infinity norm.
-        a_norm = norml_rdp(A)
+        a_norm = norml(A)
 
         ! Determine scaling factor for the matrix.
-        ee = int(log2_rdp(a_norm)) + 1
+        ee = int(log2(a_norm)) + 1
         s = max(0, ee+1)
 
         ! Scale the input matrix & initialize polynomial.
@@ -899,10 +899,10 @@ contains
         allocate(wrk(n))
 
         ! Compute the L-infinity norm.
-        a_norm = norml_csp(A)
+        a_norm = norml(A)
 
         ! Determine scaling factor for the matrix.
-        ee = int(log2_rsp(a_norm)) + 1
+        ee = int(log2(a_norm)) + 1
         s = max(0, ee+1)
 
         ! Scale the input matrix & initialize polynomial.
@@ -1267,10 +1267,10 @@ contains
         allocate(wrk(n))
 
         ! Compute the L-infinity norm.
-        a_norm = norml_cdp(A)
+        a_norm = norml(A)
 
         ! Determine scaling factor for the matrix.
-        ee = int(log2_rdp(a_norm)) + 1
+        ee = int(log2(a_norm)) + 1
         s = max(0, ee+1)
 
         ! Scale the input matrix & initialize polynomial.

--- a/src/ExpmLib.fypp
+++ b/src/ExpmLib.fypp
@@ -104,10 +104,10 @@ contains
         allocate(wrk(n))
 
         ! Compute the L-infinity norm.
-        a_norm = norml_${type[0]}$${kind}$(A)
+        a_norm = norml(A)
 
         ! Determine scaling factor for the matrix.
-        ee = int(log2_r${kind}$(a_norm)) + 1
+        ee = int(log2(a_norm)) + 1
         s = max(0, ee+1)
 
         ! Scale the input matrix & initialize polynomial.

--- a/src/LightKrylov.f90
+++ b/src/LightKrylov.f90
@@ -37,6 +37,7 @@ module LightKrylov
     public :: abstract_vector_csp
     public :: abstract_vector_cdp
     public :: zero_basis
+    public :: copy_basis
     
     ! AbstractLinops exports.
     public :: abstract_linop

--- a/src/LightKrylov.f90
+++ b/src/LightKrylov.f90
@@ -24,7 +24,7 @@ module LightKrylov
     public :: sp, atol_sp, rtol_sp
     public :: dp, atol_dp, rtol_dp
     ! MPI and I/Ω
-    public :: mpi_setup, mpi_close
+    public :: comm_setup, comm_close
     public :: get_rank, set_io_rank, io_rank
 
     ! Utils exports.

--- a/src/LightKrylov.f90
+++ b/src/LightKrylov.f90
@@ -70,6 +70,8 @@ module LightKrylov
     public :: apply_permutation_matrix, apply_inverse_permutation_matrix
     public :: arnoldi
     public :: initialize_krylov_subspace
+    public :: orthogonalize_against_basis
+    public :: orthonormalize_basis
     public :: lanczos_bidiagonalization
     public :: lanczos_tridiagonalization
     public :: krylov_schur

--- a/src/LightKrylov.f90
+++ b/src/LightKrylov.f90
@@ -36,6 +36,9 @@ module LightKrylov
     public :: abstract_vector_rdp
     public :: abstract_vector_csp
     public :: abstract_vector_cdp
+    public :: innerprod
+    public :: linear_combination
+    public :: axpby_basis
     public :: zero_basis
     public :: copy_basis
     

--- a/src/LightKrylov.fypp
+++ b/src/LightKrylov.fypp
@@ -37,6 +37,9 @@ module LightKrylov
     #:for kind, type in RC_KINDS_TYPES
     public :: abstract_vector_${type[0]}$${kind}$
     #:endfor
+    public :: innerprod
+    public :: linear_combination
+    public :: axpby_basis
     public :: zero_basis
     public :: copy_basis
     

--- a/src/LightKrylov.fypp
+++ b/src/LightKrylov.fypp
@@ -59,6 +59,8 @@ module LightKrylov
     public :: apply_permutation_matrix, apply_inverse_permutation_matrix
     public :: arnoldi
     public :: initialize_krylov_subspace
+    public :: orthogonalize_against_basis
+    public :: orthonormalize_basis
     public :: lanczos_bidiagonalization
     public :: lanczos_tridiagonalization
     public :: krylov_schur

--- a/src/LightKrylov.fypp
+++ b/src/LightKrylov.fypp
@@ -38,6 +38,7 @@ module LightKrylov
     public :: abstract_vector_${type[0]}$${kind}$
     #:endfor
     public :: zero_basis
+    public :: copy_basis
     
     ! AbstractLinops exports.
     public :: abstract_linop

--- a/src/LightKrylov.fypp
+++ b/src/LightKrylov.fypp
@@ -26,7 +26,7 @@ module LightKrylov
     public :: sp, atol_sp, rtol_sp
     public :: dp, atol_dp, rtol_dp
     ! MPI and I/Ω
-    public :: mpi_setup, mpi_close
+    public :: comm_setup, comm_close
     public :: get_rank, set_io_rank, io_rank
 
     ! Utils exports.

--- a/src/Utils.f90
+++ b/src/Utils.f90
@@ -520,7 +520,8 @@ contains
       ! Check if the matrix is symmetric
       symmetry_error = 0.5*maxval(X - transpose(X))
       if (symmetry_error > rtol_sp) then
-        write(msg,*) "Input matrix is not symmetric. 0.5*max(X-X.T) = ", symmetry_error
+        write(msg,*) "Input matrix is not symmetric. 0.5*max(X-X.T) = ", &
+            & symmetry_error, ", tol = ", rtol_sp
         call stop_error(msg, module=this_module, procedure='sqrtm_rsp')
       else if (symmetry_error > 10*atol_sp) then
         write(msg,*) "Input matrix is not exactly symmetric. 0.5*max(X-X.T) = ", symmetry_error
@@ -758,7 +759,8 @@ contains
       ! Check if the matrix is symmetric
       symmetry_error = 0.5*maxval(X - transpose(X))
       if (symmetry_error > rtol_dp) then
-        write(msg,*) "Input matrix is not symmetric. 0.5*max(X-X.T) = ", symmetry_error
+        write(msg,*) "Input matrix is not symmetric. 0.5*max(X-X.T) = ", &
+            & symmetry_error, ", tol = ", rtol_dp
         call stop_error(msg, module=this_module, procedure='sqrtm_rdp')
       else if (symmetry_error > 10*atol_dp) then
         write(msg,*) "Input matrix is not exactly symmetric. 0.5*max(X-X.T) = ", symmetry_error
@@ -991,7 +993,8 @@ contains
       ! Check if the matrix is hermitian
       symmetry_error = 0.5*maxval(abs(X - conjg(transpose(X))))
       if (symmetry_error > rtol_sp) then
-        write(msg,*) "Input matrix is not hermitian. 0.5*max(abs(X-X.H)) = ", symmetry_error
+        write(msg,*) "Input matrix is not hermitian. 0.5*max(abs(X-X.H)) = ", &
+            & symmetry_error, ", tol = ", rtol_sp
         call stop_error(msg, module=this_module, procedure='sqrtm_csp')
       else if (symmetry_error > 10*atol_sp) then
         write(msg,*) "Input matrix is not exactly hermitian. 0.5*max(X-X.T) = ", symmetry_error
@@ -1224,7 +1227,8 @@ contains
       ! Check if the matrix is hermitian
       symmetry_error = 0.5*maxval(abs(X - conjg(transpose(X))))
       if (symmetry_error > rtol_dp) then
-        write(msg,*) "Input matrix is not hermitian. 0.5*max(abs(X-X.H)) = ", symmetry_error
+        write(msg,*) "Input matrix is not hermitian. 0.5*max(abs(X-X.H)) = ", &
+            & symmetry_error, ", tol = ", rtol_dp
         call stop_error(msg, module=this_module, procedure='sqrtm_cdp')
       else if (symmetry_error > 10*atol_dp) then
         write(msg,*) "Input matrix is not exactly hermitian. 0.5*max(X-X.T) = ", symmetry_error

--- a/src/Utils.f90
+++ b/src/Utils.f90
@@ -21,7 +21,7 @@ module lightkrylov_utils
     implicit none
     private
 
-    character*128, parameter :: this_module = 'LightKrylov_Utils'
+    character(len=128), parameter :: this_module = 'LightKrylov_Utils'
 
     public :: assert_shape
     ! Compute B = inv(A) in-place for dense matrices.
@@ -176,7 +176,7 @@ contains
         !! Name of the asserted vector.
         
         ! internals
-        character*128 :: msg
+        character(len=256) :: msg
 
         if(any(shape(v) /= size)) then
             write(msg, *) "In routine "//routine//" vector "//matname//" has illegal length ", shape(v), &
@@ -198,7 +198,7 @@ contains
         !! Name of the asserted matrix.
 
         ! internals
-        character*128 :: msg
+        character(len=256) :: msg
 
         if(any(shape(A) /= size)) then
             write(msg, *) "In routine "//routine//" matrix "//matname//" has illegal shape ", shape(A), &
@@ -219,7 +219,7 @@ contains
         !! Name of the asserted vector.
         
         ! internals
-        character*128 :: msg
+        character(len=256) :: msg
 
         if(any(shape(v) /= size)) then
             write(msg, *) "In routine "//routine//" vector "//matname//" has illegal length ", shape(v), &
@@ -241,7 +241,7 @@ contains
         !! Name of the asserted matrix.
 
         ! internals
-        character*128 :: msg
+        character(len=256) :: msg
 
         if(any(shape(A) /= size)) then
             write(msg, *) "In routine "//routine//" matrix "//matname//" has illegal shape ", shape(A), &
@@ -262,7 +262,7 @@ contains
         !! Name of the asserted vector.
         
         ! internals
-        character*128 :: msg
+        character(len=256) :: msg
 
         if(any(shape(v) /= size)) then
             write(msg, *) "In routine "//routine//" vector "//matname//" has illegal length ", shape(v), &
@@ -284,7 +284,7 @@ contains
         !! Name of the asserted matrix.
 
         ! internals
-        character*128 :: msg
+        character(len=256) :: msg
 
         if(any(shape(A) /= size)) then
             write(msg, *) "In routine "//routine//" matrix "//matname//" has illegal shape ", shape(A), &
@@ -305,7 +305,7 @@ contains
         !! Name of the asserted vector.
         
         ! internals
-        character*128 :: msg
+        character(len=256) :: msg
 
         if(any(shape(v) /= size)) then
             write(msg, *) "In routine "//routine//" vector "//matname//" has illegal length ", shape(v), &
@@ -327,7 +327,7 @@ contains
         !! Name of the asserted matrix.
 
         ! internals
-        character*128 :: msg
+        character(len=256) :: msg
 
         if(any(shape(A) /= size)) then
             write(msg, *) "In routine "//routine//" matrix "//matname//" has illegal shape ", shape(A), &
@@ -499,7 +499,7 @@ contains
       real(sp) :: lambda(size(X,1))
       real(sp) :: V(size(X,1), size(X,1))
       integer :: i
-      character*128 :: msg
+      character(len=128) :: msg
 
       info = 0
 
@@ -691,7 +691,7 @@ contains
       real(dp) :: lambda(size(X,1))
       real(dp) :: V(size(X,1), size(X,1))
       integer :: i
-      character*128 :: msg
+      character(len=128) :: msg
 
       info = 0
 
@@ -878,7 +878,7 @@ contains
       real(sp) :: lambda(size(X,1))
       complex(sp) :: V(size(X,1), size(X,1))
       integer :: i
-      character*128 :: msg
+      character(len=128) :: msg
 
       info = 0
 
@@ -1065,7 +1065,7 @@ contains
       real(dp) :: lambda(size(X,1))
       complex(dp) :: V(size(X,1), size(X,1))
       integer :: i
-      character*128 :: msg
+      character(len=128) :: msg
 
       info = 0
 

--- a/src/Utils.f90
+++ b/src/Utils.f90
@@ -519,7 +519,6 @@ contains
 
       ! Check if the matrix is symmetric
       symmetry_error = 0.5*maxval(X - transpose(X))
-      print *, "Input matrix is not symmetric. 0.5*max(X-X.T) = ", symmetry_error
       if (symmetry_error > rtol_sp) then
         write(msg,*) "Input matrix is not symmetric. 0.5*max(X-X.T) = ", symmetry_error
         call stop_error(msg, module=this_module, procedure='sqrtm_rsp')
@@ -758,7 +757,6 @@ contains
 
       ! Check if the matrix is symmetric
       symmetry_error = 0.5*maxval(X - transpose(X))
-      print *, "Input matrix is not symmetric. 0.5*max(X-X.T) = ", symmetry_error
       if (symmetry_error > rtol_dp) then
         write(msg,*) "Input matrix is not symmetric. 0.5*max(X-X.T) = ", symmetry_error
         call stop_error(msg, module=this_module, procedure='sqrtm_rdp')

--- a/src/Utils.f90
+++ b/src/Utils.f90
@@ -23,7 +23,7 @@ module lightkrylov_utils
 
     character(len=128), parameter :: this_module = 'LightKrylov_Utils'
 
-    public :: assert_shape
+    public :: assert_shape, norml, log2
     ! Compute B = inv(A) in-place for dense matrices.
     public :: inv
     ! Compute AX = XD for general dense matrices.
@@ -37,13 +37,6 @@ module lightkrylov_utils
     ! Re-orders the Schur factorization of A.
     public :: ordschur
 
-    public :: log2_rsp
-    public :: norml_rsp
-    public :: log2_rdp
-    public :: norml_rdp
-    public :: norml_csp
-    public :: norml_cdp
-
     interface assert_shape
         module procedure assert_shape_vector_rsp
         module procedure assert_shape_matrix_rsp
@@ -53,6 +46,18 @@ module lightkrylov_utils
         module procedure assert_shape_matrix_csp
         module procedure assert_shape_vector_cdp
         module procedure assert_shape_matrix_cdp
+    end interface
+
+    interface norml
+        module procedure norml_rsp
+        module procedure norml_rdp
+        module procedure norml_csp
+        module procedure norml_cdp
+    end interface
+
+    interface log2
+        module procedure log2_rsp
+        module procedure log2_rdp
     end interface
 
     interface inv

--- a/src/Utils.f90
+++ b/src/Utils.f90
@@ -520,9 +520,12 @@ contains
       ! Check if the matrix is symmetric
       symmetry_error = 0.5*maxval(X - transpose(X))
       print *, "Input matrix is not symmetric. 0.5*max(X-X.T) = ", symmetry_error
-      if (symmetry_error > 10*atol_sp) then
+      if (symmetry_error > rtol_sp) then
         write(msg,*) "Input matrix is not symmetric. 0.5*max(X-X.T) = ", symmetry_error
         call stop_error(msg, module=this_module, procedure='sqrtm_rsp')
+      else if (symmetry_error > 10*atol_sp) then
+        write(msg,*) "Input matrix is not exactly symmetric. 0.5*max(X-X.T) = ", symmetry_error
+        call logger%log_warning(trim(msg), module=this_module, procedure='sqrtm_rsp')
       end if
 
       ! Perform svd
@@ -756,9 +759,12 @@ contains
       ! Check if the matrix is symmetric
       symmetry_error = 0.5*maxval(X - transpose(X))
       print *, "Input matrix is not symmetric. 0.5*max(X-X.T) = ", symmetry_error
-      if (symmetry_error > 10*atol_dp) then
+      if (symmetry_error > rtol_dp) then
         write(msg,*) "Input matrix is not symmetric. 0.5*max(X-X.T) = ", symmetry_error
         call stop_error(msg, module=this_module, procedure='sqrtm_rdp')
+      else if (symmetry_error > 10*atol_dp) then
+        write(msg,*) "Input matrix is not exactly symmetric. 0.5*max(X-X.T) = ", symmetry_error
+        call logger%log_warning(trim(msg), module=this_module, procedure='sqrtm_rdp')
       end if
 
       ! Perform svd
@@ -986,9 +992,12 @@ contains
 
       ! Check if the matrix is hermitian
       symmetry_error = 0.5*maxval(abs(X - conjg(transpose(X))))
-      if (symmetry_error > 10*atol_sp) then
+      if (symmetry_error > rtol_sp) then
         write(msg,*) "Input matrix is not hermitian. 0.5*max(abs(X-X.H)) = ", symmetry_error
         call stop_error(msg, module=this_module, procedure='sqrtm_csp')
+      else if (symmetry_error > 10*atol_sp) then
+        write(msg,*) "Input matrix is not exactly hermitian. 0.5*max(X-X.T) = ", symmetry_error
+        call logger%log_warning(trim(msg), module=this_module, procedure='sqrtm_csp')
       end if
 
       ! Perform svd
@@ -1216,9 +1225,12 @@ contains
 
       ! Check if the matrix is hermitian
       symmetry_error = 0.5*maxval(abs(X - conjg(transpose(X))))
-      if (symmetry_error > 10*atol_dp) then
+      if (symmetry_error > rtol_dp) then
         write(msg,*) "Input matrix is not hermitian. 0.5*max(abs(X-X.H)) = ", symmetry_error
         call stop_error(msg, module=this_module, procedure='sqrtm_cdp')
+      else if (symmetry_error > 10*atol_dp) then
+        write(msg,*) "Input matrix is not exactly hermitian. 0.5*max(X-X.T) = ", symmetry_error
+        call logger%log_warning(trim(msg), module=this_module, procedure='sqrtm_cdp')
       end if
 
       ! Perform svd

--- a/src/Utils.f90
+++ b/src/Utils.f90
@@ -512,13 +512,16 @@ contains
       real(sp) :: S(size(X,1))
       real(sp) :: U(size(X,1), size(X,1)), VT(size(X,1), size(X,1))
       integer :: i
+      real(sp) :: symmetry_error
       character(len=128) :: msg
 
       info = 0
 
       ! Check if the matrix is symmetric
-      if (.not. is_symmetric(X)) then
-        write(msg,*) "Input matrix is not symmetric."
+      symmetry_error = 0.5*maxval(X - transpose(X))
+      print *, "Input matrix is not symmetric. 0.5*max(X-X.T) = ", symmetry_error
+      if (symmetry_error > 10*atol_sp) then
+        write(msg,*) "Input matrix is not symmetric. 0.5*max(X-X.T) = ", symmetry_error
         call stop_error(msg, module=this_module, procedure='sqrtm_rsp')
       end if
 
@@ -745,13 +748,16 @@ contains
       real(dp) :: S(size(X,1))
       real(dp) :: U(size(X,1), size(X,1)), VT(size(X,1), size(X,1))
       integer :: i
+      real(dp) :: symmetry_error
       character(len=128) :: msg
 
       info = 0
 
       ! Check if the matrix is symmetric
-      if (.not. is_symmetric(X)) then
-        write(msg,*) "Input matrix is not symmetric."
+      symmetry_error = 0.5*maxval(X - transpose(X))
+      print *, "Input matrix is not symmetric. 0.5*max(X-X.T) = ", symmetry_error
+      if (symmetry_error > 10*atol_dp) then
+        write(msg,*) "Input matrix is not symmetric. 0.5*max(X-X.T) = ", symmetry_error
         call stop_error(msg, module=this_module, procedure='sqrtm_rdp')
       end if
 
@@ -973,13 +979,15 @@ contains
       real(sp) :: S(size(X,1))
       complex(sp) :: U(size(X,1), size(X,1)), VT(size(X,1), size(X,1))
       integer :: i
+      real(sp) :: symmetry_error
       character(len=128) :: msg
 
       info = 0
 
       ! Check if the matrix is hermitian
-      if (.not. is_hermitian(X)) then
-        write(msg,*) "Input matrix is not hermitian"
+      symmetry_error = 0.5*maxval(abs(X - conjg(transpose(X))))
+      if (symmetry_error > 10*atol_sp) then
+        write(msg,*) "Input matrix is not hermitian. 0.5*max(abs(X-X.H)) = ", symmetry_error
         call stop_error(msg, module=this_module, procedure='sqrtm_csp')
       end if
 
@@ -1201,13 +1209,15 @@ contains
       real(dp) :: S(size(X,1))
       complex(dp) :: U(size(X,1), size(X,1)), VT(size(X,1), size(X,1))
       integer :: i
+      real(dp) :: symmetry_error
       character(len=128) :: msg
 
       info = 0
 
       ! Check if the matrix is hermitian
-      if (.not. is_hermitian(X)) then
-        write(msg,*) "Input matrix is not hermitian"
+      symmetry_error = 0.5*maxval(abs(X - conjg(transpose(X))))
+      if (symmetry_error > 10*atol_dp) then
+        write(msg,*) "Input matrix is not hermitian. 0.5*max(abs(X-X.H)) = ", symmetry_error
         call stop_error(msg, module=this_module, procedure='sqrtm_cdp')
       end if
 

--- a/src/Utils.fypp
+++ b/src/Utils.fypp
@@ -422,7 +422,8 @@ contains
       ! Check if the matrix is symmetric
       symmetry_error = 0.5*maxval(X - transpose(X))
       if (symmetry_error > rtol_${kind}$) then
-        write(msg,*) "Input matrix is not symmetric. 0.5*max(X-X.T) = ", symmetry_error
+        write(msg,*) "Input matrix is not symmetric. 0.5*max(X-X.T) = ", &
+            & symmetry_error, ", tol = ", rtol_${kind}$
         call stop_error(msg, module=this_module, procedure='sqrtm_${type[0]}$${kind}$')
       else if (symmetry_error > 10*atol_${kind}$) then
         write(msg,*) "Input matrix is not exactly symmetric. 0.5*max(X-X.T) = ", symmetry_error
@@ -432,7 +433,8 @@ contains
       ! Check if the matrix is hermitian
       symmetry_error = 0.5*maxval(abs(X - conjg(transpose(X))))
       if (symmetry_error > rtol_${kind}$) then
-        write(msg,*) "Input matrix is not hermitian. 0.5*max(abs(X-X.H)) = ", symmetry_error
+        write(msg,*) "Input matrix is not hermitian. 0.5*max(abs(X-X.H)) = ", &
+            & symmetry_error, ", tol = ", rtol_${kind}$
         call stop_error(msg, module=this_module, procedure='sqrtm_${type[0]}$${kind}$')
       else if (symmetry_error > 10*atol_${kind}$) then
         write(msg,*) "Input matrix is not exactly hermitian. 0.5*max(X-X.T) = ", symmetry_error

--- a/src/Utils.fypp
+++ b/src/Utils.fypp
@@ -5,7 +5,7 @@ module lightkrylov_utils
     !-----     Standard Fortran Library     -----
     !--------------------------------------------
     use iso_fortran_env, only: output_unit
-    use stdlib_linalg, only: is_hermitian, is_symmetric, diag
+    use stdlib_linalg, only: is_hermitian, is_symmetric, diag, svd
     ! Matrix inversion.
     use stdlib_linalg_lapack, only: getrf, getri
     ! Eigenvalue problem (general + symmetric).
@@ -34,6 +34,7 @@ module lightkrylov_utils
     public :: eigh
     ! Compute matrix sqrt of input symmetric/hermitian positive definite matrix A
     public :: sqrtm
+    public :: sqrtm_eig
     ! Compute AX = XS where S is in Schur form.
     public :: schur
     ! Re-orders the Schur factorization of A.
@@ -91,6 +92,12 @@ module lightkrylov_utils
     interface sqrtm
         #:for kind, type in RC_KINDS_TYPES
         module procedure sqrtm_${type[0]}$${kind}$
+        #:endfor
+    end interface
+
+    interface sqrtm_eig
+        #:for kind, type in RC_KINDS_TYPES
+        module procedure sqrtm_eig_${type[0]}$${kind}$
         #:endfor
     end interface
 
@@ -395,6 +402,56 @@ contains
 
     subroutine sqrtm_${type[0]}$${kind}$(X, sqrtmX, info)
       !! Matrix-valued sqrt function for dense symmetric/hermitian positive (semi-)definite matrices
+      ${type}$, intent(inout) :: X(:,:)
+      !! Matrix of which to compute the sqrt
+      ${type}$, intent(out)   :: sqrtmX(size(X,1),size(X,1))
+      !! Return matrix
+      integer, intent(out) :: info
+      !! Information flag
+
+      ! internal
+      real(${kind}$) :: S(size(X,1))
+      ${type}$ :: U(size(X,1), size(X,1)), VT(size(X,1), size(X,1))
+      integer :: i
+      character(len=128) :: msg
+
+      info = 0
+
+      #:if type[0] == "r"
+      ! Check if the matrix is symmetric
+      if (.not. is_symmetric(X)) then
+        write(msg,*) "Input matrix is not symmetric."
+        call stop_error(msg, module=this_module, procedure='sqrtm_${type[0]}$${kind}$')
+      end if
+      #:else
+      ! Check if the matrix is hermitian
+      if (.not. is_hermitian(X)) then
+        write(msg,*) "Input matrix is not hermitian"
+        call stop_error(msg, module=this_module, procedure='sqrtm_${type[0]}$${kind}$')
+      end if
+      #:endif
+
+      ! Perform svd
+      call svd(X, S, U, VT)
+
+      ! Check if the matrix is positive definite (up to tol)
+      do i = 1, size(S)
+         if (S(i) .gt. 10*atol_${kind}$ ) then
+            S(i) = sqrt(S(i))
+         else
+            S(i) = zero_r${kind}$
+            info = 1
+         end if
+      end do
+
+      ! Reconstruct the square root matrix
+      sqrtmX = matmul(U, matmul(diag(S), VT))
+
+      return
+    end subroutine
+
+    subroutine sqrtm_eig_${type[0]}$${kind}$(X, sqrtmX, info)
+      !! Matrix-valued sqrt function for dense symmetric/hermitian positive (semi-)definite matrices
       ${type}$, intent(in)  :: X(:,:)
       !! Matrix of which to compute the sqrt
       ${type}$, intent(out) :: sqrtmX(size(X,1),size(X,1))
@@ -451,7 +508,6 @@ contains
 
       return
     end subroutine
-
     #:endfor
 
     !---------------------------------

--- a/src/Utils.fypp
+++ b/src/Utils.fypp
@@ -413,20 +413,24 @@ contains
       real(${kind}$) :: S(size(X,1))
       ${type}$ :: U(size(X,1), size(X,1)), VT(size(X,1), size(X,1))
       integer :: i
+      real(${kind}$) :: symmetry_error
       character(len=128) :: msg
 
       info = 0
 
       #:if type[0] == "r"
       ! Check if the matrix is symmetric
-      if (.not. is_symmetric(X)) then
-        write(msg,*) "Input matrix is not symmetric."
+      symmetry_error = 0.5*maxval(X - transpose(X))
+      print *, "Input matrix is not symmetric. 0.5*max(X-X.T) = ", symmetry_error
+      if (symmetry_error > 10*atol_${kind}$) then
+        write(msg,*) "Input matrix is not symmetric. 0.5*max(X-X.T) = ", symmetry_error
         call stop_error(msg, module=this_module, procedure='sqrtm_${type[0]}$${kind}$')
       end if
       #:else
       ! Check if the matrix is hermitian
-      if (.not. is_hermitian(X)) then
-        write(msg,*) "Input matrix is not hermitian"
+      symmetry_error = 0.5*maxval(abs(X - conjg(transpose(X))))
+      if (symmetry_error > 10*atol_${kind}$) then
+        write(msg,*) "Input matrix is not hermitian. 0.5*max(abs(X-X.H)) = ", symmetry_error
         call stop_error(msg, module=this_module, procedure='sqrtm_${type[0]}$${kind}$')
       end if
       #:endif

--- a/src/Utils.fypp
+++ b/src/Utils.fypp
@@ -421,7 +421,6 @@ contains
       #:if type[0] == "r"
       ! Check if the matrix is symmetric
       symmetry_error = 0.5*maxval(X - transpose(X))
-      print *, "Input matrix is not symmetric. 0.5*max(X-X.T) = ", symmetry_error
       if (symmetry_error > rtol_${kind}$) then
         write(msg,*) "Input matrix is not symmetric. 0.5*max(X-X.T) = ", symmetry_error
         call stop_error(msg, module=this_module, procedure='sqrtm_${type[0]}$${kind}$')

--- a/src/Utils.fypp
+++ b/src/Utils.fypp
@@ -25,7 +25,7 @@ module lightkrylov_utils
 
     character(len=128), parameter :: this_module = 'LightKrylov_Utils'
 
-    public :: assert_shape
+    public :: assert_shape, norml, log2
     ! Compute B = inv(A) in-place for dense matrices.
     public :: inv
     ! Compute AX = XD for general dense matrices.
@@ -39,17 +39,22 @@ module lightkrylov_utils
     ! Re-orders the Schur factorization of A.
     public :: ordschur
 
-    #:for kind, type in RC_KINDS_TYPES
-    #:if type[0] == "r"
-    public :: log2_${type[0]}$${kind}$
-    #:endif
-    public :: norml_${type[0]}$${kind}$
-    #:endfor
-
     interface assert_shape
         #:for kind, type in RC_KINDS_TYPES
         module procedure assert_shape_vector_${type[0]}$${kind}$
         module procedure assert_shape_matrix_${type[0]}$${kind}$
+        #:endfor
+    end interface
+
+    interface norml
+        #:for kind, type in RC_KINDS_TYPES
+        module procedure norml_${type[0]}$${kind}$
+        #:endfor
+    end interface
+
+    interface log2
+        #:for kind, type in REAL_KINDS_TYPES
+        module procedure log2_${type[0]}$${kind}$
         #:endfor
     end interface
 

--- a/src/Utils.fypp
+++ b/src/Utils.fypp
@@ -23,7 +23,7 @@ module lightkrylov_utils
     implicit none
     private
 
-    character*128, parameter :: this_module = 'LightKrylov_Utils'
+    character(len=128), parameter :: this_module = 'LightKrylov_Utils'
 
     public :: assert_shape
     ! Compute B = inv(A) in-place for dense matrices.
@@ -145,7 +145,7 @@ contains
         !! Name of the asserted vector.
         
         ! internals
-        character*128 :: msg
+        character(len=256) :: msg
 
         if(any(shape(v) /= size)) then
             write(msg, *) "In routine "//routine//" vector "//matname//" has illegal length ", shape(v), &
@@ -167,7 +167,7 @@ contains
         !! Name of the asserted matrix.
 
         ! internals
-        character*128 :: msg
+        character(len=256) :: msg
 
         if(any(shape(A) /= size)) then
             write(msg, *) "In routine "//routine//" matrix "//matname//" has illegal shape ", shape(A), &
@@ -401,7 +401,7 @@ contains
       real(${kind}$) :: lambda(size(X,1))
       ${type}$ :: V(size(X,1), size(X,1))
       integer :: i
-      character*128 :: msg
+      character(len=128) :: msg
 
       info = 0
 

--- a/src/Utils.fypp
+++ b/src/Utils.fypp
@@ -422,16 +422,22 @@ contains
       ! Check if the matrix is symmetric
       symmetry_error = 0.5*maxval(X - transpose(X))
       print *, "Input matrix is not symmetric. 0.5*max(X-X.T) = ", symmetry_error
-      if (symmetry_error > 10*atol_${kind}$) then
+      if (symmetry_error > rtol_${kind}$) then
         write(msg,*) "Input matrix is not symmetric. 0.5*max(X-X.T) = ", symmetry_error
         call stop_error(msg, module=this_module, procedure='sqrtm_${type[0]}$${kind}$')
+      else if (symmetry_error > 10*atol_${kind}$) then
+        write(msg,*) "Input matrix is not exactly symmetric. 0.5*max(X-X.T) = ", symmetry_error
+        call logger%log_warning(trim(msg), module=this_module, procedure='sqrtm_${type[0]}$${kind}$')
       end if
       #:else
       ! Check if the matrix is hermitian
       symmetry_error = 0.5*maxval(abs(X - conjg(transpose(X))))
-      if (symmetry_error > 10*atol_${kind}$) then
+      if (symmetry_error > rtol_${kind}$) then
         write(msg,*) "Input matrix is not hermitian. 0.5*max(abs(X-X.H)) = ", symmetry_error
         call stop_error(msg, module=this_module, procedure='sqrtm_${type[0]}$${kind}$')
+      else if (symmetry_error > 10*atol_${kind}$) then
+        write(msg,*) "Input matrix is not exactly hermitian. 0.5*max(X-X.T) = ", symmetry_error
+        call logger%log_warning(trim(msg), module=this_module, procedure='sqrtm_${type[0]}$${kind}$')
       end if
       #:endif
 

--- a/test/TestExpmlib.f90
+++ b/test/TestExpmlib.f90
@@ -789,8 +789,6 @@ contains
        end do
        ! reconstruct matrix
        A = matmul(sqrtmA, matmul(diag(abs(lambda)), transpose(sqrtmA)))
-       ! ensure it is exactly symmetric/hermitian
-       A = 0.5_sp*(A + transpose(A))
      
        ! compute matrix square root
        call sqrtm(A, sqrtmA, info)
@@ -811,7 +809,7 @@ contains
        !> Error type to be returned.
        type(error_type), allocatable, intent(out) :: error
        !> Problem dimension.
-       integer, parameter :: n = 5
+       integer, parameter :: n = 25
        !> Test matrix.
        real(sp) :: A(n, n)
        real(sp) :: sqrtmA(n, n)
@@ -831,8 +829,6 @@ contains
        lambda(n) = zero_rsp
        ! reconstruct matrix
        A = matmul(sqrtmA, matmul(diag(abs(lambda)), transpose(sqrtmA)))
-       ! ensure it is exactly symmetric/hermitian
-       A = 0.5_sp*(A + transpose(A))
     
        ! compute matrix square root
        call sqrtm(A, sqrtmA, info)
@@ -883,8 +879,6 @@ contains
        end do
        ! reconstruct matrix
        A = matmul(sqrtmA, matmul(diag(abs(lambda)), transpose(sqrtmA)))
-       ! ensure it is exactly symmetric/hermitian
-       A = 0.5_dp*(A + transpose(A))
      
        ! compute matrix square root
        call sqrtm(A, sqrtmA, info)
@@ -905,7 +899,7 @@ contains
        !> Error type to be returned.
        type(error_type), allocatable, intent(out) :: error
        !> Problem dimension.
-       integer, parameter :: n = 5
+       integer, parameter :: n = 25
        !> Test matrix.
        real(dp) :: A(n, n)
        real(dp) :: sqrtmA(n, n)
@@ -925,8 +919,6 @@ contains
        lambda(n) = zero_rdp
        ! reconstruct matrix
        A = matmul(sqrtmA, matmul(diag(abs(lambda)), transpose(sqrtmA)))
-       ! ensure it is exactly symmetric/hermitian
-       A = 0.5_dp*(A + transpose(A))
     
        ! compute matrix square root
        call sqrtm(A, sqrtmA, info)
@@ -978,8 +970,6 @@ contains
        end do
        ! reconstruct matrix
        A = matmul(sqrtmA, matmul(diag(abs(lambda)), conjg(transpose(sqrtmA))))
-       ! ensure it is exactly symmetric/hermitian
-       A = 0.5_sp*(A + conjg(transpose(A)))
      
        ! compute matrix square root
        call sqrtm(A, sqrtmA, info)
@@ -1000,7 +990,7 @@ contains
        !> Error type to be returned.
        type(error_type), allocatable, intent(out) :: error
        !> Problem dimension.
-       integer, parameter :: n = 5
+       integer, parameter :: n = 25
        !> Test matrix.
        complex(sp) :: A(n, n)
        complex(sp) :: sqrtmA(n, n)
@@ -1021,8 +1011,6 @@ contains
        lambda(n) = zero_rsp
        ! reconstruct matrix
        A = matmul(sqrtmA, matmul(diag(abs(lambda)), conjg(transpose(sqrtmA))))
-       ! ensure it is exactly symmetric/hermitian
-       A = 0.5_sp*(A + conjg(transpose(A)))
     
        ! compute matrix square root
        call sqrtm(A, sqrtmA, info)
@@ -1074,8 +1062,6 @@ contains
        end do
        ! reconstruct matrix
        A = matmul(sqrtmA, matmul(diag(abs(lambda)), conjg(transpose(sqrtmA))))
-       ! ensure it is exactly symmetric/hermitian
-       A = 0.5_dp*(A + conjg(transpose(A)))
      
        ! compute matrix square root
        call sqrtm(A, sqrtmA, info)
@@ -1096,7 +1082,7 @@ contains
        !> Error type to be returned.
        type(error_type), allocatable, intent(out) :: error
        !> Problem dimension.
-       integer, parameter :: n = 5
+       integer, parameter :: n = 25
        !> Test matrix.
        complex(dp) :: A(n, n)
        complex(dp) :: sqrtmA(n, n)
@@ -1117,8 +1103,6 @@ contains
        lambda(n) = zero_rdp
        ! reconstruct matrix
        A = matmul(sqrtmA, matmul(diag(abs(lambda)), conjg(transpose(sqrtmA))))
-       ! ensure it is exactly symmetric/hermitian
-       A = 0.5_dp*(A + conjg(transpose(A)))
     
        ! compute matrix square root
        call sqrtm(A, sqrtmA, info)

--- a/test/TestExpmlib.fypp
+++ b/test/TestExpmlib.fypp
@@ -268,12 +268,8 @@ contains
        ! reconstruct matrix
        #:if type[0] == "r"
        A = matmul(sqrtmA, matmul(diag(abs(lambda)), transpose(sqrtmA)))
-       ! ensure it is exactly symmetric/hermitian
-       A = 0.5_${kind}$*(A + transpose(A))
        #:else
        A = matmul(sqrtmA, matmul(diag(abs(lambda)), conjg(transpose(sqrtmA))))
-       ! ensure it is exactly symmetric/hermitian
-       A = 0.5_${kind}$*(A + conjg(transpose(A)))
        #:endif
      
        ! compute matrix square root
@@ -301,7 +297,7 @@ contains
        !> Error type to be returned.
        type(error_type), allocatable, intent(out) :: error
        !> Problem dimension.
-       integer, parameter :: n = 5
+       integer, parameter :: n = 25
        !> Test matrix.
        ${type}$ :: A(n, n)
        ${type}$ :: sqrtmA(n, n)
@@ -331,12 +327,8 @@ contains
        ! reconstruct matrix
        #:if type[0] == "r"
        A = matmul(sqrtmA, matmul(diag(abs(lambda)), transpose(sqrtmA)))
-       ! ensure it is exactly symmetric/hermitian
-       A = 0.5_${kind}$*(A + transpose(A))
        #:else
        A = matmul(sqrtmA, matmul(diag(abs(lambda)), conjg(transpose(sqrtmA))))
-       ! ensure it is exactly symmetric/hermitian
-       A = 0.5_${kind}$*(A + conjg(transpose(A)))
        #:endif
     
        ! compute matrix square root


### PR DESCRIPTION
1. Added and deployed orthogonalization/normalization wrappers throughout the code.

New definitions:
```
orthogonalize_against_basis
orthonormalize_basis
```

2. Multiple dispatch wrappers for `norml` and `log2`. `innerprod`, `linear_combination`, `axpby_basis` and `copy_basis` exported directly in `LightKrylov`.

3. Switch from eigenvalue- to svd-based algorithm for `sqrtm`. Alternative kept for now.