### PR TITLE
Updates since pre-release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           #   toolchain: {compiler: intel-classic, version: '2021.10', flags: ["/fpp /O3"]}
           # - os: windows-latest
           #   toolchain: {compiler: intel, version: '2024.1', flags: ["/fpp /O3"]}
-          - os: macos-12
+          - os: macos-13
             toolchain: {compiler: gcc, version: 13, flags: ['-cpp -O3 -march=native -mtune=native']}
           # - os: macos-12
           #   toolchain: {compiler: intel-classic, version: '2021.10', flags: ['-fpp -O3 -xhost']}

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@
 # Log files
 *.log
 *.npy
+*.txt
 
 # swap files
 *~

--- a/example/ginzburg_landau/Ginzburg_Landau.f90
+++ b/example/ginzburg_landau/Ginzburg_Landau.f90
@@ -52,7 +52,7 @@ module Ginzburg_Landau
    !------------------------------------------
  
    type, extends(abstract_linop_cdp), public :: exponential_prop
-      real(kind=wp) :: tau ! Integration time.
+      real(kind=wp), public :: tau ! Integration time.
     contains
       private
       procedure, pass(self), public :: matvec => direct_solver

--- a/example/ginzburg_landau/Ginzburg_Landau.f90
+++ b/example/ginzburg_landau/Ginzburg_Landau.f90
@@ -59,7 +59,18 @@ module Ginzburg_Landau
       procedure, pass(self), public :: rmatvec => adjoint_solver
    end type exponential_prop
 
+   interface exponential_prop
+      module function construct_exptA(tau) result(A)
+         real(kind=wp), intent(in) :: tau
+         type(exponential_prop) :: A
+      end function
+   end interface
+
 contains
+
+   module procedure construct_exptA
+      A%tau = tau
+   end procedure
 
    !========================================================================
    !========================================================================

--- a/example/ginzburg_landau/Ginzburg_Landau.f90
+++ b/example/ginzburg_landau/Ginzburg_Landau.f90
@@ -5,39 +5,39 @@ module Ginzburg_Landau
    use LightKrylov
    use LightKrylov, only: wp => dp
    ! Standard Library.
-   use stdlib_math, only : linspace
-   use stdlib_optval, only : optval
+   use stdlib_math, only: linspace
+   use stdlib_optval, only: optval
    implicit none
- 
+
    character*128, parameter, private :: this_module = 'Ginzburg_Landau'
- 
+
    public :: nx
    public :: initialize_parameters
- 
+
    !------------------------------
    !-----     PARAMETERS     -----
    !------------------------------
- 
+
    ! Mesh related parameters.
-   real(kind=wp), parameter :: L  = 200.0_wp ! Domain length
-   integer      , parameter :: nx = 512      ! Number of grid points (excluding boundaries).
-   real(kind=wp), parameter :: dx = L/(nx+1) ! Grid size.
- 
+   real(kind=wp), parameter :: L = 200.0_wp ! Domain length
+   integer, parameter :: nx = 512      ! Number of grid points (excluding boundaries).
+   real(kind=wp), parameter :: dx = L/(nx + 1) ! Grid size.
+
    ! Physical parameters.
-   complex(kind=wp), parameter :: nu    = cmplx(2.0_wp, 0.2_wp, kind=wp)
+   complex(kind=wp), parameter :: nu = cmplx(2.0_wp, 0.2_wp, kind=wp)
    complex(kind=wp), parameter :: gamma = cmplx(1.0_wp, -1.0_wp, kind=wp)
-   real(kind=wp)   , parameter :: mu_0  = 0.38_wp
-   real(kind=wp)   , parameter :: c_mu  = 0.2_wp
-   real(kind=wp)   , parameter :: mu_2  = -0.01_wp
+   real(kind=wp), parameter :: mu_0 = 0.38_wp
+   real(kind=wp), parameter :: c_mu = 0.2_wp
+   real(kind=wp), parameter :: mu_2 = -0.01_wp
    real(kind=wp)               :: mu(1:nx)
- 
+
    !-------------------------------------------
    !-----     LIGHTKRYLOV VECTOR TYPE     -----
    !-------------------------------------------
- 
+
    type, extends(abstract_vector_cdp), public :: state_vector
       complex(kind=wp) :: state(nx) = 0.0_wp
-    contains
+   contains
       private
       procedure, pass(self), public :: zero
       procedure, pass(self), public :: dot
@@ -46,21 +46,21 @@ module Ginzburg_Landau
       procedure, pass(self), public :: rand
       procedure, pass(self), public :: get_size
    end type state_vector
- 
+
    !------------------------------------------
    !-----     EXPONENTIAL PROPAGATOR     -----
    !------------------------------------------
- 
+
    type, extends(abstract_linop_cdp), public :: exponential_prop
       real(kind=wp), public :: tau ! Integration time.
-    contains
+   contains
       private
       procedure, pass(self), public :: matvec => direct_solver
       procedure, pass(self), public :: rmatvec => adjoint_solver
    end type exponential_prop
- 
- contains
- 
+
+contains
+
    !========================================================================
    !========================================================================
    !=====                                                              =====
@@ -68,186 +68,181 @@ module Ginzburg_Landau
    !=====                                                              =====
    !========================================================================
    !========================================================================
- 
+
    !--------------------------------------------------------------
    !-----     CONSTRUCT THE MESH AND PHYSICAL PARAMETERS     -----
    !--------------------------------------------------------------
- 
+
    subroutine initialize_parameters()
-     implicit none
-     ! Mesh array.
-     real(kind=wp), allocatable :: x(:)
- 
-     ! Construct mesh.
-     x = linspace(-L/2, L/2, nx+2)
- 
-     ! Construct mu(x)
-     mu(:) = (mu_0 - c_mu**2) + (mu_2 / 2.0_wp) * x(2:nx+1)**2
- 
-     return
+      implicit none
+      ! Mesh array.
+      real(kind=wp), allocatable :: x(:)
+
+      ! Construct mesh.
+      x = linspace(-L/2, L/2, nx + 2)
+
+      ! Construct mu(x)
+      mu(:) = (mu_0 - c_mu**2) + (mu_2/2.0_wp)*x(2:nx + 1)**2
+
+      return
    end subroutine initialize_parameters
- 
- 
+
    !---------------------------------------------------------
    !-----      LINEARIZED GINZBURG-LANDAU EQUATIONS     -----
    !---------------------------------------------------------
- 
+
    subroutine rhs(me, t, x, f)
-     ! Time-integrator.
-     class(rk_class), intent(inout)             :: me
-     ! Current time.
-     real(kind=wp)  , intent(in)                :: t
-     ! State vector.
-     real(kind=wp)  , dimension(:), intent(in)  :: x
-     ! Time-derivative.
-     real(kind=wp)  , dimension(:), intent(out) :: f
- 
-     ! Internal variables.
-     integer :: i, j, k
-     real(kind=wp), dimension(nx) :: u, du
-     real(kind=wp), dimension(nx) :: v, dv
-     real(kind=wp)                :: d2u, d2v, cu, cv
- 
-     ! Sets the internal variables.
-     f = 0.0_wp
-     u = x(1:nx)      ; du = f(1:nx)
-     v = x(nx+1:2*nx) ; dv = f(nx+1:2*nx)
- 
-     !---------------------------------------------------
-     !-----     Linear Ginzburg Landau Equation     -----
-     !---------------------------------------------------
- 
-     ! Left most boundary points.
-     cu = u(2) / (2*dx) ; cv = v(2) / (2*dx)
-     du(1) = -(real(nu)*cu - aimag(nu)*cv) ! Convective term.
-     dv(1) = -(aimag(nu)*cu + real(nu)*cv) ! Convective term.
- 
-     d2u = (u(2) - 2*u(1)) / dx**2 ; d2v = (v(2) - 2*v(1)) / dx**2
-     du(1) = du(1) + real(gamma)*d2u - aimag(gamma)*d2v ! Diffusion term.
-     dv(1) = dv(1) + aimag(gamma)*d2u + real(gamma)*d2v ! Diffusion term.
- 
-     du(1) = du(1) + mu(1)*u(1) ! Non-parallel term.
-     dv(1) = dv(1) + mu(1)*v(1) ! Non-parallel term.
- 
-     ! Interior nodes.
-     do i = 2, nx-1
-        ! Convective term.
-        cu = (u(i+1) - u(i-1)) / (2*dx)
-        cv = (v(i+1) - v(i-1)) / (2*dx)
-        du(i) = -(real(nu)*cu - aimag(nu)*cv)
-        dv(i) = -(aimag(nu)*cu + real(nu)*cv)
- 
-        ! Diffusion term.
-        d2u = (u(i+1) - 2*u(i) + u(i-1)) / dx**2
-        d2v = (v(i+1) - 2*v(i) + v(i-1)) / dx**2
-        du(i) = du(i) + real(gamma)*d2u - aimag(gamma)*d2v
-        dv(i) = dv(i) + aimag(gamma)*d2u + real(gamma)*d2v
- 
-        ! Non-parallel term.
-        du(i) = du(i) + mu(i)*u(i)
-        dv(i) = dv(i) + mu(i)*v(i)
-     enddo
- 
-     ! Right most boundary points.
-     cu = -u(nx-1) / (2*dx) ; cv = -v(nx-1) / (2*dx)
-     du(nx) = -(real(nu)*cu - aimag(nu)*cv) ! Convective term.
-     dv(nx) = -(aimag(nu)*cu + real(nu)*cv) ! Convective term.
- 
-     d2u = (-2*u(nx) + u(nx-1)) / dx**2 ; d2v = (-2*v(nx) + v(nx-1)) / dx**2
-     du(nx) = du(nx) + real(gamma)*d2u - aimag(gamma)*d2v ! Diffusion term.
-     dv(nx) = dv(nx) + aimag(gamma)*d2u + real(gamma)*d2v ! Diffusion term.
- 
-     du(nx) = du(nx) + mu(nx)*u(nx) ! Non-parallel term.
-     dv(nx) = dv(nx) + mu(nx)*v(nx) ! Non-parallel term.
- 
-     ! Copy results to the output array.
-     f(1:nx) = du ; f(nx+1:2*nx) = dv
- 
-     return
+      ! Time-integrator.
+      class(rk_class), intent(inout)             :: me
+      ! Current time.
+      real(kind=wp), intent(in)                :: t
+      ! State vector.
+      real(kind=wp), dimension(:), intent(in)  :: x
+      ! Time-derivative.
+      real(kind=wp), dimension(:), intent(out) :: f
+
+      ! Internal variables.
+      integer :: i, j, k
+      real(kind=wp), dimension(nx) :: u, du
+      real(kind=wp), dimension(nx) :: v, dv
+      real(kind=wp)                :: d2u, d2v, cu, cv
+
+      ! Sets the internal variables.
+      f = 0.0_wp
+      u = x(1:nx); du = f(1:nx)
+      v = x(nx + 1:2*nx); dv = f(nx + 1:2*nx)
+
+      !---------------------------------------------------
+      !-----     Linear Ginzburg Landau Equation     -----
+      !---------------------------------------------------
+
+      ! Left most boundary points.
+      cu = u(2)/(2*dx); cv = v(2)/(2*dx)
+      du(1) = -(real(nu)*cu - aimag(nu)*cv) ! Convective term.
+      dv(1) = -(aimag(nu)*cu + real(nu)*cv) ! Convective term.
+
+      d2u = (u(2) - 2*u(1))/dx**2; d2v = (v(2) - 2*v(1))/dx**2
+      du(1) = du(1) + real(gamma)*d2u - aimag(gamma)*d2v ! Diffusion term.
+      dv(1) = dv(1) + aimag(gamma)*d2u + real(gamma)*d2v ! Diffusion term.
+
+      du(1) = du(1) + mu(1)*u(1) ! Non-parallel term.
+      dv(1) = dv(1) + mu(1)*v(1) ! Non-parallel term.
+
+      ! Interior nodes.
+      do i = 2, nx - 1
+         ! Convective term.
+         cu = (u(i + 1) - u(i - 1))/(2*dx)
+         cv = (v(i + 1) - v(i - 1))/(2*dx)
+         du(i) = -(real(nu)*cu - aimag(nu)*cv)
+         dv(i) = -(aimag(nu)*cu + real(nu)*cv)
+
+         ! Diffusion term.
+         d2u = (u(i + 1) - 2*u(i) + u(i - 1))/dx**2
+         d2v = (v(i + 1) - 2*v(i) + v(i - 1))/dx**2
+         du(i) = du(i) + real(gamma)*d2u - aimag(gamma)*d2v
+         dv(i) = dv(i) + aimag(gamma)*d2u + real(gamma)*d2v
+
+         ! Non-parallel term.
+         du(i) = du(i) + mu(i)*u(i)
+         dv(i) = dv(i) + mu(i)*v(i)
+      end do
+
+      ! Right most boundary points.
+      cu = -u(nx - 1)/(2*dx); cv = -v(nx - 1)/(2*dx)
+      du(nx) = -(real(nu)*cu - aimag(nu)*cv) ! Convective term.
+      dv(nx) = -(aimag(nu)*cu + real(nu)*cv) ! Convective term.
+
+      d2u = (-2*u(nx) + u(nx - 1))/dx**2; d2v = (-2*v(nx) + v(nx - 1))/dx**2
+      du(nx) = du(nx) + real(gamma)*d2u - aimag(gamma)*d2v ! Diffusion term.
+      dv(nx) = dv(nx) + aimag(gamma)*d2u + real(gamma)*d2v ! Diffusion term.
+
+      du(nx) = du(nx) + mu(nx)*u(nx) ! Non-parallel term.
+      dv(nx) = dv(nx) + mu(nx)*v(nx) ! Non-parallel term.
+
+      ! Copy results to the output array.
+      f(1:nx) = du; f(nx + 1:2*nx) = dv
+
+      return
    end subroutine rhs
- 
+
    !-----------------------------------------------------------
    !-----     Adjoint linear Ginzburg-Landau equation     -----
    !-----------------------------------------------------------
- 
+
    subroutine adjoint_rhs(me, t, x, f)
-     ! Time-integrator.
-     class(rk_class), intent(inout)             :: me
-     ! Current time.
-     real(kind=wp)  , intent(in)                :: t
-     ! State vector.
-     real(kind=wp)  , dimension(:), intent(in)  :: x
-     ! Time-derivative.
-     real(kind=wp)  , dimension(:), intent(out) :: f
- 
-     ! Internal variables.
-     integer :: i, j, k
-     real(kind=wp), dimension(nx) :: u, du
-     real(kind=wp), dimension(nx) :: v, dv
-     real(kind=wp)                :: d2u, d2v, cu, cv
- 
-     ! Sets the internal variables.
-     f = 0.0_wp
-     u = x(1:nx)      ; du = f(1:nx)
-     v = x(nx+1:2*nx) ; dv = f(nx+1:2*nx)
- 
-     !---------------------------------------------------
-     !-----     Linear Ginzburg Landau Equation     -----
-     !---------------------------------------------------
- 
-     ! Left most boundary points.
-     cu = u(2) / (2*dx) ; cv = v(2) / (2*dx)
-     du(1) = (real(nu)*cu + aimag(nu)*cv) ! Convective term.
-     dv(1) = (-aimag(nu)*cu + real(nu)*cv) ! Convective term.
- 
-     d2u = (u(2) - 2*u(1)) / dx**2 ; d2v = (v(2) - 2*v(1)) / dx**2
-     du(1) = du(1) + real(gamma)*d2u + aimag(gamma)*d2v ! Diffusion term.
-     dv(1) = dv(1) - aimag(gamma)*d2u + real(gamma)*d2v ! Diffusion term.
- 
-     du(1) = du(1) + mu(1)*u(1) ! Non-parallel term.
-     dv(1) = dv(1) + mu(1)*v(1) ! Non-parallel term.
- 
-     ! Interior nodes.
-     do i = 2, nx-1
-        ! Convective term.
-        cu = (u(i+1) - u(i-1)) / (2*dx)
-        cv = (v(i+1) - v(i-1)) / (2*dx)
-        du(i) = (real(nu)*cu + aimag(nu)*cv)
-        dv(i) = (-aimag(nu)*cu + real(nu)*cv)
- 
-        ! Diffusion term.
-        d2u = (u(i+1) - 2*u(i) + u(i-1)) / dx**2
-        d2v = (v(i+1) - 2*v(i) + v(i-1)) / dx**2
-        du(i) = du(i) + real(gamma)*d2u + aimag(gamma)*d2v
-        dv(i) = dv(i) - aimag(gamma)*d2u + real(gamma)*d2v
- 
-        ! Non-parallel term.
-        du(i) = du(i) + mu(i)*u(i)
-        dv(i) = dv(i) + mu(i)*v(i)
-     enddo
- 
-     ! Right most boundary points.
-     cu = -u(nx-1) / (2*dx) ; cv = -v(nx-1) / (2*dx)
-     du(nx) = (real(nu)*cu + aimag(nu)*cv) ! Convective term.
-     dv(nx) = (-aimag(nu)*cu + real(nu)*cv) ! Convective term.
- 
-     d2u = (-2*u(nx) + u(nx-1)) / dx**2 ; d2v = (-2*v(nx) + v(nx-1)) / dx**2
-     du(nx) = du(nx) + real(gamma)*d2u + aimag(gamma)*d2v ! Diffusion term.
-     dv(nx) = dv(nx) - aimag(gamma)*d2u + real(gamma)*d2v ! Diffusion term.
- 
-     du(nx) = du(nx) + mu(nx)*u(nx) ! Non-parallel term.
-     dv(nx) = dv(nx) + mu(nx)*v(nx) ! Non-parallel term.
- 
-     ! Copy results to the output array.
-     f(1:nx) = du ; f(nx+1:2*nx) = dv
- 
-     return
+      ! Time-integrator.
+      class(rk_class), intent(inout)             :: me
+      ! Current time.
+      real(kind=wp), intent(in)                :: t
+      ! State vector.
+      real(kind=wp), dimension(:), intent(in)  :: x
+      ! Time-derivative.
+      real(kind=wp), dimension(:), intent(out) :: f
+
+      ! Internal variables.
+      integer :: i, j, k
+      real(kind=wp), dimension(nx) :: u, du
+      real(kind=wp), dimension(nx) :: v, dv
+      real(kind=wp)                :: d2u, d2v, cu, cv
+
+      ! Sets the internal variables.
+      f = 0.0_wp
+      u = x(1:nx); du = f(1:nx)
+      v = x(nx + 1:2*nx); dv = f(nx + 1:2*nx)
+
+      !---------------------------------------------------
+      !-----     Linear Ginzburg Landau Equation     -----
+      !---------------------------------------------------
+
+      ! Left most boundary points.
+      cu = u(2)/(2*dx); cv = v(2)/(2*dx)
+      du(1) = (real(nu)*cu + aimag(nu)*cv) ! Convective term.
+      dv(1) = (-aimag(nu)*cu + real(nu)*cv) ! Convective term.
+
+      d2u = (u(2) - 2*u(1))/dx**2; d2v = (v(2) - 2*v(1))/dx**2
+      du(1) = du(1) + real(gamma)*d2u + aimag(gamma)*d2v ! Diffusion term.
+      dv(1) = dv(1) - aimag(gamma)*d2u + real(gamma)*d2v ! Diffusion term.
+
+      du(1) = du(1) + mu(1)*u(1) ! Non-parallel term.
+      dv(1) = dv(1) + mu(1)*v(1) ! Non-parallel term.
+
+      ! Interior nodes.
+      do i = 2, nx - 1
+         ! Convective term.
+         cu = (u(i + 1) - u(i - 1))/(2*dx)
+         cv = (v(i + 1) - v(i - 1))/(2*dx)
+         du(i) = (real(nu)*cu + aimag(nu)*cv)
+         dv(i) = (-aimag(nu)*cu + real(nu)*cv)
+
+         ! Diffusion term.
+         d2u = (u(i + 1) - 2*u(i) + u(i - 1))/dx**2
+         d2v = (v(i + 1) - 2*v(i) + v(i - 1))/dx**2
+         du(i) = du(i) + real(gamma)*d2u + aimag(gamma)*d2v
+         dv(i) = dv(i) - aimag(gamma)*d2u + real(gamma)*d2v
+
+         ! Non-parallel term.
+         du(i) = du(i) + mu(i)*u(i)
+         dv(i) = dv(i) + mu(i)*v(i)
+      end do
+
+      ! Right most boundary points.
+      cu = -u(nx - 1)/(2*dx); cv = -v(nx - 1)/(2*dx)
+      du(nx) = (real(nu)*cu + aimag(nu)*cv) ! Convective term.
+      dv(nx) = (-aimag(nu)*cu + real(nu)*cv) ! Convective term.
+
+      d2u = (-2*u(nx) + u(nx - 1))/dx**2; d2v = (-2*v(nx) + v(nx - 1))/dx**2
+      du(nx) = du(nx) + real(gamma)*d2u + aimag(gamma)*d2v ! Diffusion term.
+      dv(nx) = dv(nx) - aimag(gamma)*d2u + real(gamma)*d2v ! Diffusion term.
+
+      du(nx) = du(nx) + mu(nx)*u(nx) ! Non-parallel term.
+      dv(nx) = dv(nx) + mu(nx)*v(nx) ! Non-parallel term.
+
+      ! Copy results to the output array.
+      f(1:nx) = du; f(nx + 1:2*nx) = dv
+
+      return
    end subroutine adjoint_rhs
- 
- 
- 
- 
- 
+
    !=========================================================
    !=========================================================
    !=====                                               =====
@@ -255,134 +250,134 @@ module Ginzburg_Landau
    !=====                                               =====
    !=========================================================
    !=========================================================
- 
+
    !----------------------------------------------------
    !-----     TYPE-BOUND PROCEDURE FOR VECTORS     -----
    !----------------------------------------------------
- 
+
    subroutine zero(self)
-     class(state_vector), intent(inout) :: self
-     self%state = 0.0_wp
-     return
+      class(state_vector), intent(inout) :: self
+      self%state = 0.0_wp
+      return
    end subroutine zero
- 
+
    complex(kind=wp) function dot(self, vec) result(alpha)
-     class(state_vector)   , intent(in) :: self
-     class(abstract_vector_cdp), intent(in) :: vec
-     select type(vec)
-     type is(state_vector)
-        alpha = dot_product(self%state, vec%state)
-     end select
-     return
+      class(state_vector), intent(in) :: self
+      class(abstract_vector_cdp), intent(in) :: vec
+      select type (vec)
+      type is (state_vector)
+         alpha = dot_product(self%state, vec%state)
+      end select
+      return
    end function dot
- 
+
    subroutine scal(self, alpha)
-     class(state_vector), intent(inout) :: self
-     complex(kind=wp)      , intent(in)    :: alpha
-     self%state = self%state * alpha
-     return
+      class(state_vector), intent(inout) :: self
+      complex(kind=wp), intent(in)    :: alpha
+      self%state = self%state*alpha
+      return
    end subroutine scal
- 
+
    subroutine axpby(self, alpha, vec, beta)
-     class(state_vector)   , intent(inout) :: self
-     class(abstract_vector_cdp), intent(in)    :: vec
-     complex(kind=wp)         , intent(in)    :: alpha, beta
-     select type(vec)
-     type is(state_vector)
-        self%state = alpha*self%state + beta*vec%state
-     end select
-     return
+      class(state_vector), intent(inout) :: self
+      class(abstract_vector_cdp), intent(in)    :: vec
+      complex(kind=wp), intent(in)    :: alpha, beta
+      select type (vec)
+      type is (state_vector)
+         self%state = alpha*self%state + beta*vec%state
+      end select
+      return
    end subroutine axpby
- 
+
    integer function get_size(self) result(N)
-     class(state_vector), intent(in) :: self
-     N = nx
-     return
+      class(state_vector), intent(in) :: self
+      N = nx
+      return
    end function get_size
- 
+
    subroutine rand(self, ifnorm)
-     class(state_vector), intent(inout) :: self
-     logical, optional,   intent(in)    :: ifnorm
-     real(kind=wp) :: tmp(nx, 2)
-     ! internals
-     logical :: normalize
-     real(kind=wp) :: alpha
-     normalize = optval(ifnorm,.true.)
-     call random_number(tmp)
-     self%state%re = tmp(:, 1) ; self%state%im = tmp(:, 2)
-     if (normalize) then
-       alpha = self%norm()
-       call self%scal(cmplx(1.0_wp, 0.0_wp, kind=wp)/alpha)
-     endif
-     return
+      class(state_vector), intent(inout) :: self
+      logical, optional, intent(in)    :: ifnorm
+      real(kind=wp) :: tmp(nx, 2)
+      ! internals
+      logical :: normalize
+      real(kind=wp) :: alpha
+      normalize = optval(ifnorm, .true.)
+      call random_number(tmp)
+      self%state%re = tmp(:, 1); self%state%im = tmp(:, 2)
+      if (normalize) then
+         alpha = self%norm()
+         call self%scal(cmplx(1.0_wp, 0.0_wp, kind=wp)/alpha)
+      end if
+      return
    end subroutine rand
- 
+
    !------------------------------------------------------------------------
    !-----     TYPE-BOUND PROCEDURES FOR THE EXPONENTIAL PROPAGATOR     -----
    !------------------------------------------------------------------------
- 
+
    subroutine direct_solver(self, vec_in, vec_out)
-     ! Linear Operator.
-     class(exponential_prop), intent(inout)  :: self
-     ! Input vector.
-     class(abstract_vector_cdp) , intent(in)  :: vec_in
-     ! Output vector.
-     class(abstract_vector_cdp) , intent(out) :: vec_out
- 
-     ! Time-integrator.
-     type(rks54_class) :: prop
-     real(kind=wp)     :: dt = 1.0_wp
-     real(kind=wp)     :: state_ic(2*nx), state_fc(2*nx)
- 
-     select type(vec_in)
-     type is(state_vector)
-        select type(vec_out)
-        type is(state_vector)
-           ! Get state vector.
-           state_ic(:nx) = vec_in%state%re
-           state_ic(nx+1:) = vec_in%state%im
-           ! Initialize propagator.
-           call prop%initialize(n=2*nx, f=rhs)
-           ! Integrate forward in time.
-           call prop%integrate(0.0_wp, state_ic, dt, self%tau, state_fc)
-           ! Pass-back the state vector.
-           vec_out%state%re = state_fc(:nx)
-           vec_out%state%im = state_fc(nx+1:)
-        end select
-     end select
-     return
+      ! Linear Operator.
+      class(exponential_prop), intent(inout)  :: self
+      ! Input vector.
+      class(abstract_vector_cdp), intent(in)  :: vec_in
+      ! Output vector.
+      class(abstract_vector_cdp), intent(out) :: vec_out
+
+      ! Time-integrator.
+      type(rks54_class) :: prop
+      real(kind=wp)     :: dt = 1.0_wp
+      real(kind=wp)     :: state_ic(2*nx), state_fc(2*nx)
+
+      select type (vec_in)
+      type is (state_vector)
+         select type (vec_out)
+         type is (state_vector)
+            ! Get state vector.
+            state_ic(:nx) = vec_in%state%re
+            state_ic(nx + 1:) = vec_in%state%im
+            ! Initialize propagator.
+            call prop%initialize(n=2*nx, f=rhs)
+            ! Integrate forward in time.
+            call prop%integrate(0.0_wp, state_ic, dt, self%tau, state_fc)
+            ! Pass-back the state vector.
+            vec_out%state%re = state_fc(:nx)
+            vec_out%state%im = state_fc(nx + 1:)
+         end select
+      end select
+      return
    end subroutine direct_solver
- 
+
    subroutine adjoint_solver(self, vec_in, vec_out)
-     ! Linear Operator.
-     class(exponential_prop), intent(inout)  :: self
-     ! Input vector.
-     class(abstract_vector_cdp) , intent(in)  :: vec_in
-     ! Output vector.
-     class(abstract_vector_cdp) , intent(out) :: vec_out
- 
-     ! Time-integrator.
-     type(rks54_class) :: prop
-     real(kind=wp)     :: dt = 1.0_wp
-     real(kind=wp)     :: state_ic(2*nx), state_fc(2*nx)
- 
-     select type(vec_in)
-     type is(state_vector)
-        select type(vec_out)
-        type is(state_vector)
-           ! Get the state.
-           state_ic(:nx) = vec_in%state%re
-           state_fc(nx+1:) = vec_in%state%im
-           ! Initialize propagator.
-           call prop%initialize(n=2*nx, f=adjoint_rhs)
-           ! Integrate forward in time.
-           call prop%integrate(0.0_wp, state_ic, dt, self%tau, state_fc)
-           ! Pass-back the state.
-           vec_out%state%re = state_fc(:nx)
-           vec_out%state%im = state_fc(nx+1:)
-        end select
-     end select
-     return
+      ! Linear Operator.
+      class(exponential_prop), intent(inout)  :: self
+      ! Input vector.
+      class(abstract_vector_cdp), intent(in)  :: vec_in
+      ! Output vector.
+      class(abstract_vector_cdp), intent(out) :: vec_out
+
+      ! Time-integrator.
+      type(rks54_class) :: prop
+      real(kind=wp)     :: dt = 1.0_wp
+      real(kind=wp)     :: state_ic(2*nx), state_fc(2*nx)
+
+      select type (vec_in)
+      type is (state_vector)
+         select type (vec_out)
+         type is (state_vector)
+            ! Get the state.
+            state_ic(:nx) = vec_in%state%re
+            state_fc(nx + 1:) = vec_in%state%im
+            ! Initialize propagator.
+            call prop%initialize(n=2*nx, f=adjoint_rhs)
+            ! Integrate forward in time.
+            call prop%integrate(0.0_wp, state_ic, dt, self%tau, state_fc)
+            ! Pass-back the state.
+            vec_out%state%re = state_fc(:nx)
+            vec_out%state%im = state_fc(nx + 1:)
+         end select
+      end select
+      return
    end subroutine adjoint_solver
- 
- end module Ginzburg_Landau
+
+end module Ginzburg_Landau

--- a/example/ginzburg_landau/Ginzburg_Landau.f90
+++ b/example/ginzburg_landau/Ginzburg_Landau.f90
@@ -323,7 +323,7 @@ module Ginzburg_Landau
  
    subroutine direct_solver(self, vec_in, vec_out)
      ! Linear Operator.
-     class(exponential_prop), intent(in)  :: self
+     class(exponential_prop), intent(inout)  :: self
      ! Input vector.
      class(abstract_vector_cdp) , intent(in)  :: vec_in
      ! Output vector.
@@ -355,7 +355,7 @@ module Ginzburg_Landau
  
    subroutine adjoint_solver(self, vec_in, vec_out)
      ! Linear Operator.
-     class(exponential_prop), intent(in)  :: self
+     class(exponential_prop), intent(inout)  :: self
      ! Input vector.
      class(abstract_vector_cdp) , intent(in)  :: vec_in
      ! Output vector.

--- a/example/ginzburg_landau/main.f90
+++ b/example/ginzburg_landau/main.f90
@@ -1,7 +1,7 @@
 program demo
    use stdlib_io_npy, only: save_npy
-   use LightKrylov
    use LightKrylov, only: wp => dp
+   use LightKrylov
    use LightKrylov_Logger
    use Ginzburg_Landau
    implicit none

--- a/example/ginzburg_landau/main.f90
+++ b/example/ginzburg_landau/main.f90
@@ -1,83 +1,83 @@
 program demo
-  use stdlib_io_npy, only : save_npy
-  use LightKrylov
-  use LightKrylov, only: wp => dp
-  use LightKrylov_Logger
-  use Ginzburg_Landau
-  implicit none
+   use stdlib_io_npy, only: save_npy
+   use LightKrylov
+   use LightKrylov, only: wp => dp
+   use LightKrylov_Logger
+   use Ginzburg_Landau
+   implicit none
 
-  character(len=128), parameter :: this_module = 'Example Ginzburg_Landau'
+   character(len=128), parameter :: this_module = 'Example Ginzburg_Landau'
 
-  !------------------------------------------------
-  !-----     LINEAR OPERATOR INVESTIGATED     -----
-  !------------------------------------------------
+   !------------------------------------------------
+   !-----     LINEAR OPERATOR INVESTIGATED     -----
+   !------------------------------------------------
 
-  !> Exponential propagator.
-  type(exponential_prop), allocatable :: A
-  !> Sampling time.
-  real(kind=wp), parameter :: tau = 0.1_wp
+   !> Exponential propagator.
+   type(exponential_prop), allocatable :: A
+   !> Sampling time.
+   real(kind=wp), parameter :: tau = 0.1_wp
 
-  !---------------------------------------------------
-  !-----     KRYLOV-BASED EIGENDECOMPOSITION     -----
-  !---------------------------------------------------
+   !---------------------------------------------------
+   !-----     KRYLOV-BASED EIGENDECOMPOSITION     -----
+   !---------------------------------------------------
 
-  !> Number of eigenvalues we wish to converge.
-  integer, parameter :: nev = 32
-  !> Krylov subspace.
-  type(state_vector), allocatable :: X(:)
-  !> Eigenvalues.
-  complex(kind=wp), allocatable :: lambda(:)
-  !> Residual.
-  real(kind=wp), allocatable    :: residuals(:)
-  !> Information flag.
-  integer          :: info
+   !> Number of eigenvalues we wish to converge.
+   integer, parameter :: nev = 32
+   !> Krylov subspace.
+   type(state_vector), allocatable :: X(:)
+   !> Eigenvalues.
+   complex(kind=wp), allocatable :: lambda(:)
+   !> Residual.
+   real(kind=wp), allocatable    :: residuals(:)
+   !> Information flag.
+   integer          :: info
 
-  !> Miscellaneous.
-  integer       :: i
-  complex(wp) :: eigenvectors(nx, nev)
+   !> Miscellaneous.
+   integer       :: i
+   complex(wp) :: eigenvectors(nx, nev)
 
-  !=============================================================================
+   !=============================================================================
 
-  !----------------------------------
-  !-----     INITIALIZATION     -----
-  !----------------------------------
+   !----------------------------------
+   !-----     INITIALIZATION     -----
+   !----------------------------------
 
-  !> Set up logging
-  call logger_setup()
+   !> Set up logging
+   call logger_setup()
 
-  !> Initialize physical parameters.
-  call initialize_parameters()
+   !> Initialize physical parameters.
+   call initialize_parameters()
 
-  !> Initialize exponential propagator.
-  A = exponential_prop(tau)
+   !> Initialize exponential propagator.
+   A = exponential_prop(tau)
 
-  !> Initialize Krylov subspace.
-  allocate(X(nev)) ; call zero_basis(X)
+   !> Initialize Krylov subspace.
+   allocate (X(nev)); call zero_basis(X)
 
-  !------------------------------------------
-  !-----     EIGENVALUE COMPUTATION     -----
-  !------------------------------------------
+   !------------------------------------------
+   !-----     EIGENVALUE COMPUTATION     -----
+   !------------------------------------------
 
-  !> Call to LightKrylov.
-  call eigs(A, X, lambda, residuals, info)
-  call check_info(info, 'eigs', module=this_module, procedure='main')
+   !> Call to LightKrylov.
+   call eigs(A, X, lambda, residuals, info)
+   call check_info(info, 'eigs', module=this_module, procedure='main')
 
-  !> Transform eigenspectrum from unit-disk to standard complex plane.
-  lambda = log(lambda) / tau
+   !> Transform eigenspectrum from unit-disk to standard complex plane.
+   lambda = log(lambda)/tau
 
-  !--------------------------------
-  !-----     SAVE TO DISK     -----
-  !--------------------------------
+   !--------------------------------
+   !-----     SAVE TO DISK     -----
+   !--------------------------------
 
-  !> Save the eigenspectrum.
-  call save_eigenspectrum(lambda, residuals, "example/ginzburg_landau/eigenspectrum.npy")
+   !> Save the eigenspectrum.
+   call save_eigenspectrum(lambda, residuals, "example/ginzburg_landau/eigenspectrum.npy")
 
-  !> Reconstruct the leading eigenvectors from the Krylov basis.
-  do i = 1, nev
-    eigenvectors(:, i) = X(i)%state
-  enddo
+   !> Reconstruct the leading eigenvectors from the Krylov basis.
+   do i = 1, nev
+      eigenvectors(:, i) = X(i)%state
+   end do
 
-  !> Save eigenvectors to disk.
-  call save_npy("example/ginzburg_landau/eigenvectors.npy", eigenvectors)
+   !> Save eigenvectors to disk.
+   call save_npy("example/ginzburg_landau/eigenvectors.npy", eigenvectors)
 
 end program demo

--- a/example/roessler/main.f90
+++ b/example/roessler/main.f90
@@ -1,9 +1,9 @@
 program demo
-   use stdlib_linalg, only : eye, eigvals
-   use stdlib_io_npy, only : save_npy
-   use stdlib_sorting, only : sort
-   use stdlib_strings, only : padl
-   use stdlib_logger, only : information_level, warning_level, debug_level, error_level, none_level
+   use stdlib_linalg, only: eye, eigvals
+   use stdlib_io_npy, only: save_npy
+   use stdlib_sorting, only: sort
+   use stdlib_strings, only: padl
+   use stdlib_logger, only: information_level, warning_level, debug_level, error_level, none_level
    ! RKLIB module for time integration.
    use rklib_module
    ! LightKrylov for linear algebra
@@ -41,9 +41,9 @@ program demo
    real(wp), dimension(r, r)       :: Lr
    ! IO
    character(len=20)    :: data_fmt, header_fmt
-   
-   write(header_fmt,*) '(22X,*(A,2X))'
-   write(data_fmt,  *) '(A22,*(1X,F15.6))'
+
+   write (header_fmt, *) '(22X,*(A,2X))'
+   write (data_fmt, *) '(A22,*(1X,F15.6))'
 
    ! Set up logging
    call logger_setup()
@@ -57,7 +57,7 @@ program demo
    print *, '########################################################################################'
    print *, ''
 
-   vec = (/ 0.0_wp, -5.0_wp, 0.05_wp /) ! some intial point
+   vec = (/0.0_wp, -5.0_wp, 0.05_wp/) ! some intial point
    Tend = 300.0_wp ! Integration time
    ! Integrate equations
    call write_report_header
@@ -66,20 +66,20 @@ program demo
    call rename(report_file, 'example/roessler/roessler_attractor.txt')
 
    print header_fmt, padl('X', 14), padl('Y', 14), padl('Z', 14), padl('time', 14)
-   print data_fmt, 'Initial position :',  vec(1),  vec(2),  vec(3), 0.0_wp
-   print data_fmt, 'Final position :',   eval(1), eval(2), eval(3), Tend
-   print *,''
+   print data_fmt, 'Initial position :', vec(1), vec(2), vec(3), 0.0_wp
+   print data_fmt, 'Final position :', eval(1), eval(2), eval(3), Tend
+   print *, ''
 
    print *, '########################################################################################'
-   print '(A,E9.2,A)',' #             Newton iteration with constant tolerance (tol=', tol, ')                 #'
+   print '(A,E9.2,A)', ' #             Newton iteration with constant tolerance (tol=', tol, ')                 #'
    print *, '########################################################################################'
    print *, ''
 
-   call set_position((/ 0.0_wp, 6.1_wp, 1.3_wp /), bf)  ! initial guess
+   call set_position((/0.0_wp, 6.1_wp, 1.3_wp/), bf)  ! initial guess
    bf%T = 6.0_wp ! period guess
    print header_fmt, padl('X', 14), padl('Y', 14), padl('Z', 14), padl('T', 14)
    print data_fmt, 'Initial guess PO:', bf%x, bf%y, bf%z, bf%T
-   print *,''
+   print *, ''
 
    ! Initialize system and Jacobian
    sys = roessler_upo()
@@ -98,20 +98,20 @@ program demo
    print header_fmt, padl('X', 14), padl('Y', 14), padl('Z', 14), padl('T', 14)
    print data_fmt, 'Solution:         ', bf%x, bf%y, bf%z, bf%T
    print data_fmt, 'Solution residual:', residual%x, residual%y, residual%z, residual%T
-   print *,''
+   print *, ''
 
    print *, '########################################################################################'
-   print '(A,E9.2,A)',' #             Newton iteration with dynamic tolerances (target=', tol, ')              #'
+   print '(A,E9.2,A)', ' #             Newton iteration with dynamic tolerances (target=', tol, ')              #'
    print *, '########################################################################################'
    print *, ''
 
-   call set_position((/ 0.0_wp, 6.1_wp, 1.3_wp /), bf)  ! some initial guess
+   call set_position((/0.0_wp, 6.1_wp, 1.3_wp/), bf)  ! some initial guess
    bf%T = 6.0_wp ! period guess
    print header_fmt, padl('X', 14), padl('Y', 14), padl('Z', 14), padl('T', 14)
    print data_fmt, 'Initial guess PO:  ', bf%x, bf%y, bf%z, bf%T
-   print *,''
+   print *, ''
    sys%jacobian%X = bf
-   
+
    call newton(sys, bf, gmres_rdp, info, tolerance=tol, options=opts, scheduler=dynamic_tol_dp)
 
    call sys%eval(bf, residual, tol)
@@ -119,7 +119,7 @@ program demo
    print header_fmt, padl('X', 14), padl('Y', 14), padl('Z', 14), padl('T', 14)
    print data_fmt, 'Solution:         ', bf%x, bf%y, bf%z, bf%T
    print data_fmt, 'Solution residual:', residual%x, residual%y, residual%z, residual%T
-   print *,''
+   print *, ''
 
    print *, '########################################################################################'
    print *, '#                        Monodromy matrix and floquet exponents                        #'
@@ -133,9 +133,9 @@ program demo
    M = 0.0_wp
    Id = eye(npts)
    do i = 1, npts
-      call set_position(Id(:,i), dx)
+      call set_position(Id(:, i), dx)
       call sys%jacobian%matvec(dx, residual)
-      call get_position(residual, M(:,i))
+      call get_position(residual, M(:, i))
    end do
    eval = real(eigvals(M))
    call sort(eval, reverse=.true.)
@@ -154,9 +154,9 @@ program demo
    call bfp%zero()
    ! Set the baseflow to a fixed point
    d = sqrt(c**2 - 4*a*b)
-   bfp%x = ( c - d)/ 2
+   bfp%x = (c - d)/2
    bfp%y = (-c + d)/(2*a)
-   bfp%z = ( c - d)/(2*a)
+   bfp%z = (c - d)/(2*a)
 
    ! Compute OTD modes on the fixed point
    call zero_basis(OTD_in); call zero_basis(OTD_out)
@@ -174,17 +174,17 @@ program demo
    ! get baseflow
    call get_pos(bfp, vec)
    ! get OTD basis vectors
-   u  = 0.0_wp
+   u = 0.0_wp
    Lu = 0.0_wp
    do i = 1, r
-      call get_pos(OTD_out(i), u(:,i))
-      call linear_roessler(u(:,i), vec, Lu(:,i))
+      call get_pos(OTD_out(i), u(:, i))
+      call linear_roessler(u(:, i), vec, Lu(:, i))
    end do
    ! compute Lr
    Lr = 0.0_wp
    do i = 1, r
       do j = 1, r
-         Lr(i,j) = dot_product(Lu(:,i), u(:,j))
+         Lr(i, j) = dot_product(Lu(:, i), u(:, j))
       end do
    end do
    eval = 0.0_wp
@@ -213,7 +213,7 @@ program demo
    print '(*(A16,1X))', ' ', 'LE_1', 'LE_2'
    print '(A16,1X,2(F16.9,1X),A16,1X,F16.9)', 'Reference   ', LE_ref, 'Period T=', bf%T
    call OTD_map(bfp, OTD_in, Tend, OTD_out, t_FTLE, if_rst=.true.)
-   call rename(report_file_OTD,    'example/roessler/PO_OTD.txt')
+   call rename(report_file_OTD, 'example/roessler/PO_OTD.txt')
    call rename(report_file_OTD_LE, 'example/roessler/PO_LE.txt')
    print *, ''
 
@@ -234,7 +234,7 @@ program demo
    print '(A16,1X,*(F16.9,1X))', 'Reference   ', LE_ref
    print *, ''
    call OTD_map(bfp, OTD_in, Tend, OTD_out, t_FTLE, if_rst=.false.) ! we do not reset the bf!
-   call rename(report_file_OTD,    'example/roessler/PO-chaos_OTD.txt')
+   call rename(report_file_OTD, 'example/roessler/PO-chaos_OTD.txt')
    call rename(report_file_OTD_LE, 'example/roessler/PO-chaos_LE.txt')
    print *, ''
 

--- a/example/roessler/main.f90
+++ b/example/roessler/main.f90
@@ -2,27 +2,33 @@ program demo
    use stdlib_linalg, only : eye, eigvals
    use stdlib_io_npy, only : save_npy
    use stdlib_sorting, only : sort
+   use stdlib_strings, only : padl
    use stdlib_logger, only : information_level, warning_level, debug_level, error_level, none_level
+   ! RKLIB module for time integration.
+   use rklib_module
+   ! LightKrylov for linear algebra
    use LightKrylov
    use LightKrylov, only: wp => dp
    use LightKrylov_Logger
    use lightkrylov_IterativeSolvers, only: gmres_rdp
    use LightKrylov_Utils
-   ! Roessler
+   ! Roessler system
    use Roessler
    use Roessler_OTD
    implicit none
 
-   character(len=128), parameter :: this_module = 'Example Roessler'
+   character(len=*), parameter :: this_module = 'Example Roessler'
 
    ! Roessler system.
-   type(roessler_upo), allocatable :: sys
+   type(roessler_upo) :: sys
    ! State vectors
-   type(state_vector), allocatable :: bf, dx, residual, fp
+   type(state_vector) :: bf, dx, residual, fp
    ! Position vectors
-   type(pos_vector), allocatable   :: bfp
+   type(pos_vector)   :: bfp
    ! OTD basis
-   type(pos_vector), allocatable   :: OTD_in(:), OTD_out(:)
+   type(pos_vector)   :: OTD_in(r), OTD_out(r)
+   ! Time-integrator
+   type(rks54_class)  :: nonlinear_integrator
 
    ! Misc
    type(newton_dp_opts)            :: opts
@@ -34,30 +40,45 @@ program demo
    real(wp), dimension(npts, r)    :: u, Lu
    real(wp), dimension(r, r)       :: Lr
    ! IO
-   character(len=20)    :: fmt
+   character(len=20)    :: data_fmt, header_fmt
    
-   write(fmt,*) '(A22,4(1X,F18.6))'
+   write(header_fmt,*) '(22X,*(A,2X))'
+   write(data_fmt,  *) '(A22,*(1X,F15.6))'
 
    ! Set up logging
    call logger_setup()
    call logger%configure(level=error_level, time_stamp=.false.)
 
    ! Initialize baseflow and perturbation state vectors
-   allocate(bf, dx, residual)
    call bf%zero(); call dx%zero(); call residual%zero()
 
-   ! Set tolerace
-   tol = 1e-12_wp
+   print *, '########################################################################################'
+   print *, '#                         Roessler system chaotic attractor                            #'
+   print *, '########################################################################################'
+   print *, ''
+
+   vec = (/ 0.0_wp, -5.0_wp, 0.05_wp /) ! some intial point
+   Tend = 300.0_wp ! Integration time
+   ! Integrate equations
+   call write_report_header
+   call nonlinear_integrator%initialize(n=npts, f=NL_rhs, report=roessler_report_file, report_rate=20)
+   call nonlinear_integrator%integrate(0.0_wp, vec, 1.0_wp, Tend, eval)
+   call rename(report_file, 'example/roessler/roessler_attractor.txt')
+
+   print header_fmt, padl('X', 14), padl('Y', 14), padl('Z', 14), padl('time', 14)
+   print data_fmt, 'Initial position :',  vec(1),  vec(2),  vec(3), 0.0_wp
+   print data_fmt, 'Final position :',   eval(1), eval(2), eval(3), Tend
+   print *,''
 
    print *, '########################################################################################'
    print '(A,E9.2,A)',' #             Newton iteration with constant tolerance (tol=', tol, ')                 #'
    print *, '########################################################################################'
    print *, ''
 
-   call set_position((/ 0.0_wp, 6.1_wp, 1.3_wp /), bf)  ! some initial guess
+   call set_position((/ 0.0_wp, 6.1_wp, 1.3_wp /), bf)  ! initial guess
    bf%T = 6.0_wp ! period guess
-   print '(A22,4(16X,A,2X))', '         ', 'X', 'Y', 'Z', 'T'
-   print fmt, 'Initial guess PO:   ', bf%x, bf%y, bf%z, bf%T
+   print header_fmt, padl('X', 14), padl('Y', 14), padl('Z', 14), padl('T', 14)
+   print data_fmt, 'Initial guess PO:', bf%x, bf%y, bf%z, bf%T
    print *,''
 
    ! Initialize system and Jacobian
@@ -66,14 +87,17 @@ program demo
    sys%jacobian = jacobian()
    sys%jacobian%X = bf
 
+   ! Set tolerance
+   tol = 1e-12_wp
+
    opts = newton_dp_opts(maxiter=30, ifbisect=.false.)
    call newton(sys, bf, gmres_rdp, info, tolerance=tol, options=opts, scheduler=constant_atol_dp)
 
    call sys%eval(bf, residual, tol)
    print *, ''
-   print '(A22,4(16X,A,2X))', '       ', 'X', 'Y', 'Z', 'T'
-   print fmt, 'Solution:           ', bf%x, bf%y, bf%z, bf%T
-   print fmt, 'Solution residual:  ', residual%x, residual%y, residual%z, residual%T
+   print header_fmt, padl('X', 14), padl('Y', 14), padl('Z', 14), padl('T', 14)
+   print data_fmt, 'Solution:         ', bf%x, bf%y, bf%z, bf%T
+   print data_fmt, 'Solution residual:', residual%x, residual%y, residual%z, residual%T
    print *,''
 
    print *, '########################################################################################'
@@ -83,8 +107,8 @@ program demo
 
    call set_position((/ 0.0_wp, 6.1_wp, 1.3_wp /), bf)  ! some initial guess
    bf%T = 6.0_wp ! period guess
-   print '(A22,4(16X,A,2X))', '         ', 'X', 'Y', 'Z', 'T'
-   print fmt, 'Initial guess PO:  ', bf%x, bf%y, bf%z, bf%T
+   print header_fmt, padl('X', 14), padl('Y', 14), padl('Z', 14), padl('T', 14)
+   print data_fmt, 'Initial guess PO:  ', bf%x, bf%y, bf%z, bf%T
    print *,''
    sys%jacobian%X = bf
    
@@ -92,9 +116,9 @@ program demo
 
    call sys%eval(bf, residual, tol)
    print *, ''
-   print '(A22,4(16X,A,2X))', '       ', 'X', 'Y', 'Z', 'T'
-   print fmt, 'Solution:           ', bf%x, bf%y, bf%z, bf%T
-   print fmt, 'Solution residual:  ', residual%x, residual%y, residual%z, residual%T
+   print header_fmt, padl('X', 14), padl('Y', 14), padl('Z', 14), padl('T', 14)
+   print data_fmt, 'Solution:         ', bf%x, bf%y, bf%z, bf%T
+   print data_fmt, 'Solution residual:', residual%x, residual%y, residual%z, residual%T
    print *,''
 
    print *, '########################################################################################'
@@ -126,7 +150,8 @@ program demo
    print *, '#                  Optimally Time-Dependent (OTD) modes on fixed point                 #'
    print *, '########################################################################################'
    print *, ''
-   allocate(bfp); call bfp%zero()
+   ! Initialize fixed point
+   call bfp%zero()
    ! Set the baseflow to a fixed point
    d = sqrt(c**2 - 4*a*b)
    bfp%x = ( c - d)/ 2
@@ -134,7 +159,6 @@ program demo
    bfp%z = ( c - d)/(2*a)
 
    ! Compute OTD modes on the fixed point
-   allocate(OTD_in(r), OTD_out(r))
    call zero_basis(OTD_in); call zero_basis(OTD_out)
 
    ! Initialize basis
@@ -146,7 +170,7 @@ program demo
    t_FTLE = 5.0_wp
    call write_header()
    call OTD_map(bfp, OTD_in, Tend, OTD_out, t_FTLE)
-   call rename(file, 'example/roessler/FP_OTD.txt')
+   call rename(report_file_OTD, 'example/roessler/FP_OTD.txt')
    ! get baseflow
    call get_pos(bfp, vec)
    ! get OTD basis vectors
@@ -189,8 +213,8 @@ program demo
    print '(*(A16,1X))', ' ', 'LE_1', 'LE_2'
    print '(A16,1X,2(F16.9,1X),A16,1X,F16.9)', 'Reference   ', LE_ref, 'Period T=', bf%T
    call OTD_map(bfp, OTD_in, Tend, OTD_out, t_FTLE, if_rst=.true.)
-   call rename(file,    'example/roessler/PO_OTD.txt')
-   call rename(file_LE, 'example/roessler/PO_LE.txt')
+   call rename(report_file_OTD,    'example/roessler/PO_OTD.txt')
+   call rename(report_file_OTD_LE, 'example/roessler/PO_LE.txt')
    print *, ''
 
    print *, ''
@@ -210,8 +234,8 @@ program demo
    print '(A16,1X,*(F16.9,1X))', 'Reference   ', LE_ref
    print *, ''
    call OTD_map(bfp, OTD_in, Tend, OTD_out, t_FTLE, if_rst=.false.) ! we do not reset the bf!
-   call rename(file,    'example/roessler/PO-chaos_OTD.txt')
-   call rename(file_LE, 'example/roessler/PO-chaos_LE.txt')
+   call rename(report_file_OTD,    'example/roessler/PO-chaos_OTD.txt')
+   call rename(report_file_OTD_LE, 'example/roessler/PO-chaos_LE.txt')
    print *, ''
-   
+
 end program demo

--- a/example/roessler/roessler.f90
+++ b/example/roessler/roessler.f90
@@ -9,7 +9,8 @@ module Roessler
    use LightKrylov, only: wp => dp
    implicit none
  
-   character*128, parameter, private :: this_module = 'Roessler'
+   character(len=*), parameter, private :: this_module = 'Roessler'
+   character(len=*), parameter :: report_file = 'example/roessler/roessler_output.txt'
  
    public :: a, b, c
  
@@ -254,7 +255,6 @@ contains
       ! Time-integrator.
       type(rks54_class)         :: nonlinear_integrator
       real(wp)                  :: dt = 1.0_wp
-      real(wp)                  :: period
       real(wp), dimension(npts) :: pos_in, pos_out
       
       ! Evaluate F(X).
@@ -432,7 +432,17 @@ contains
       print '(*(F15.6,1X))', t, x
 
       return
-   end subroutine
+   end subroutine roessler_report_stdout
+
+   subroutine write_report_header()
+      ! internals
+      integer :: i, j, iunit
+      open(newunit=iunit, file=report_file, status='new', action='write')
+      ! time, baseflow
+      write(iunit,'(*(A16,1X))') 't', 'BF_x', 'BF_y', 'BF_z'
+      close(iunit)
+      return
+   end subroutine write_report_header
 
    subroutine roessler_report_file(me, t, x)
       class(rk_class), intent(inout)      :: me
@@ -440,10 +450,10 @@ contains
       real(wp), dimension(:), intent(in)  :: x
       ! internals
       integer :: iunit
-      open(newunit=iunit, file='new_orbit.txt', status='old', action='write', position='append')
+      open(newunit=iunit, file=report_file, status='old', action='write', position='append')
       write(iunit, '(*(F15.6,1X))') t, x
       close(iunit)
       return
-   end subroutine
+   end subroutine roessler_report_file
  
 end module Roessler

--- a/example/roessler/roessler.f90
+++ b/example/roessler/roessler.f90
@@ -8,25 +8,25 @@ module Roessler
    use LightKrylov
    use LightKrylov, only: wp => dp
    implicit none
- 
+
    character(len=*), parameter, private :: this_module = 'Roessler'
    character(len=*), parameter :: report_file = 'example/roessler/roessler_output.txt'
- 
+
    public :: a, b, c
- 
+
    !------------------------------
    !-----     PARAMETERS     -----
    !------------------------------
- 
-   integer,  parameter :: npts = 3
+
+   integer, parameter :: npts = 3
    real(wp), parameter :: a = 0.2_wp
    real(wp), parameter :: b = 0.2_wp
    real(wp), parameter :: c = 5.7_wp
- 
+
    !-------------------------------------------
    !-----     LIGHTKRYLOV VECTOR TYPE     -----
    !-------------------------------------------
- 
+
    type, extends(abstract_vector_rdp), public :: state_vector
       real(wp) :: x = 0.0_wp
       real(wp) :: y = 0.0_wp
@@ -65,7 +65,7 @@ module Roessler
       procedure, pass(self), public :: matvec => monodromy_map
       procedure, pass(self), public :: rmatvec => monodromy_map ! dummy, we do not need the adjoint of the monodromy
    end type floquet_operator
- 
+
 contains
 
    !=========================================================
@@ -75,11 +75,11 @@ contains
    !=====                                               =====
    !=========================================================
    !=========================================================
-   
+
    !----------------------------------------------------
    !-----     TYPE-BOUND PROCEDURE FOR VECTORS     -----
    !----------------------------------------------------
-   
+
    subroutine zero(self)
       class(state_vector), intent(inout) :: self
       ! spatial coordinates of initial condition for orbit
@@ -92,10 +92,10 @@ contains
    end subroutine zero
 
    real(wp) function dot(self, vec) result(alpha)
-      class(state_vector)       , intent(in) :: self
+      class(state_vector), intent(in) :: self
       class(abstract_vector_rdp), intent(in) :: vec
-      select type(vec)
-      type is(state_vector)
+      select type (vec)
+      type is (state_vector)
          alpha = self%x*vec%x + self%y*vec%y + self%z*vec%z + self%T*vec%T
       end select
       return
@@ -103,20 +103,20 @@ contains
 
    subroutine scal(self, alpha)
       class(state_vector), intent(inout) :: self
-      real(wp)           , intent(in)    :: alpha
-      self%x = self%x * alpha
-      self%y = self%y * alpha
-      self%z = self%z * alpha
-      self%T = self%T * alpha
+      real(wp), intent(in)    :: alpha
+      self%x = self%x*alpha
+      self%y = self%y*alpha
+      self%z = self%z*alpha
+      self%T = self%T*alpha
       return
    end subroutine scal
 
    subroutine axpby(self, alpha, vec, beta)
-      class(state_vector)       , intent(inout) :: self
+      class(state_vector), intent(inout) :: self
       class(abstract_vector_rdp), intent(in)    :: vec
-      real(wp)                  , intent(in)    :: alpha, beta
-      select type(vec)
-      type is(state_vector)
+      real(wp), intent(in)    :: alpha, beta
+      select type (vec)
+      type is (state_vector)
          self%x = alpha*self%x + beta*vec%x
          self%y = alpha*self%y + beta*vec%y
          self%z = alpha*self%z + beta*vec%z
@@ -127,13 +127,13 @@ contains
 
    integer function get_size(self) result(N)
       class(state_vector), intent(in) :: self
-      N = npts+1
+      N = npts + 1
       return
    end function get_size
 
    subroutine rand(self, ifnorm)
       class(state_vector), intent(inout) :: self
-      logical, optional,   intent(in)    :: ifnorm
+      logical, optional, intent(in)    :: ifnorm
       logical :: normalized
       real(wp) :: mu, var
       real(wp) :: alpha
@@ -149,10 +149,10 @@ contains
       if (normalized) then
          alpha = self%norm()
          call self%scal(1.0_wp/alpha)
-      endif
+      end if
       return
    end subroutine rand
- 
+
    !===================================
    !===================================
    !=====                         =====
@@ -164,18 +164,18 @@ contains
    !----------------------------------------
    !-----      NONLINEAR EQUATIONS     -----
    !----------------------------------------
- 
+
    subroutine nonlinear_roessler(x, f)
       ! State vector.
-      real(kind=wp)  , dimension(npts), intent(in)  :: x
+      real(kind=wp), dimension(npts), intent(in)  :: x
       ! Time-derivative.
-      real(kind=wp)  , dimension(npts), intent(out) :: f
-      
-      f  = 0.0_wp
+      real(kind=wp), dimension(npts), intent(out) :: f
+
+      f = 0.0_wp
       f(1) = -x(2) - x(3)
-      f(2) = x(1) + a * x(2)
-      f(3) = b + x(3) * (x(1) - c)
-      
+      f(2) = x(1) + a*x(2)
+      f(3) = b + x(3)*(x(1) - c)
+
       return
    end subroutine nonlinear_roessler
 
@@ -185,83 +185,83 @@ contains
 
    subroutine linear_roessler(xp, bf, f)
       ! State vector.
-      real(kind=wp)  , dimension(:), intent(in)  :: xp
+      real(kind=wp), dimension(:), intent(in)  :: xp
       ! Base state.
-      real(kind=wp)  , dimension(:), intent(in)  :: bf
+      real(kind=wp), dimension(:), intent(in)  :: bf
       ! Time-derivative.
-      real(kind=wp)  , dimension(:), intent(out) :: f
+      real(kind=wp), dimension(:), intent(out) :: f
 
       f = 0.0_wp
       f(1) = -xp(2) - xp(3)
-      f(2) =  xp(1) + a*xp(2)
-      f(3) =  xp(1)*bf(3) + xp(3)*(bf(1) - c)
-   
+      f(2) = xp(1) + a*xp(2)
+      f(3) = xp(1)*bf(3) + xp(3)*(bf(1) - c)
+
       return
    end subroutine linear_roessler
 
    !-----------------------------------------------------------------
    !-----      WRAPPER FOR NONLINEAR INTEGRATION WITH RKLIB     -----
    !-----------------------------------------------------------------
- 
+
    subroutine NL_rhs(me, t, x, f)
       ! Time-integrator.
       class(rk_class), intent(inout)             :: me
       ! Current time.
-      real(kind=wp)  , intent(in)                :: t
+      real(kind=wp), intent(in)                :: t
       ! State vector.
-      real(kind=wp)  , dimension(:), intent(in)  :: x
+      real(kind=wp), dimension(:), intent(in)  :: x
       ! Time-derivative.
-      real(kind=wp)  , dimension(:), intent(out) :: f
+      real(kind=wp), dimension(:), intent(out) :: f
 
       call nonlinear_roessler(x, f)
-      
+
       return
    end subroutine NL_rhs
- 
+
    !-------------------------------------------------------------
    !-----      WRAPPER FOR LINEAR INTEGRATION WITH RKLIB    -----
    !-------------------------------------------------------------
- 
+
    subroutine combined_rhs(me, t, x, f)
       ! Time-integrator.
       class(rk_class), intent(inout)             :: me
       ! Current time.
-      real(kind=wp)  , intent(in)                :: t
+      real(kind=wp), intent(in)                :: t
       ! State vector.
-      real(kind=wp)  , dimension(:), intent(in)  :: x
+      real(kind=wp), dimension(:), intent(in)  :: x
       ! Time-derivative.
-      real(kind=wp)  , dimension(:), intent(out) :: f
- 
-      call nonlinear_roessler(            x(:npts), f(:npts))
-      call    linear_roessler(x(npts+1:), x(:npts), f(npts+1:))
-     
+      real(kind=wp), dimension(:), intent(out) :: f
+
+      call nonlinear_roessler(x(:npts), f(:npts))
+      call linear_roessler(x(npts + 1:), x(:npts), f(npts + 1:))
+
       return
    end subroutine combined_rhs
- 
+
    !-------------------------------------------------------------
    !-----     TYPE-BOUND PROCEDURES FOR THE INTEGRATORS     -----
    !-------------------------------------------------------------
- 
+
    subroutine nonlinear_map(self, vec_in, vec_out, atol)
       ! Dynamical system.
-      class(roessler_upo),        intent(inout)  :: self
+      class(roessler_upo), intent(inout)  :: self
       ! Input vector.
       class(abstract_vector_rdp), intent(in)  :: vec_in
       ! Output vector.
       class(abstract_vector_rdp), intent(out) :: vec_out
       ! Solver tolerances if needed
-      real(wp),                   intent(in)  :: atol
-      
+      real(wp), intent(in)  :: atol
+
       ! Time-integrator.
       type(rks54_class)         :: nonlinear_integrator
       real(wp)                  :: dt = 1.0_wp
       real(wp), dimension(npts) :: pos_in, pos_out
-      
+
       ! Evaluate F(X).
-      select type(vec_in)
-      type is(state_vector)
-         select type(vec_out)
-         type is(state_vector)
+      select type (vec_in)
+      type is (state_vector)
+         select type (vec_out)
+         type is (state_vector)
             ! Get state vector.
             call get_position(vec_in, pos_in)
             ! Initialize integrator.
@@ -275,36 +275,36 @@ contains
             call vec_out%sub(vec_in)
 
             ! Add period residual
-            vec_out%T = 0.0_wp            
+            vec_out%T = 0.0_wp
          end select
       end select
 
       return
    end subroutine nonlinear_map
- 
+
    subroutine linear_map(self, vec_in, vec_out)
       ! Linear Operator.
       class(jacobian), intent(inout) :: self
       ! Input vector.
-      class(abstract_vector_rdp) , intent(in)  :: vec_in
+      class(abstract_vector_rdp), intent(in)  :: vec_in
       ! Output vector.
-      class(abstract_vector_rdp) , intent(out) :: vec_out
-      
+      class(abstract_vector_rdp), intent(out) :: vec_out
+
       ! Time-integrator.
       type(rks54_class)           :: combined_roessler
       real(wp)                    :: dt = 1.0_wp
       real(wp)                    :: period
       real(wp), dimension(2*npts) :: pos_in, pos_out
       type(state_vector)          :: vec
-      
-      select type(vec_in)
-      type is(state_vector)
-         select type(vec_out)
-         type is(state_vector)
+
+      select type (vec_in)
+      type is (state_vector)
+         select type (vec_out)
+         type is (state_vector)
             ! Get the state.
             call get_position(self%X, pos_in(:npts))
-            call get_period(  self%X, period)
-            call get_position(vec_in, pos_in(npts+1:))
+            call get_period(self%X, period)
+            call get_position(vec_in, pos_in(npts + 1:))
             ! Initialize integrator.
             call combined_roessler%initialize(n=2*npts, f=combined_rhs)!, report=roessler_report_stdout, report_rate=1)
             ! Evaluate:
@@ -312,7 +312,7 @@ contains
             ! 2. exp(tau*J) @ dx
             call combined_roessler%integrate(0.0_wp, pos_in, dt, period, pos_out)
             ! Pass-back the state.
-            call set_position(pos_out(npts+1:), vec_out)
+            call set_position(pos_out(npts + 1:), vec_out)
 
             ! Evaluate [ exp(tau*J) - I ] @ dx.
             call vec_out%sub(vec_in)
@@ -322,12 +322,12 @@ contains
             call vec_out%axpby(1.0_wp, vec, vec_in%T)
 
             ! Evaluate f'(X(0), 0).T @ dx and add phase condition
-            call compute_fdot(pos_in(:npts), vec) 
+            call compute_fdot(pos_in(:npts), vec)
             vec_out%T = vec_in%dot(vec)
-            
+
          end select
       end select
-      
+
       return
    end subroutine linear_map
 
@@ -335,25 +335,25 @@ contains
       ! Linear Operator.
       class(floquet_operator), intent(inout) :: self
       ! Input vector.
-      class(abstract_vector_rdp) , intent(in)  :: vec_in
+      class(abstract_vector_rdp), intent(in)  :: vec_in
       ! Output vector.
-      class(abstract_vector_rdp) , intent(out) :: vec_out
-      
+      class(abstract_vector_rdp), intent(out) :: vec_out
+
       ! Time-integrator.
       type(rks54_class)           :: combined_roessler
       real(wp)                    :: dt = 1.0_wp
       real(wp)                    :: period
       real(wp), dimension(2*npts) :: pos_in, pos_out
       type(state_vector)          :: vec
-      
-      select type(vec_in)
-      type is(state_vector)
-         select type(vec_out)
-         type is(state_vector)
+
+      select type (vec_in)
+      type is (state_vector)
+         select type (vec_out)
+         type is (state_vector)
             ! Get the state.
             call get_position(self%X, pos_in(:npts))
-            call get_period(  self%X, period)
-            call get_position(vec_in, pos_in(npts+1:))
+            call get_period(self%X, period)
+            call get_position(vec_in, pos_in(npts + 1:))
             ! Initialize integrator.
             call combined_roessler%initialize(n=2*npts, f=combined_rhs)!, report=roessler_report_stdout, report_rate=1)
             ! Evaluate:
@@ -361,27 +361,27 @@ contains
             ! 2. exp(tau*J) @ dx
             call combined_roessler%integrate(0.0_wp, pos_in, dt, period, pos_out)
             ! Pass-back the state.
-            call set_position(pos_out(npts+1:), vec_out)
+            call set_position(pos_out(npts + 1:), vec_out)
          end select
       end select
-      
+
       return
    end subroutine monodromy_map
 
    !-------------------------------------------
    !-----     MISCELLANEOUS UTILITIES     -----
    !-------------------------------------------
- 
+
    subroutine get_position(vec_in, pos)
       class(abstract_vector_rdp), intent(in)  :: vec_in
-      real(wp), dimension(npts),  intent(out) :: pos
+      real(wp), dimension(npts), intent(out) :: pos
 
       pos = 0.0_wp
       select type (vec_in)
       type is (state_vector)
-          pos(1) = vec_in%x
-          pos(2) = vec_in%y
-          pos(3) = vec_in%z
+         pos(1) = vec_in%x
+         pos(2) = vec_in%y
+         pos(3) = vec_in%z
       end select
 
       return
@@ -389,18 +389,18 @@ contains
 
    subroutine get_period(vec_in, period)
       class(abstract_vector_rdp), intent(in)  :: vec_in
-      real(wp),                   intent(out) :: period
+      real(wp), intent(out) :: period
 
       select type (vec_in)
       type is (state_vector)
-          period = vec_in%T
+         period = vec_in%T
       end select
 
       return
    end subroutine get_period
 
    subroutine set_position(pos, vec_out)
-      real(wp), dimension(npts),  intent(in)  :: pos
+      real(wp), dimension(npts), intent(in)  :: pos
       class(abstract_vector_rdp), intent(out) :: vec_out
 
       select type (vec_out)
@@ -414,7 +414,7 @@ contains
    end subroutine set_position
 
    subroutine compute_fdot(pos, vec_out)
-      real(wp), dimension(npts) , intent(in)  :: pos
+      real(wp), dimension(npts), intent(in)  :: pos
       class(abstract_vector_rdp), intent(out) :: vec_out
       ! internal
       real(wp), dimension(npts) :: wrk
@@ -428,7 +428,7 @@ contains
       class(rk_class), intent(inout)      :: me
       real(wp), intent(in)                :: t
       real(wp), dimension(:), intent(in)  :: x
-      
+
       print '(*(F15.6,1X))', t, x
 
       return
@@ -437,10 +437,10 @@ contains
    subroutine write_report_header()
       ! internals
       integer :: i, j, iunit
-      open(newunit=iunit, file=report_file, status='new', action='write')
+      open (newunit=iunit, file=report_file, status='new', action='write')
       ! time, baseflow
-      write(iunit,'(*(A16,1X))') 't', 'BF_x', 'BF_y', 'BF_z'
-      close(iunit)
+      write (iunit, '(*(A16,1X))') 't', 'BF_x', 'BF_y', 'BF_z'
+      close (iunit)
       return
    end subroutine write_report_header
 
@@ -450,10 +450,10 @@ contains
       real(wp), dimension(:), intent(in)  :: x
       ! internals
       integer :: iunit
-      open(newunit=iunit, file=report_file, status='old', action='write', position='append')
-      write(iunit, '(*(F15.6,1X))') t, x
-      close(iunit)
+      open (newunit=iunit, file=report_file, status='old', action='write', position='append')
+      write (iunit, '(*(F15.6,1X))') t, x
+      close (iunit)
       return
    end subroutine roessler_report_file
- 
+
 end module Roessler

--- a/example/roessler/roessler.f90
+++ b/example/roessler/roessler.f90
@@ -48,7 +48,7 @@ module Roessler
    type, extends(abstract_system_rdp), public :: roessler_upo
    contains
       private
-      procedure, pass(self), public :: eval => nonlinear_map
+      procedure, pass(self), public :: response => nonlinear_map
    end type roessler_upo
 
    type, extends(abstract_jacobian_linop_rdp), public :: jacobian
@@ -243,7 +243,7 @@ contains
  
    subroutine nonlinear_map(self, vec_in, vec_out, atol)
       ! Dynamical system.
-      class(roessler_upo),        intent(in)  :: self
+      class(roessler_upo),        intent(inout)  :: self
       ! Input vector.
       class(abstract_vector_rdp), intent(in)  :: vec_in
       ! Output vector.
@@ -284,7 +284,7 @@ contains
  
    subroutine linear_map(self, vec_in, vec_out)
       ! Linear Operator.
-      class(jacobian), intent(in) :: self
+      class(jacobian), intent(inout) :: self
       ! Input vector.
       class(abstract_vector_rdp) , intent(in)  :: vec_in
       ! Output vector.
@@ -333,7 +333,7 @@ contains
 
    subroutine monodromy_map(self, vec_in, vec_out)
       ! Linear Operator.
-      class(floquet_operator), intent(in) :: self
+      class(floquet_operator), intent(inout) :: self
       ! Input vector.
       class(abstract_vector_rdp) , intent(in)  :: vec_in
       ! Output vector.

--- a/example/roessler/roessler_OTD.f90
+++ b/example/roessler/roessler_OTD.f90
@@ -14,7 +14,7 @@ module Roessler_OTD
    use Roessler
    implicit none
  
-   character*128, parameter, private :: this_module = 'Roessler_OTD'
+   character(len=*), parameter, private :: this_module = 'Roessler_OTD'
  
    public :: a, b, c
  
@@ -24,8 +24,8 @@ module Roessler_OTD
  
    integer,  parameter :: r = 2
    real(wp), parameter :: t_GS = 5.0_wp ! In finite-precision arithmetic we need to reorthonormalize sometimes
-   character(len=128), parameter :: file    = 'example/roessler/output_roessler_OTD.txt'
-   character(len=128), parameter :: file_LE = 'example/roessler/output_roessler_OTD_LE.txt'
+   character(len=*), parameter :: report_file_OTD    = 'example/roessler/output_roessler_OTD.txt'
+   character(len=*), parameter :: report_file_OTD_LE = 'example/roessler/output_roessler_OTD_LE.txt'
 
    ! Reference values (https://chaosbook.org/extras/simon/Roessler.html, orbit 1)
    real(wp), dimension(2), parameter :: EV_ref = (/ 0.097000856_wp, 0.097000856_wp /)
@@ -365,7 +365,7 @@ contains
       is_cc = .false.
       if (abs(aimag(l(1))) > 0.0_wp) is_cc = .true.
 
-      open(newunit=iunit, file=file, status='old', action='write', position='append')
+      open(newunit=iunit, file=report_file_OTD, status='old', action='write', position='append')
       write(iunit, '(*(E16.9,1X))', ADVANCE='NO') t, bf, q
       if (is_cc) then
          write(iunit, '(I2,1X,*(E16.9,1X))', ADVANCE='NO') 1, s(1), real(l(1)), aimag(l(1)), real(u(:,1)), aimag(u(:,1))
@@ -393,7 +393,7 @@ contains
       LE = FTLE/period
       call sort(LE)
       print '(A10,I3,A3,1X,*(F16.9,1X))', 'OTD:  t=', p_cnt, 'T ', LE
-      open(newunit=iunit, file=file_LE, status='old', action='write', position='append')
+      open(newunit=iunit, file=report_file_OTD_LE, status='old', action='write', position='append')
       write(iunit, '(F16.9,1X,I16,1X,*(F16.9,1X))') time, p_cnt, LE, LE_ref
       close(iunit)
       return
@@ -402,7 +402,7 @@ contains
    subroutine write_header()
       ! internals
       integer :: i, j, iunit
-      open(newunit=iunit, file=file, status='new', action='write')
+      open(newunit=iunit, file=report_file_OTD, status='new', action='write')
       ! time, baseflow
       write(iunit,'(*(A16,1X))', ADVANCE='NO') 't', 'BF_x', 'BF_y', 'BF_z'
       ! basis vectors
@@ -439,7 +439,7 @@ contains
    subroutine write_header_LE()
       ! internals
       integer :: i, iunit
-      open(newunit=iunit, file=file_LE, status='new', action='write')
+      open(newunit=iunit, file=report_file_OTD_LE, status='new', action='write')
       ! time, baseflow
       write(iunit,'(*(A16,1X))', ADVANCE='NO') 't', 'period'
       ! LE

--- a/example/roessler/roessler_OTD.f90
+++ b/example/roessler/roessler_OTD.f90
@@ -2,7 +2,7 @@ module Roessler_OTD
    ! Standard Library.
    use stdlib_stats_distribution_normal, only: normal => rvs_normal
    use stdlib_optval, only: optval
-   use stdlib_sorting, only : sort
+   use stdlib_sorting, only: sort
    use stdlib_linalg, only: eig, svdvals, eye
    ! RKLIB module for time integration.
    use rklib_module
@@ -13,28 +13,28 @@ module Roessler_OTD
    ! Roessler
    use Roessler
    implicit none
- 
+
    character(len=*), parameter, private :: this_module = 'Roessler_OTD'
- 
+
    public :: a, b, c
- 
+
    !------------------------------
    !-----     PARAMETERS     -----
    !------------------------------
- 
-   integer,  parameter :: r = 2
+
+   integer, parameter :: r = 2
    real(wp), parameter :: t_GS = 5.0_wp ! In finite-precision arithmetic we need to reorthonormalize sometimes
-   character(len=*), parameter :: report_file_OTD    = 'example/roessler/output_roessler_OTD.txt'
+   character(len=*), parameter :: report_file_OTD = 'example/roessler/output_roessler_OTD.txt'
    character(len=*), parameter :: report_file_OTD_LE = 'example/roessler/output_roessler_OTD_LE.txt'
 
    ! Reference values (https://chaosbook.org/extras/simon/Roessler.html, orbit 1)
-   real(wp), dimension(2), parameter :: EV_ref = (/ 0.097000856_wp, 0.097000856_wp /)
-   real(wp), dimension(2), parameter :: LE_ref = (/ 0.0_wp        , 0.149141556_wp /)
+   real(wp), dimension(2), parameter :: EV_ref = (/0.097000856_wp, 0.097000856_wp/)
+   real(wp), dimension(2), parameter :: LE_ref = (/0.0_wp, 0.149141556_wp/)
 
    !-------------------------------------------
    !-----     LIGHTKRYLOV VECTOR TYPE     -----
    !-------------------------------------------
- 
+
    type, extends(abstract_vector_rdp), public :: pos_vector
       real(wp) :: x = 0.0_wp
       real(wp) :: y = 0.0_wp
@@ -48,7 +48,7 @@ module Roessler_OTD
       procedure, pass(self), public :: rand => rand_p
       procedure, pass(self), public :: get_size => get_size_p
    end type pos_vector
- 
+
 contains
 
    !=========================================================
@@ -58,11 +58,11 @@ contains
    !=====                                               =====
    !=========================================================
    !=========================================================
-   
+
    !----------------------------------------------------
    !-----     TYPE-BOUND PROCEDURE FOR VECTORS     -----
    !----------------------------------------------------
-      
+
    subroutine zero_p(self)
       class(pos_vector), intent(inout) :: self
       ! spatial coordinates of initial condition for orbit
@@ -71,156 +71,156 @@ contains
       self%z = 0.0_wp
       return
    end subroutine zero_p
-   
+
    real(wp) function dot_p(self, vec) result(alpha)
-      class(pos_vector)       , intent(in) :: self
+      class(pos_vector), intent(in) :: self
       class(abstract_vector_rdp), intent(in) :: vec
-      select type(vec)
-      type is(pos_vector)
+      select type (vec)
+      type is (pos_vector)
          alpha = self%x*vec%x + self%y*vec%y + self%z*vec%z
       end select
       return
    end function dot_p
-   
+
    subroutine scal_p(self, alpha)
       class(pos_vector), intent(inout) :: self
-      real(wp)           , intent(in)    :: alpha
-      self%x = self%x * alpha
-      self%y = self%y * alpha
-      self%z = self%z * alpha
+      real(wp), intent(in)    :: alpha
+      self%x = self%x*alpha
+      self%y = self%y*alpha
+      self%z = self%z*alpha
       return
    end subroutine scal_p
-   
+
    subroutine axpby_p(self, alpha, vec, beta)
-      class(pos_vector)       , intent(inout) :: self
+      class(pos_vector), intent(inout) :: self
       class(abstract_vector_rdp), intent(in)    :: vec
-      real(wp)                  , intent(in)    :: alpha, beta
-      select type(vec)
-      type is(pos_vector)
+      real(wp), intent(in)    :: alpha, beta
+      select type (vec)
+      type is (pos_vector)
          self%x = alpha*self%x + beta*vec%x
          self%y = alpha*self%y + beta*vec%y
          self%z = alpha*self%z + beta*vec%z
       end select
       return
    end subroutine axpby_p
-   
+
    integer function get_size_p(self) result(N)
       class(pos_vector), intent(in) :: self
-      N = npts+1
+      N = npts + 1
       return
    end function get_size_p
-   
+
    subroutine rand_p(self, ifnorm)
       class(pos_vector), intent(inout) :: self
-      logical, optional,   intent(in)    :: ifnorm
+      logical, optional, intent(in)    :: ifnorm
       logical :: normalized
       real(wp) :: mu, var
       real(wp) :: alpha
-   
+
       mu = 0.0_wp
       var = 1.0_wp
       self%x = normal(mu, var)
       self%y = normal(mu, var)
       self%z = normal(mu, var)
- 
+
       normalized = optval(ifnorm, .false.)
       if (normalized) then
          alpha = self%norm()
          call self%scal(1.0_wp/alpha)
-      endif
+      end if
       return
    end subroutine rand_p
-   
+
    subroutine OTD_rhs(me, t, x, f)
       ! Time-integrator.
       class(rk_class), intent(inout)             :: me
       ! Current time.
-      real(kind=wp)  , intent(in)                :: t
+      real(kind=wp), intent(in)                :: t
       ! State vector.
-      real(kind=wp)  , dimension(:), intent(in)  :: x
+      real(kind=wp), dimension(:), intent(in)  :: x
       ! Time-derivative.
-      real(kind=wp)  , dimension(:), intent(out) :: f
+      real(kind=wp), dimension(:), intent(out) :: f
       ! internal
-      real(kind=wp)  , dimension(npts)   :: bf
-      real(kind=wp)  , dimension(npts,r) :: q, Lq, fp
-      real(kind=wp)  , dimension(r,r)    :: Lr, Phi
+      real(kind=wp), dimension(npts)   :: bf
+      real(kind=wp), dimension(npts, r) :: q, Lq, fp
+      real(kind=wp), dimension(r, r)    :: Lr, Phi
       integer :: i, j
-   
+
       bf = x(:npts)
-      q = reshape(x(npts+1:(r+1)*npts), shape(q))
-   
-      call    nonlinear_roessler(        bf, f(:npts))
+      q = reshape(x(npts + 1:(r + 1)*npts), shape(q))
+
+      call nonlinear_roessler(bf, f(:npts))
       do i = 1, r
-         call linear_roessler   (q(:,i), bf, Lq(:,i))
+         call linear_roessler(q(:, i), bf, Lq(:, i))
       end do
       ! build reduced operator and rotation matrix
       Lr = 0.0_wp
       Phi = 0.0_wp
       do i = 1, r
          do j = 1, r
-            Lr(i,j) = dot_product(q(:,i), Lq(:,j))
+            Lr(i, j) = dot_product(q(:, i), Lq(:, j))
          end do
-         do j = i+1, r
-            Phi(i,j) =  Lr(i, j)
-            Phi(j,i) = -Phi(i,j)
-         enddo
+         do j = i + 1, r
+            Phi(i, j) = Lr(i, j)
+            Phi(j, i) = -Phi(i, j)
+         end do
       end do
       ! Construct forcing and add the rhs
       fp = Lq - matmul(q, Lr - Phi)
-      f(npts+1:(r+1)*npts) = reshape(fp, [size(fp)])
+      f(npts + 1:(r + 1)*npts) = reshape(fp, [size(fp)])
       ! Construct dFTLE(i)/dt = Lr(i,i)
       do i = 1, r
-         f((r+1)*npts+i) = Lr(i,i)
+         f((r + 1)*npts + i) = Lr(i, i)
       end do
       return
    end subroutine OTD_rhs
-   
+
    !------------------------------
    !-----     INTEGRATOR     -----
    !------------------------------
 
    subroutine OTD_step(integrator, bf, vec_in, FTLE_in, time, Tstep, vec_out, FTLE_out)
       ! Integrator
-      class(rk_class)           , intent(inout)  :: integrator
+      class(rk_class), intent(inout)  :: integrator
       ! Basic state
       class(abstract_vector_rdp), intent(inout)  :: bf
       ! Input vector.
       class(abstract_vector_rdp), intent(in)     :: vec_in(r)
       ! Fundamental solution matrix
-      real(wp),                   intent(in)     :: FTLE_in(r)
+      real(wp), intent(in)     :: FTLE_in(r)
       ! Current simulation time
-      real(wp),                   intent(inout)  :: time
+      real(wp), intent(inout)  :: time
       ! Integration time for this step.
-      real(wp),                   intent(in)     :: Tstep
+      real(wp), intent(in)     :: Tstep
       ! Output vector.
       class(abstract_vector_rdp), intent(out)    :: vec_out(r)
       ! Fundamental solution matrix
-      real(wp),                   intent(out)    :: FTLE_out(r)
-      
-      ! internals      
+      real(wp), intent(out)    :: FTLE_out(r)
+
+      ! internals
       real(wp)                          :: dt = 1.0_wp
-      real(wp), dimension((r+1)*npts+r) :: pos_in, pos_out
+      real(wp), dimension((r + 1)*npts + r) :: pos_in, pos_out
       integer                           :: i
-      
-      select type(integrator)
-      type is(rks54_class)
+
+      select type (integrator)
+      type is (rks54_class)
          ! Get the state.
          call get_pos(bf, pos_in(:npts)) ! bf is a state vector
          do i = 1, r
-            call get_pos(vec_in(i), pos_in(npts*i+1:npts*(i+1)))
+            call get_pos(vec_in(i), pos_in(npts*i + 1:npts*(i + 1)))
          end do
-         pos_in(npts*(r+1)+1:) = FTLE_in
+         pos_in(npts*(r + 1) + 1:) = FTLE_in
          ! Integrate.
-         call integrator%integrate(time, pos_in, dt, time+Tstep, pos_out)
+         call integrator%integrate(time, pos_in, dt, time + Tstep, pos_out)
          ! Pass-back the state.
          call set_pos(pos_out(:npts), bf)
          do i = 1, r
-            call set_pos(pos_out(npts*i+1:npts*(i+1)), vec_out(i))
+            call set_pos(pos_out(npts*i + 1:npts*(i + 1)), vec_out(i))
          end do
-         FTLE_out = pos_out(npts*(r+1)+1:)
-         time = time + Tstep     
+         FTLE_out = pos_out(npts*(r + 1) + 1:)
+         time = time + Tstep
       end select
-      
+
       return
    end subroutine OTD_step
 
@@ -230,13 +230,13 @@ contains
       ! Input vector.
       class(abstract_vector_rdp), intent(inout) :: vec_in(r)
       ! Integration time.
-      real(wp),                   intent(in)    :: Tend
+      real(wp), intent(in)    :: Tend
       ! Output vector.
       class(abstract_vector_rdp), intent(out)   :: vec_out(r)
       ! Integration time for FLTEs
-      real(wp),                   intent(in)    :: t_FTLE
+      real(wp), intent(in)    :: t_FTLE
       ! restart trajectory at t_FLTE?
-      logical, optional,          intent(in)    :: if_rst
+      logical, optional, intent(in)    :: if_rst
 
       ! internals
       type(rks54_class)         :: OTD_roessler
@@ -247,22 +247,22 @@ contains
       real(wp), dimension(r)    :: FTLE_in, FTLE_out
       real(wp), dimension(npts) :: bf_bkp
 
-      integer, parameter :: ndof = npts*(r+1) + r
+      integer, parameter :: ndof = npts*(r + 1) + r
 
       ! Initialize integrator.
       call OTD_roessler%initialize(n=ndof, f=OTD_rhs, report=OTD_report_file, report_rate=20)
-      
+
       ! Save IC
       call get_pos(bf, bf_bkp)
 
       ! Initialization
-      time    = 0.0_wp
+      time = 0.0_wp
       FTLE_in = 0.0_wp
-      p_cnt   = 0
-      tvec = (/ t_GS, t_FTLE /)
-      idx  = minloc(tvec)
-      t1   = minval(tvec)
-      t2   = maxval(tvec)
+      p_cnt = 0
+      tvec = (/t_GS, t_FTLE/)
+      idx = minloc(tvec)
+      t1 = minval(tvec)
+      t2 = maxval(tvec)
       ! Regular integration with much less frequent reorthonormalization
       do j = 1, floor(Tend/t2)
          do i = 1, floor(t2/t1)
@@ -275,7 +275,7 @@ contains
                call report_LE(FTLE_out, time, t_FTLE, p_cnt)
                FTLE_in = 0.0_wp                                   ! reset FTLE computation
                if (if_rst) call set_pos(bf_bkp, bf)               ! reset orbit to avoid orbit drift
-            endif
+            end if
             call copy(vec_in, vec_out)
          end do
          t_complete = modulo(t2, t1)
@@ -288,7 +288,7 @@ contains
             call report_LE(FTLE_out, time, t_FTLE, p_cnt)
             FTLE_in = 0.0_wp                                      ! reset FTLE computation
             if (if_rst) call set_pos(bf_bkp, bf)                  ! reset orbit to avoid orbit drift
-         endif
+         end if
          call copy(vec_in, vec_out)
       end do
       t_complete = modulo(Tend, t2)
@@ -299,22 +299,22 @@ contains
    !-------------------------------------------
    !-----     MISCELLANEOUS UTILITIES     -----
    !-------------------------------------------
- 
+
    subroutine get_pos(vec_in, pos)
       class(abstract_vector_rdp), intent(in)  :: vec_in
-      real(wp), dimension(npts),  intent(out) :: pos
+      real(wp), dimension(npts), intent(out) :: pos
       pos = 0.0_wp
       select type (vec_in)
       type is (pos_vector)
-          pos(1) = vec_in%x
-          pos(2) = vec_in%y
-          pos(3) = vec_in%z
+         pos(1) = vec_in%x
+         pos(2) = vec_in%y
+         pos(3) = vec_in%z
       end select
       return
    end subroutine get_pos
 
    subroutine set_pos(pos, vec_out)
-      real(wp), dimension(npts),  intent(in)  :: pos
+      real(wp), dimension(npts), intent(in)  :: pos
       class(abstract_vector_rdp), intent(out) :: vec_out
       select type (vec_out)
       type is (pos_vector)
@@ -329,33 +329,33 @@ contains
       class(rk_class), intent(inout)      :: me
       real(wp), intent(in)                :: t
       real(wp), dimension(:), intent(in)  :: x
-      
+
       ! internal
       real(wp), dimension(npts)      :: bf
-      real(wp), dimension(npts,r)    :: q, Lq
-      real(wp), dimension(r,r)       :: Lr, Lsym, qTq
+      real(wp), dimension(npts, r)    :: q, Lq
+      real(wp), dimension(r, r)       :: Lr, Lsym, qTq
       real(wp), dimension(r)         :: FTLE, s
       complex(wp), dimension(r)      :: l
-      complex(wp), dimension(r,r)    :: v
-      complex(wp), dimension(npts,r) :: u, su
+      complex(wp), dimension(r, r)    :: v
+      complex(wp), dimension(npts, r) :: u, su
       integer                        :: i, j, iunit
       logical                        :: is_cc
       integer, allocatable           :: idx(:)
 
-      bf   = x(:npts)
-      q    = reshape(x(npts+1:(r+1)*npts), shape(q))
-      FTLE = x(npts*(r+1)+1:)/t
+      bf = x(:npts)
+      q = reshape(x(npts + 1:(r + 1)*npts), shape(q))
+      FTLE = x(npts*(r + 1) + 1:)/t
 
       do i = 1, r
-         call linear_roessler   (q(:,i), bf, Lq(:,i))
+         call linear_roessler(q(:, i), bf, Lq(:, i))
       end do
       ! build reduced operator
       Lr = 0.0_wp
       qTq = 0.0_wp
       do i = 1, r
          do j = 1, r
-            Lr(i,j)  = dot_product(Lq(:,i), q(:,j))
-            qTq(i,j) = dot_product( q(:,i), q(:,j))
+            Lr(i, j) = dot_product(Lq(:, i), q(:, j))
+            qTq(i, j) = dot_product(q(:, i), q(:, j))
          end do
       end do
       ! spectral analysis
@@ -370,15 +370,18 @@ contains
       is_cc = .false.
       if (abs(aimag(l(1))) > 0.0_wp) is_cc = .true.
 
-      open(newunit=iunit, file=report_file_OTD, status='old', action='write', position='append')
-      write(iunit, '(*(E16.9,1X))', ADVANCE='NO') t, bf, q
+      open (newunit=iunit, file=report_file_OTD, status='old', action='write', position='append')
+      write (iunit, '(*(E16.9,1X))', ADVANCE='NO') t, bf, q
       if (is_cc) then
-         write(iunit, '(I2,1X,*(E16.9,1X))', ADVANCE='NO') 1, s(i), real(su(:,i)), real(l(1)), aimag(l(1)), real(u(:,1)), aimag(u(:,1))
+         write (iunit, '(I2,1X,*(E16.9,1X))', ADVANCE='NO') 1, s(i), real(su(:, i)), &
+            real(l(1)), aimag(l(1)), real(u(:, 1)), aimag(u(:, 1))
       else
-         write(iunit, '(I2,1X,*(E16.9,1X))', ADVANCE='NO') 0, s(i), real(su(:,i)), real(l), real(u)
-      endif
-      write(iunit, '(*(E16.9,1X))') FTLE, ( qTq(i, i) - 1, i = 1, r), (( qTq(i, j), j = 1, i-1), i = 2, r)
-      close(iunit)
+         write (iunit, '(I2,1X,*(E16.9,1X))', ADVANCE='NO') 0, s(i), real(su(:, i)), &
+            real(l), real(u)
+      end if
+      write (iunit, '(*(E16.9,1X))') FTLE, (qTq(i, i) - 1, i=1, r), &
+         ((qTq(i, j), j=1, i - 1), i=2, r)
+      close (iunit)
 
       return
    end subroutine OTD_report_file
@@ -387,78 +390,78 @@ contains
       ! Integrated FTLE values
       real(wp), dimension(r), intent(in) :: FTLE
       ! simulation
-      real(wp),               intent(in) :: time
+      real(wp), intent(in) :: time
       ! period
-      real(wp),               intent(in) :: period
+      real(wp), intent(in) :: period
       ! period counter
-      integer,                intent(in) :: p_cnt
+      integer, intent(in) :: p_cnt
       ! internal
       integer :: iunit
       real(wp), dimension(r) :: LE
       LE = FTLE/period
       call sort(LE)
       print '(A10,I3,A3,1X,*(F16.9,1X))', 'OTD:  t=', p_cnt, 'T ', LE
-      open(newunit=iunit, file=report_file_OTD_LE, status='old', action='write', position='append')
-      write(iunit, '(F16.9,1X,I16,1X,*(F16.9,1X))') time, p_cnt, LE, LE_ref
-      close(iunit)
+      open (newunit=iunit, file=report_file_OTD_LE, status='old', action='write', position='append')
+      write (iunit, '(F16.9,1X,I16,1X,*(F16.9,1X))') time, p_cnt, LE, LE_ref
+      close (iunit)
       return
    end subroutine report_LE
 
    subroutine write_header()
       ! internals
       integer :: i, j, iunit
-      open(newunit=iunit, file=report_file_OTD, status='new', action='write')
+      open (newunit=iunit, file=report_file_OTD, status='new', action='write')
       ! time, baseflow
-      write(iunit,'(*(A16,1X))', ADVANCE='NO') 't', 'BF_x', 'BF_y', 'BF_z'
+      write (iunit, '(*(A16,1X))', ADVANCE='NO') 't', 'BF_x', 'BF_y', 'BF_z'
       ! basis vectors
-      do i = 1, r 
-         write(iunit,'(*(A13,I1,A2,1X))', ADVANCE='NO') 'q', i, '_x', 'q', i, '_y', 'q', i, '_z'
+      do i = 1, r
+         write (iunit, '(*(A13,I1,A2,1X))', ADVANCE='NO') 'q', i, '_x', 'q', i, '_y', 'q', i, '_z'
       end do
       ! instantaneous numerical abscissa of the reduced operator
-      write(iunit,'(A2,1X,A16,1X)', ADVANCE='NO') 'cc', 'sigma_1'
+      write (iunit, '(A2,1X,A16,1X)', ADVANCE='NO') 'cc', 'sigma_1'
       ! instantaneous direction of largest possible growth
-      write(iunit,'(*(A13,I1,A2,1X))', ADVANCE='NO') 'us', i, '_x', 'us', i, '_y', 'us', i, '_z'
+      write (iunit, '(*(A13,I1,A2,1X))', ADVANCE='NO') 'us', i, '_x', 'us', i, '_y', 'us', i, '_z'
       ! instantaneous eigenvalues of the reduced operator
       do i = 1, r
-         write(iunit,'(A15,I1,1X)', ADVANCE='NO') 'l_', i
+         write (iunit, '(A15,I1,1X)', ADVANCE='NO') 'l_', i
       end do
       ! instantaneous projected eigenvectors of the reduced operator
       do i = 1, r
-         write(iunit,'(*(A13,I1,A2,1X))', ADVANCE='NO') 'u', i, '_x', 'u', i, '_y', 'u', i, '_z'
+         write (iunit, '(*(A13,I1,A2,1X))', ADVANCE='NO') 'u', i, '_x', 'u', i, '_y', 'u', i, '_z'
       end do
       ! instantaneous FLTEs
       do i = 1, r
-         write(iunit,'(A15,I1,1X)', ADVANCE='NO') 'FTLE_', i
+         write (iunit, '(A15,I1,1X)', ADVANCE='NO') 'FTLE_', i
       end do
       ! orthonormality of the basis vectors
       do i = 1, r
-         write(iunit,'(A7,I1,A2,I1,A5,1X)', ADVANCE='NO') '<q', i, ',q', i, '> - 1'
+         write (iunit, '(A7,I1,A2,I1,A5,1X)', ADVANCE='NO') '<q', i, ',q', i, '> - 1'
       end do
       do i = 2, r
-         do j = 1, i-1
-            write(iunit,'(A11,I1,A2,I1,A1,1X)', ADVANCE='NO') '<q', j, ',q', i, '>'
+         do j = 1, i - 1
+            write (iunit, '(A11,I1,A2,I1,A1,1X)', ADVANCE='NO') '<q', j, ',q', i, '>'
          end do
       end do
-      write(iunit,*) ''; close(iunit)
+      write (iunit, *) ''; close (iunit)
       return
    end subroutine write_header
 
    subroutine write_header_LE()
       ! internals
       integer :: i, iunit
-      open(newunit=iunit, file=report_file_OTD_LE, status='new', action='write')
+      open (newunit=iunit, file=report_file_OTD_LE, status='new', action='write')
       ! time, baseflow
-      write(iunit,'(*(A16,1X))', ADVANCE='NO') 't', 'period'
+      write (iunit, '(*(A16,1X))', ADVANCE='NO') 't', 'period'
       ! LE
       do i = 1, r
-         write(iunit,'(A15,I1,1X)', ADVANCE='NO') 'LE_', i
+         write (iunit, '(A15,I1,1X)', ADVANCE='NO') 'LE_', i
       end do
       ! LE_ref
       do i = 1, r
-         write(iunit,'(A15,I1,1X)', ADVANCE='NO') 'LEref_', i
+         write (iunit, '(A15,I1,1X)', ADVANCE='NO') 'LEref_', i
       end do
-      write(iunit,*) ''; close(iunit)
+      write (iunit, *) ''; close (iunit)
       return
    end subroutine write_header_LE
- 
+
 end module Roessler_OTD

--- a/src/AbstractLinops.f90
+++ b/src/AbstractLinops.f90
@@ -27,9 +27,8 @@ module LightKrylov_AbstractLinops
         !!  @warning
         !!  Users should not extend this abstract class to define their own types.
         !!  @endwarning
-    private
-        integer :: matvec_counter  = 0
-        integer :: rmatvec_counter = 0
+        integer, private :: matvec_counter  = 0
+        integer, private :: rmatvec_counter = 0
     contains
         procedure, pass(self), public :: get_counter
         !! Return matvec/rmatvec counter value

--- a/src/AbstractLinops.f90
+++ b/src/AbstractLinops.f90
@@ -15,7 +15,8 @@ module lightkrylov_AbstractLinops
     implicit none
     private
 
-    character(len=128), parameter :: this_module = 'Lightkrylov_AbstractLinops'
+    character(len=*), parameter :: this_module      = 'LK_Linops'
+    character(len=*), parameter :: this_module_long = 'Lightkrylov_AbstractLinops'
 
     type, abstract, public :: abstract_linop
         !!  Base type to define an abstract linear operator. All other types defined in

--- a/src/AbstractLinops.f90
+++ b/src/AbstractLinops.f90
@@ -31,14 +31,10 @@ module LightKrylov_AbstractLinops
         integer :: matvec_counter  = 0
         integer :: rmatvec_counter = 0
     contains
-        procedure, pass(self), public :: get_matvec_counter
-        !! Return matvec counter value
-        procedure, pass(self), public :: reset_matvec_counter
-        !! Reset matvec counter
-        procedure, pass(self), public :: get_rmatvec_counter
-        !! Return rmatvec counter value
-        procedure, pass(self), public :: reset_rmatvec_counter
-        !! Reset rmatvec counter
+        procedure, pass(self), public :: get_counter
+        !! Return matvec/rmatvec counter value
+        procedure, pass(self), public :: reset_counter
+        !! Reset matvec/rmatvec counter
     end type abstract_linop
 
     !------------------------------------------------------------------------------
@@ -440,60 +436,45 @@ contains
     !--------------------------------------------------------------
     !-----     Getter/Setter routines for abstract_linops     -----
     !--------------------------------------------------------------
- 
-    pure integer function get_matvec_counter(self) result(count)
+
+    pure integer function get_counter(self, trans) result(count)
       !! Getter function for the number of matvec calls
       class(abstract_linop), intent(in) :: self
-      count = self%matvec_counter
-    end function get_matvec_counter
+      logical, intent(in) :: trans
+      !! matvec or rmatvec?
+      if (trans) then
+         count = self%rmatvec_counter
+      else
+         count = self%matvec_counter
+      end if
+    end function get_counter
 
-    subroutine reset_matvec_counter(self, counter, ifprint)
+    subroutine reset_counter(self, trans, procedure, counter)
       class(abstract_linop), intent(inout) :: self
+      logical, intent(in) :: trans
+      !! matvec or rmatvec?
+      character(len=*), intent(in) :: procedure
+      !! name of the caller routine
       integer, optional, intent(in) :: counter
       !! optional flag to reset to an integer other than zero.
-      logical, optional, intent(in) :: ifprint
-      !! optional flag to print the number of matvecs to log prior to resetting
       ! internals
-      integer :: counter_
-      logical :: ifprint_
+      integer :: counter_, count_old
       character(len=128) :: msg
       counter_ = optval(counter, 0)
-      ifprint_ = optval(ifprint, .false.)
-      if (ifprint_) then
-         write(msg,'(A,I0,A,I0,A)') 'Total number of matvecs: ', self%get_matvec_counter(), &
-                  & '. Resetting counter to ', counter_, '.'
-         call logger%log_message(msg, module=this_module, procedure='reset_matvec_counter')
+      count_old = self%get_counter(trans)
+      if ( count_old /= 0 .or. counter_ /= 0) then
+        if (trans) then
+            write(msg,'(A,I0,A,I0,A)') 'Total number of rmatvecs: ', count_old, '. Resetting counter to ', counter_, '.'
+            call logger%log_message(msg, module=this_module, procedure='reset_counter('//trim(procedure)//')')
+            self%rmatvec_counter = counter_
+        else
+            write(msg,'(A,I0,A,I0,A)') 'Total number of matvecs: ', count_old, '. Resetting counter to ', counter_, '.'
+            call logger%log_message(msg, module=this_module, procedure='reset_counter('//trim(procedure)//')')
+            self%matvec_counter = counter_
+        end if
       end if
-      self%matvec_counter = counter_
       return
-    end subroutine reset_matvec_counter
-
-    pure integer function get_rmatvec_counter(self) result(count)
-      !! Getter function for the number of rmatvec calls
-      class(abstract_linop), intent(in) :: self
-      count = self%rmatvec_counter
-    end function get_rmatvec_counter
-
-    subroutine reset_rmatvec_counter(self, counter, ifprint)
-      class(abstract_linop), intent(inout) :: self
-      integer, optional, intent(in) :: counter
-      !! optional flag to reset to an integer other than zero.
-      logical, optional, intent(in) :: ifprint
-      !! optional flag to print the number of rmatvecs to log prior to resetting
-      ! internals
-      integer :: counter_
-      logical :: ifprint_
-      character(len=128) :: msg
-      counter_ = optval(counter, 0)
-      ifprint_ = optval(ifprint, .false.)
-      if (ifprint_) then
-         write(msg,'(A,I0,A,I0,A)') 'Total number of rmatvecs: ', self%get_rmatvec_counter(), &
-                  & '. Resetting counter to ', counter_, '.'
-         call logger%log_message(msg, module=this_module, procedure='reset_rmatvec_counter')
-      end if
-      self%matvec_counter = counter_
-      return
-    end subroutine reset_rmatvec_counter
+    end subroutine reset_counter
 
     !---------------------------------------------------------------------
     !-----     Wrappers for matvec/rmatvec to increment counters     -----

--- a/src/AbstractLinops.fypp
+++ b/src/AbstractLinops.fypp
@@ -17,7 +17,8 @@ module lightkrylov_AbstractLinops
     implicit none
     private
 
-    character(len=128), parameter :: this_module = 'Lightkrylov_AbstractLinops'
+    character(len=*), parameter :: this_module      = 'LK_Linops'
+    character(len=*), parameter :: this_module_long = 'Lightkrylov_AbstractLinops'
 
     type, abstract, public :: abstract_linop
         !!  Base type to define an abstract linear operator. All other types defined in

--- a/src/AbstractLinops.fypp
+++ b/src/AbstractLinops.fypp
@@ -1,6 +1,6 @@
 #:include "../include/common.fypp"
 #:set RC_KINDS_TYPES = REAL_KINDS_TYPES + CMPLX_KINDS_TYPES
-module lightkrylov_AbstractLinops
+module LightKrylov_AbstractLinops
     !!  This module provides the base classes `abtract_linop_rsp`, `abstract_linop_rdp`,
     !!  `abstract_linop_csp` and `abstract_linop_cdp` which can be used to define your own
     !!  linear operators. To do so, you simply need to provide two type-bound procedures:
@@ -11,9 +11,11 @@ module lightkrylov_AbstractLinops
     !!  It also provides extended types to define the identity operator, symmetric linear
     !!  operators, scalar-multiplication of a linear multiplication, as well as addition
     !!  of two linear operators.
-    use lightkrylov_Constants
-    use lightkrylov_Utils
-    use lightkrylov_AbstractVectors
+    use stdlib_optval, only: optval
+    use LightKrylov_Logger
+    use LightKrylov_Constants
+    use LightKrylov_Utils
+    use LightKrylov_AbstractVectors
     implicit none
     private
 
@@ -27,6 +29,18 @@ module lightkrylov_AbstractLinops
         !!  @warning
         !!  Users should not extend this abstract class to define their own types.
         !!  @endwarning
+    private
+        integer :: matvec_counter  = 0
+        integer :: rmatvec_counter = 0
+    contains
+        procedure, pass(self), public :: get_matvec_counter
+        !! Return matvec counter value
+        procedure, pass(self), public :: reset_matvec_counter
+        !! Reset matvec counter
+        procedure, pass(self), public :: get_rmatvec_counter
+        !! Return rmatvec counter value
+        procedure, pass(self), public :: reset_rmatvec_counter
+        !! Reset rmatvec counter
     end type abstract_linop
 
     #:for kind, type in RC_KINDS_TYPES
@@ -37,10 +51,16 @@ module lightkrylov_AbstractLinops
         !! Base type to extend in order to define a ${type}$-valued linear operator.
     contains
         private
+        ! User defined procedures
         procedure(abstract_matvec_${type[0]}$${kind}$), pass(self), deferred, public :: matvec
         !! Procedure to compute the matrix-vector product \( \mathbf{y} = \mathbf{Ax} \).
         procedure(abstract_matvec_${type[0]}$${kind}$), pass(self), deferred, public :: rmatvec
         !! Procedure to compute the reversed matrix-vector product \( \mathbf{y} = \mathbf{A}^H \mathbf{x} \).
+        ! Wrappers including counter increment
+        procedure, pass(self), public :: apply_matvec => apply_matvec_${type[0]}$${kind}$
+        !! Wrapper for matvec including the counter increment
+        procedure, pass(self), public :: apply_rmatvec => apply_rmatvec_${type[0]}$${kind}$
+        !! Wrapper for rmatvec including the counter increment
     end type
 
     abstract interface
@@ -48,7 +68,7 @@ module lightkrylov_AbstractLinops
             !! Interface for the matrix-vector product.
             use lightkrylov_AbstractVectors
             import abstract_linop_${type[0]}$${kind}$
-            class(abstract_linop_${type[0]}$${kind}$) , intent(in)  :: self
+            class(abstract_linop_${type[0]}$${kind}$) , intent(inout)  :: self
             !! Linear operator \(\mathbf{A}\).
             class(abstract_vector_${type[0]}$${kind}$), intent(in)  :: vec_in
             !! Vector to be multiplied by \(\mathbf{A}\).
@@ -165,9 +185,95 @@ module lightkrylov_AbstractLinops
     #:endfor
 contains
 
+    !--------------------------------------------------------------
+    !-----     Getter/Setter routines for abstract_linops     -----
+    !--------------------------------------------------------------
+ 
+    pure integer function get_matvec_counter(self) result(count)
+      !! Getter function for the number of matvec calls
+      class(abstract_linop), intent(in) :: self
+      count = self%matvec_counter
+    end function get_matvec_counter
+
+    subroutine reset_matvec_counter(self, counter, ifprint)
+      class(abstract_linop), intent(inout) :: self
+      integer, optional, intent(in) :: counter
+      !! optional flag to reset to an integer other than zero.
+      logical, optional, intent(in) :: ifprint
+      !! optional flag to print the number of matvecs to log prior to resetting
+      ! internals
+      integer :: counter_
+      logical :: ifprint_
+      character(len=128) :: msg
+      counter_ = optval(counter, 0)
+      ifprint_ = optval(ifprint, .false.)
+      if (ifprint_) then
+         write(msg,'(A,I0,A,I0,A)') 'Total number of matvecs: ', self%get_matvec_counter(), &
+                  & '. Resetting counter to ', counter_, '.'
+         call logger%log_message(msg, module=this_module, procedure='reset_matvec_counter')
+      end if
+      self%matvec_counter = counter_
+      return
+    end subroutine reset_matvec_counter
+
+    pure integer function get_rmatvec_counter(self) result(count)
+      !! Getter function for the number of rmatvec calls
+      class(abstract_linop), intent(in) :: self
+      count = self%rmatvec_counter
+    end function get_rmatvec_counter
+
+    subroutine reset_rmatvec_counter(self, counter, ifprint)
+      class(abstract_linop), intent(inout) :: self
+      integer, optional, intent(in) :: counter
+      !! optional flag to reset to an integer other than zero.
+      logical, optional, intent(in) :: ifprint
+      !! optional flag to print the number of rmatvecs to log prior to resetting
+      ! internals
+      integer :: counter_
+      logical :: ifprint_
+      character(len=128) :: msg
+      counter_ = optval(counter, 0)
+      ifprint_ = optval(ifprint, .false.)
+      if (ifprint_) then
+         write(msg,'(A,I0,A,I0,A)') 'Total number of rmatvecs: ', self%get_rmatvec_counter(), &
+                  & '. Resetting counter to ', counter_, '.'
+         call logger%log_message(msg, module=this_module, procedure='reset_rmatvec_counter')
+      end if
+      self%matvec_counter = counter_
+      return
+    end subroutine reset_rmatvec_counter
+
+    !---------------------------------------------------------------------
+    !-----     Wrappers for matvec/rmatvec to increment counters     -----
+    !---------------------------------------------------------------------
+
+    #:for kind, type in RC_KINDS_TYPES
+    subroutine apply_matvec_${type[0]}$${kind}$(self, vec_in, vec_out)
+        class(abstract_linop_${type[0]}$${kind}$), intent(inout) :: self
+        class(abstract_vector_${type[0]}$${kind}$), intent(in) :: vec_in
+        class(abstract_vector_${type[0]}$${kind}$), intent(out) :: vec_out
+        self%matvec_counter = self%matvec_counter + 1
+        call self%matvec(vec_in, vec_out)
+        return
+    end subroutine apply_matvec_${type[0]}$${kind}$
+
+    subroutine apply_rmatvec_${type[0]}$${kind}$(self, vec_in, vec_out)
+        class(abstract_linop_${type[0]}$${kind}$), intent(inout) :: self
+        class(abstract_vector_${type[0]}$${kind}$), intent(in) :: vec_in
+        class(abstract_vector_${type[0]}$${kind}$), intent(out) :: vec_out
+        self%rmatvec_counter = self%rmatvec_counter + 1
+        call self%rmatvec(vec_in, vec_out)
+        return
+    end subroutine apply_rmatvec_${type[0]}$${kind}$
+    #:endfor
+
+    !------------------------------------------------------------------------------
+    !-----     Concrete matvec/rmatvec implementations for special linops     -----
+    !------------------------------------------------------------------------------
+
     #:for kind, type in RC_KINDS_TYPES
     subroutine id_matvec_${type[0]}$${kind}$(self, vec_in, vec_out)
-        class(Id_${type[0]}$${kind}$), intent(in) :: self
+        class(Id_${type[0]}$${kind}$), intent(inout) :: self
         class(abstract_vector_${type[0]}$${kind}$), intent(in) :: vec_in
         class(abstract_vector_${type[0]}$${kind}$), intent(out) :: vec_out
         call copy(vec_out, vec_in)
@@ -177,25 +283,25 @@ contains
 
     #:for kind, type in RC_KINDS_TYPES
     subroutine scaled_matvec_${type[0]}$${kind}$(self, vec_in, vec_out)
-        class(scaled_linop_${type[0]}$${kind}$), intent(in) :: self
+        class(scaled_linop_${type[0]}$${kind}$), intent(inout) :: self
         class(abstract_vector_${type[0]}$${kind}$), intent(in) :: vec_in
         class(abstract_vector_${type[0]}$${kind}$), intent(out) :: vec_out
-        call self%A%matvec(vec_in, vec_out) ; call vec_out%scal(self%sigma)
+        call self%A%apply_matvec(vec_in, vec_out) ; call vec_out%scal(self%sigma)
         return
     end subroutine scaled_matvec_${type[0]}$${kind}$
 
     subroutine scaled_rmatvec_${type[0]}$${kind}$(self, vec_in, vec_out)
-        class(scaled_linop_${type[0]}$${kind}$), intent(in) :: self
+        class(scaled_linop_${type[0]}$${kind}$), intent(inout) :: self
         class(abstract_vector_${type[0]}$${kind}$), intent(in) :: vec_in
         class(abstract_vector_${type[0]}$${kind}$), intent(out) :: vec_out
-        call self%A%rmatvec(vec_in, vec_out) ; call vec_out%scal(self%sigma)
+        call self%A%apply_rmatvec(vec_in, vec_out) ; call vec_out%scal(self%sigma)
         return
     end subroutine scaled_rmatvec_${type[0]}$${kind}$
     #:endfor
 
     #:for kind, type in RC_KINDS_TYPES
     subroutine axpby_matvec_${type[0]}$${kind}$(self, vec_in, vec_out)
-        class(axpby_linop_${type[0]}$${kind}$), intent(in) :: self
+        class(axpby_linop_${type[0]}$${kind}$), intent(inout) :: self
         class(abstract_vector_${type[0]}$${kind}$), intent(in) :: vec_in
         class(abstract_vector_${type[0]}$${kind}$), intent(out) :: vec_out
 
@@ -207,16 +313,16 @@ contains
 
         ! w = A @ x
         if (self%transA) then
-            call self%A%rmatvec(vec_in, wrk)
+            call self%A%apply_rmatvec(vec_in, wrk)
         else
-            call self%A%matvec(vec_in, wrk)
+            call self%A%apply_matvec(vec_in, wrk)
         endif
 
         ! y = B @ x
         if (self%transB) then
-            call self%B%rmatvec(vec_in, vec_out)
+            call self%B%apply_rmatvec(vec_in, vec_out)
         else
-            call self%B%matvec(vec_in, vec_out)
+            call self%B%apply_matvec(vec_in, vec_out)
         endif
 
         ! y = alpha*w + beta*y
@@ -226,7 +332,7 @@ contains
     end subroutine axpby_matvec_${type[0]}$${kind}$
 
     subroutine axpby_rmatvec_${type[0]}$${kind}$(self, vec_in, vec_out)
-        class(axpby_linop_${type[0]}$${kind}$), intent(in) :: self
+        class(axpby_linop_${type[0]}$${kind}$), intent(inout) :: self
         class(abstract_vector_${type[0]}$${kind}$), intent(in) :: vec_in
         class(abstract_vector_${type[0]}$${kind}$), intent(out) :: vec_out
 
@@ -238,16 +344,16 @@ contains
 
         ! w = A @ x
         if (self%transA) then
-            call self%A%matvec(vec_in, wrk)
+            call self%A%apply_matvec(vec_in, wrk)
         else
-            call self%A%rmatvec(vec_in, wrk)
+            call self%A%apply_rmatvec(vec_in, wrk)
         endif
 
         ! y = B @ x
         if (self%transB) then
-            call self%B%matvec(vec_in, vec_out)
+            call self%B%apply_matvec(vec_in, vec_out)
         else
-            call self%B%rmatvec(vec_in, vec_out)
+            call self%B%apply_rmatvec(vec_in, vec_out)
         endif
 
         ! y = alpha*w + beta*y
@@ -260,21 +366,21 @@ contains
 
     #:for kind, type in RC_KINDS_TYPES
     subroutine adjoint_matvec_${type[0]}$${kind}$(self, vec_in, vec_out)
-        class(adjoint_linop_${type[0]}$${kind}$), intent(in) :: self
+        class(adjoint_linop_${type[0]}$${kind}$), intent(inout) :: self
         class(abstract_vector_${type[0]}$${kind}$), intent(in) :: vec_in
         class(abstract_vector_${type[0]}$${kind}$), intent(out) :: vec_out
 
-        call self%A%rmatvec(vec_in, vec_out)
+        call self%A%apply_rmatvec(vec_in, vec_out)
 
         return
     end subroutine adjoint_matvec_${type[0]}$${kind}$
 
     subroutine adjoint_rmatvec_${type[0]}$${kind}$(self, vec_in, vec_out)
-        class(adjoint_linop_${type[0]}$${kind}$), intent(in) :: self
+        class(adjoint_linop_${type[0]}$${kind}$), intent(inout) :: self
         class(abstract_vector_${type[0]}$${kind}$), intent(in) :: vec_in
         class(abstract_vector_${type[0]}$${kind}$), intent(out) :: vec_out
 
-        call self%A%matvec(vec_in, vec_out)
+        call self%A%apply_matvec(vec_in, vec_out)
 
         return
     end subroutine adjoint_rmatvec_${type[0]}$${kind}$

--- a/src/AbstractLinops.fypp
+++ b/src/AbstractLinops.fypp
@@ -33,14 +33,10 @@ module LightKrylov_AbstractLinops
         integer :: matvec_counter  = 0
         integer :: rmatvec_counter = 0
     contains
-        procedure, pass(self), public :: get_matvec_counter
-        !! Return matvec counter value
-        procedure, pass(self), public :: reset_matvec_counter
-        !! Reset matvec counter
-        procedure, pass(self), public :: get_rmatvec_counter
-        !! Return rmatvec counter value
-        procedure, pass(self), public :: reset_rmatvec_counter
-        !! Reset rmatvec counter
+        procedure, pass(self), public :: get_counter
+        !! Return matvec/rmatvec counter value
+        procedure, pass(self), public :: reset_counter
+        !! Reset matvec/rmatvec counter
     end type abstract_linop
 
     #:for kind, type in RC_KINDS_TYPES
@@ -188,60 +184,45 @@ contains
     !--------------------------------------------------------------
     !-----     Getter/Setter routines for abstract_linops     -----
     !--------------------------------------------------------------
- 
-    pure integer function get_matvec_counter(self) result(count)
+
+    pure integer function get_counter(self, trans) result(count)
       !! Getter function for the number of matvec calls
       class(abstract_linop), intent(in) :: self
-      count = self%matvec_counter
-    end function get_matvec_counter
+      logical, intent(in) :: trans
+      !! matvec or rmatvec?
+      if (trans) then
+         count = self%rmatvec_counter
+      else
+         count = self%matvec_counter
+      end if
+    end function get_counter
 
-    subroutine reset_matvec_counter(self, counter, ifprint)
+    subroutine reset_counter(self, trans, procedure, counter)
       class(abstract_linop), intent(inout) :: self
+      logical, intent(in) :: trans
+      !! matvec or rmatvec?
+      character(len=*), intent(in) :: procedure
+      !! name of the caller routine
       integer, optional, intent(in) :: counter
       !! optional flag to reset to an integer other than zero.
-      logical, optional, intent(in) :: ifprint
-      !! optional flag to print the number of matvecs to log prior to resetting
       ! internals
-      integer :: counter_
-      logical :: ifprint_
+      integer :: counter_, count_old
       character(len=128) :: msg
       counter_ = optval(counter, 0)
-      ifprint_ = optval(ifprint, .false.)
-      if (ifprint_) then
-         write(msg,'(A,I0,A,I0,A)') 'Total number of matvecs: ', self%get_matvec_counter(), &
-                  & '. Resetting counter to ', counter_, '.'
-         call logger%log_message(msg, module=this_module, procedure='reset_matvec_counter')
+      count_old = self%get_counter(trans)
+      if ( count_old /= 0 .or. counter_ /= 0) then
+        if (trans) then
+            write(msg,'(A,I0,A,I0,A)') 'Total number of rmatvecs: ', count_old, '. Resetting counter to ', counter_, '.'
+            call logger%log_message(msg, module=this_module, procedure='reset_counter('//trim(procedure)//')')
+            self%rmatvec_counter = counter_
+        else
+            write(msg,'(A,I0,A,I0,A)') 'Total number of matvecs: ', count_old, '. Resetting counter to ', counter_, '.'
+            call logger%log_message(msg, module=this_module, procedure='reset_counter('//trim(procedure)//')')
+            self%matvec_counter = counter_
+        end if
       end if
-      self%matvec_counter = counter_
       return
-    end subroutine reset_matvec_counter
-
-    pure integer function get_rmatvec_counter(self) result(count)
-      !! Getter function for the number of rmatvec calls
-      class(abstract_linop), intent(in) :: self
-      count = self%rmatvec_counter
-    end function get_rmatvec_counter
-
-    subroutine reset_rmatvec_counter(self, counter, ifprint)
-      class(abstract_linop), intent(inout) :: self
-      integer, optional, intent(in) :: counter
-      !! optional flag to reset to an integer other than zero.
-      logical, optional, intent(in) :: ifprint
-      !! optional flag to print the number of rmatvecs to log prior to resetting
-      ! internals
-      integer :: counter_
-      logical :: ifprint_
-      character(len=128) :: msg
-      counter_ = optval(counter, 0)
-      ifprint_ = optval(ifprint, .false.)
-      if (ifprint_) then
-         write(msg,'(A,I0,A,I0,A)') 'Total number of rmatvecs: ', self%get_rmatvec_counter(), &
-                  & '. Resetting counter to ', counter_, '.'
-         call logger%log_message(msg, module=this_module, procedure='reset_rmatvec_counter')
-      end if
-      self%matvec_counter = counter_
-      return
-    end subroutine reset_rmatvec_counter
+    end subroutine reset_counter
 
     !---------------------------------------------------------------------
     !-----     Wrappers for matvec/rmatvec to increment counters     -----

--- a/src/AbstractLinops.fypp
+++ b/src/AbstractLinops.fypp
@@ -29,9 +29,8 @@ module LightKrylov_AbstractLinops
         !!  @warning
         !!  Users should not extend this abstract class to define their own types.
         !!  @endwarning
-    private
-        integer :: matvec_counter  = 0
-        integer :: rmatvec_counter = 0
+        integer, private :: matvec_counter  = 0
+        integer, private :: rmatvec_counter = 0
     contains
         procedure, pass(self), public :: get_counter
         !! Return matvec/rmatvec counter value

--- a/src/AbstractSystems.f90
+++ b/src/AbstractSystems.f90
@@ -203,23 +203,22 @@ contains
       count = self%eval_counter
     end function get_eval_counter
 
-    subroutine reset_eval_counter(self, counter, ifprint)
+    subroutine reset_eval_counter(self, procedure, counter)
       class(abstract_system), intent(inout) :: self
+      character(len=*), intent(in) :: procedure
+      !! name of the caller routine
       integer, optional, intent(in) :: counter
       !! optional flag to reset to an integer other than zero.
-      logical, optional, intent(in) :: ifprint
-      !! optional flag to print the number of evals to log prior to resetting.
       ! internals
-      integer :: counter_
-      logical :: ifprint_
+      integer :: counter_, count_old
       character(len=128) :: msg
       counter_ = optval(counter, 0)
-      ifprint_ = optval(ifprint, .false.)
-      if (ifprint_) then
-         write(msg,'(A,I0,A,I0,A)') 'Total number of evals: ', self%get_eval_counter(), '. Resetting counter to ', counter_, '.'
-         call logger%log_message(msg, module=this_module, procedure='reset_eval_counter')
+      count_old = self%get_eval_counter()
+      if (count_old /= 0 .or. counter_ /= 0) then
+        write(msg,'(A,I0,A,I0,A)') 'Total number of evals: ', count_old, '. Resetting counter to ', counter_, '.'
+        call logger%log_message(msg, module=this_module, procedure='reset_eval_counter('//trim(procedure)//')')
+        self%eval_counter = counter_
       end if
-      self%eval_counter = counter_
       return
     end subroutine reset_eval_counter
 

--- a/src/AbstractSystems.f90
+++ b/src/AbstractSystems.f90
@@ -7,7 +7,8 @@ module LightKrylov_AbstractSystems
     implicit none
     private
 
-    character(len=128), parameter :: this_module = 'LightKrylov_AbstractSystems'
+    character(len=*), parameter :: this_module      = 'LK_Systems'
+    character(len=*), parameter :: this_module_long = 'LK_AbstractSystems'
 
     ! Base type for abstract systems.
     type, abstract, public :: abstract_system

--- a/src/AbstractSystems.f90
+++ b/src/AbstractSystems.f90
@@ -1,6 +1,8 @@
 module LightKrylov_AbstractSystems
     !!  This module provides the abstract types necessary to define an algebraic system of
     !!  nonlinear equations to be solved using the Newton method.
+    use stdlib_optval, only: optval
+    use LightKrylov_Logger
     use LightKrylov_Constants
     use LightKrylov_AbstractVectors
     use LightKrylov_AbstractLinops
@@ -12,6 +14,13 @@ module LightKrylov_AbstractSystems
 
     ! Base type for abstract systems.
     type, abstract, public :: abstract_system
+    private
+        integer :: eval_counter = 0
+    contains
+        procedure, pass(self), public :: get_eval_counter
+        !! Return eval counter value
+        procedure, pass(self), public :: reset_eval_counter
+        !! Reset eval counter
     end type abstract_system
 
     !----------------------------------------------------------------------------
@@ -33,8 +42,11 @@ module LightKrylov_AbstractSystems
         !! System Jacobian \( \left. \frac{\partial \mathbf{F}}{\partial \mathbf{X}} \right|_{X^*} \).
     contains
         private
-        procedure(abstract_eval_rsp), pass(self), deferred, public :: eval
+        procedure(abstract_eval_rsp), pass(self), deferred, public :: response
         !! Procedure to evaluate the system response \( \mathbf{Y} = \mathbf{F}(\mathbf{X}) \).
+        ! Wrapper including counter increment
+        procedure, pass(self), public :: eval => eval_rsp
+        !! Wrapper for response including the counter increment
     end type
 
     abstract interface
@@ -42,7 +54,7 @@ module LightKrylov_AbstractSystems
             !! Interface for the evaluation of the system response.
             use LightKrylov_AbstractVectors
             import abstract_system_rsp, sp
-            class(abstract_system_rsp), intent(in)  :: self
+            class(abstract_system_rsp), intent(inout)  :: self
             !! System
             class(abstract_vector_rsp), intent(in)  :: vec_in
             !! State
@@ -72,8 +84,11 @@ module LightKrylov_AbstractSystems
         !! System Jacobian \( \left. \frac{\partial \mathbf{F}}{\partial \mathbf{X}} \right|_{X^*} \).
     contains
         private
-        procedure(abstract_eval_rdp), pass(self), deferred, public :: eval
+        procedure(abstract_eval_rdp), pass(self), deferred, public :: response
         !! Procedure to evaluate the system response \( \mathbf{Y} = \mathbf{F}(\mathbf{X}) \).
+        ! Wrapper including counter increment
+        procedure, pass(self), public :: eval => eval_rdp
+        !! Wrapper for response including the counter increment
     end type
 
     abstract interface
@@ -81,7 +96,7 @@ module LightKrylov_AbstractSystems
             !! Interface for the evaluation of the system response.
             use LightKrylov_AbstractVectors
             import abstract_system_rdp, dp
-            class(abstract_system_rdp), intent(in)  :: self
+            class(abstract_system_rdp), intent(inout)  :: self
             !! System
             class(abstract_vector_rdp), intent(in)  :: vec_in
             !! State
@@ -111,8 +126,11 @@ module LightKrylov_AbstractSystems
         !! System Jacobian \( \left. \frac{\partial \mathbf{F}}{\partial \mathbf{X}} \right|_{X^*} \).
     contains
         private
-        procedure(abstract_eval_csp), pass(self), deferred, public :: eval
+        procedure(abstract_eval_csp), pass(self), deferred, public :: response
         !! Procedure to evaluate the system response \( \mathbf{Y} = \mathbf{F}(\mathbf{X}) \).
+        ! Wrapper including counter increment
+        procedure, pass(self), public :: eval => eval_csp
+        !! Wrapper for response including the counter increment
     end type
 
     abstract interface
@@ -120,7 +138,7 @@ module LightKrylov_AbstractSystems
             !! Interface for the evaluation of the system response.
             use LightKrylov_AbstractVectors
             import abstract_system_csp, sp
-            class(abstract_system_csp), intent(in)  :: self
+            class(abstract_system_csp), intent(inout)  :: self
             !! System
             class(abstract_vector_csp), intent(in)  :: vec_in
             !! State
@@ -150,8 +168,11 @@ module LightKrylov_AbstractSystems
         !! System Jacobian \( \left. \frac{\partial \mathbf{F}}{\partial \mathbf{X}} \right|_{X^*} \).
     contains
         private
-        procedure(abstract_eval_cdp), pass(self), deferred, public :: eval
+        procedure(abstract_eval_cdp), pass(self), deferred, public :: response
         !! Procedure to evaluate the system response \( \mathbf{Y} = \mathbf{F}(\mathbf{X}) \).
+        ! Wrapper including counter increment
+        procedure, pass(self), public :: eval => eval_cdp
+        !! Wrapper for response including the counter increment
     end type
 
     abstract interface
@@ -159,7 +180,7 @@ module LightKrylov_AbstractSystems
             !! Interface for the evaluation of the system response.
             use LightKrylov_AbstractVectors
             import abstract_system_cdp, dp
-            class(abstract_system_cdp), intent(in)  :: self
+            class(abstract_system_cdp), intent(inout)  :: self
             !! System
             class(abstract_vector_cdp), intent(in)  :: vec_in
             !! State
@@ -169,5 +190,78 @@ module LightKrylov_AbstractSystems
             !! Solver tolerance
         end subroutine abstract_eval_cdp
     end interface
+
+contains
+
+    !---------------------------------------------------------------
+    !-----     Getter/Setter routines for abstract_systems     -----
+    !---------------------------------------------------------------
+ 
+    pure integer function get_eval_counter(self) result(count)
+      !! Getter function for the number of eval calls
+      class(abstract_system), intent(in) :: self
+      count = self%eval_counter
+    end function get_eval_counter
+
+    subroutine reset_eval_counter(self, counter, ifprint)
+      class(abstract_system), intent(inout) :: self
+      integer, optional, intent(in) :: counter
+      !! optional flag to reset to an integer other than zero.
+      logical, optional, intent(in) :: ifprint
+      !! optional flag to print the number of evals to log prior to resetting.
+      ! internals
+      integer :: counter_
+      logical :: ifprint_
+      character(len=128) :: msg
+      counter_ = optval(counter, 0)
+      ifprint_ = optval(ifprint, .false.)
+      if (ifprint_) then
+         write(msg,'(A,I0,A,I0,A)') 'Total number of evals: ', self%get_eval_counter(), '. Resetting counter to ', counter_, '.'
+         call logger%log_message(msg, module=this_module, procedure='reset_eval_counter')
+      end if
+      self%eval_counter = counter_
+      return
+    end subroutine reset_eval_counter
+
+    !---------------------------------------------------------------------
+    !-----     Wrapper for system response to increment counters     -----
+    !---------------------------------------------------------------------
+
+    subroutine eval_rsp(self, vec_in, vec_out, atol)
+        class(abstract_system_rsp), intent(inout) :: self
+        class(abstract_vector_rsp), intent(in)    :: vec_in
+        class(abstract_vector_rsp), intent(out)   :: vec_out
+        real(sp),                             intent(in)    :: atol
+        self%eval_counter = self%eval_counter + 1
+        call self%response(vec_in, vec_out, atol)
+        return
+    end subroutine eval_rsp
+    subroutine eval_rdp(self, vec_in, vec_out, atol)
+        class(abstract_system_rdp), intent(inout) :: self
+        class(abstract_vector_rdp), intent(in)    :: vec_in
+        class(abstract_vector_rdp), intent(out)   :: vec_out
+        real(dp),                             intent(in)    :: atol
+        self%eval_counter = self%eval_counter + 1
+        call self%response(vec_in, vec_out, atol)
+        return
+    end subroutine eval_rdp
+    subroutine eval_csp(self, vec_in, vec_out, atol)
+        class(abstract_system_csp), intent(inout) :: self
+        class(abstract_vector_csp), intent(in)    :: vec_in
+        class(abstract_vector_csp), intent(out)   :: vec_out
+        real(sp),                             intent(in)    :: atol
+        self%eval_counter = self%eval_counter + 1
+        call self%response(vec_in, vec_out, atol)
+        return
+    end subroutine eval_csp
+    subroutine eval_cdp(self, vec_in, vec_out, atol)
+        class(abstract_system_cdp), intent(inout) :: self
+        class(abstract_vector_cdp), intent(in)    :: vec_in
+        class(abstract_vector_cdp), intent(out)   :: vec_out
+        real(dp),                             intent(in)    :: atol
+        self%eval_counter = self%eval_counter + 1
+        call self%response(vec_in, vec_out, atol)
+        return
+    end subroutine eval_cdp
 
 end module LightKrylov_AbstractSystems

--- a/src/AbstractSystems.fypp
+++ b/src/AbstractSystems.fypp
@@ -9,7 +9,8 @@ module LightKrylov_AbstractSystems
     implicit none
     private
 
-    character(len=128), parameter :: this_module = 'LightKrylov_AbstractSystems'
+    character(len=*), parameter :: this_module      = 'LK_Systems'
+    character(len=*), parameter :: this_module_long = 'LK_AbstractSystems'
 
     ! Base type for abstract systems.
     type, abstract, public :: abstract_system

--- a/src/AbstractSystems.fypp
+++ b/src/AbstractSystems.fypp
@@ -3,6 +3,8 @@
 module LightKrylov_AbstractSystems
     !!  This module provides the abstract types necessary to define an algebraic system of
     !!  nonlinear equations to be solved using the Newton method.
+    use stdlib_optval, only: optval
+    use LightKrylov_Logger
     use LightKrylov_Constants
     use LightKrylov_AbstractVectors
     use LightKrylov_AbstractLinops
@@ -14,6 +16,13 @@ module LightKrylov_AbstractSystems
 
     ! Base type for abstract systems.
     type, abstract, public :: abstract_system
+    private
+        integer :: eval_counter = 0
+    contains
+        procedure, pass(self), public :: get_eval_counter
+        !! Return eval counter value
+        procedure, pass(self), public :: reset_eval_counter
+        !! Reset eval counter
     end type abstract_system
 
     #:for kind, type in RC_KINDS_TYPES
@@ -36,8 +45,11 @@ module LightKrylov_AbstractSystems
         !! System Jacobian \( \left. \frac{\partial \mathbf{F}}{\partial \mathbf{X}} \right|_{X^*} \).
     contains
         private
-        procedure(abstract_eval_${type[0]}$${kind}$), pass(self), deferred, public :: eval
+        procedure(abstract_eval_${type[0]}$${kind}$), pass(self), deferred, public :: response
         !! Procedure to evaluate the system response \( \mathbf{Y} = \mathbf{F}(\mathbf{X}) \).
+        ! Wrapper including counter increment
+        procedure, pass(self), public :: eval => eval_${type[0]}$${kind}$
+        !! Wrapper for response including the counter increment
     end type
 
     abstract interface
@@ -45,7 +57,7 @@ module LightKrylov_AbstractSystems
             !! Interface for the evaluation of the system response.
             use LightKrylov_AbstractVectors
             import abstract_system_${type[0]}$${kind}$, ${kind}$
-            class(abstract_system_${type[0]}$${kind}$), intent(in)  :: self
+            class(abstract_system_${type[0]}$${kind}$), intent(inout)  :: self
             !! System
             class(abstract_vector_${type[0]}$${kind}$), intent(in)  :: vec_in
             !! State
@@ -57,4 +69,52 @@ module LightKrylov_AbstractSystems
     end interface
 
     #:endfor
+contains
+
+    !---------------------------------------------------------------
+    !-----     Getter/Setter routines for abstract_systems     -----
+    !---------------------------------------------------------------
+ 
+    pure integer function get_eval_counter(self) result(count)
+      !! Getter function for the number of eval calls
+      class(abstract_system), intent(in) :: self
+      count = self%eval_counter
+    end function get_eval_counter
+
+    subroutine reset_eval_counter(self, counter, ifprint)
+      class(abstract_system), intent(inout) :: self
+      integer, optional, intent(in) :: counter
+      !! optional flag to reset to an integer other than zero.
+      logical, optional, intent(in) :: ifprint
+      !! optional flag to print the number of evals to log prior to resetting.
+      ! internals
+      integer :: counter_
+      logical :: ifprint_
+      character(len=128) :: msg
+      counter_ = optval(counter, 0)
+      ifprint_ = optval(ifprint, .false.)
+      if (ifprint_) then
+         write(msg,'(A,I0,A,I0,A)') 'Total number of evals: ', self%get_eval_counter(), '. Resetting counter to ', counter_, '.'
+         call logger%log_message(msg, module=this_module, procedure='reset_eval_counter')
+      end if
+      self%eval_counter = counter_
+      return
+    end subroutine reset_eval_counter
+
+    !---------------------------------------------------------------------
+    !-----     Wrapper for system response to increment counters     -----
+    !---------------------------------------------------------------------
+
+    #:for kind, type in RC_KINDS_TYPES
+    subroutine eval_${type[0]}$${kind}$(self, vec_in, vec_out, atol)
+        class(abstract_system_${type[0]}$${kind}$), intent(inout) :: self
+        class(abstract_vector_${type[0]}$${kind}$), intent(in)    :: vec_in
+        class(abstract_vector_${type[0]}$${kind}$), intent(out)   :: vec_out
+        real(${kind}$),                             intent(in)    :: atol
+        self%eval_counter = self%eval_counter + 1
+        call self%response(vec_in, vec_out, atol)
+        return
+    end subroutine eval_${type[0]}$${kind}$
+    #:endfor
+
 end module LightKrylov_AbstractSystems

--- a/src/AbstractSystems.fypp
+++ b/src/AbstractSystems.fypp
@@ -81,23 +81,22 @@ contains
       count = self%eval_counter
     end function get_eval_counter
 
-    subroutine reset_eval_counter(self, counter, ifprint)
+    subroutine reset_eval_counter(self, procedure, counter)
       class(abstract_system), intent(inout) :: self
+      character(len=*), intent(in) :: procedure
+      !! name of the caller routine
       integer, optional, intent(in) :: counter
       !! optional flag to reset to an integer other than zero.
-      logical, optional, intent(in) :: ifprint
-      !! optional flag to print the number of evals to log prior to resetting.
       ! internals
-      integer :: counter_
-      logical :: ifprint_
+      integer :: counter_, count_old
       character(len=128) :: msg
       counter_ = optval(counter, 0)
-      ifprint_ = optval(ifprint, .false.)
-      if (ifprint_) then
-         write(msg,'(A,I0,A,I0,A)') 'Total number of evals: ', self%get_eval_counter(), '. Resetting counter to ', counter_, '.'
-         call logger%log_message(msg, module=this_module, procedure='reset_eval_counter')
+      count_old = self%get_eval_counter()
+      if (count_old /= 0 .or. counter_ /= 0) then
+        write(msg,'(A,I0,A,I0,A)') 'Total number of evals: ', count_old, '. Resetting counter to ', counter_, '.'
+        call logger%log_message(msg, module=this_module, procedure='reset_eval_counter('//trim(procedure)//')')
+        self%eval_counter = counter_
       end if
-      self%eval_counter = counter_
       return
     end subroutine reset_eval_counter
 

--- a/src/AbstractVectors.f90
+++ b/src/AbstractVectors.f90
@@ -45,7 +45,8 @@ module lightkrylov_AbstractVectors
     implicit none
     private
 
-    character(len=128), parameter :: this_module = 'Lightkrylov_AbstractVectors'
+    character(len=*), parameter :: this_module      = 'LK_Vectors'
+    character(len=*), parameter :: this_module_long = 'Lightkrylov_AbstractVectors'
 
     public :: innerprod
     public :: linear_combination

--- a/src/AbstractVectors.fypp
+++ b/src/AbstractVectors.fypp
@@ -47,7 +47,8 @@ module lightkrylov_AbstractVectors
     implicit none
     private
 
-    character(len=128), parameter :: this_module = 'Lightkrylov_AbstractVectors'
+    character(len=*), parameter :: this_module      = 'LK_Vectors'
+    character(len=*), parameter :: this_module_long = 'Lightkrylov_AbstractVectors'
 
     public :: innerprod
     public :: linear_combination

--- a/src/BaseKrylov.f90
+++ b/src/BaseKrylov.f90
@@ -28,7 +28,8 @@ module lightkrylov_BaseKrylov
     implicit none
     private
     
-    character(len=128), parameter :: this_module = 'LightKrylov_BaseKrylov'
+    character(len=*), parameter :: this_module      = 'LK_BKrylov'
+    character(len=*), parameter :: this_module_long = 'LightKrylov_BaseKrylov'
 
     public :: qr
     public :: apply_permutation_matrix

--- a/src/BaseKrylov.f90
+++ b/src/BaseKrylov.f90
@@ -223,7 +223,7 @@ module lightkrylov_BaseKrylov
         !!
         !!  `A` : Linear operator derived from one the base types provided by the `AbstractLinops`
         !!        module. The operator needs to be square, i.e. the dimension of its domain and
-        !!        co-domain is the same. It is an `intent(in)` argument.
+        !!        co-domain is the same. It is an `intent(inout)` argument.
         !!
         !!  `X` : Array of types derived from one the base types provided by the `AbstractVectors`
         !!        module. It needs to be consistent with the type of `A`. On exit, it contains the
@@ -427,7 +427,7 @@ module lightkrylov_BaseKrylov
         !!  ### Arguments
         !!
         !!  `A` : Symmetric or Hermitian linear operator derived from one the base types 
-        !!        provided by the `AbstractLinops` module. It is an `intent(in)` argument.
+        !!        provided by the `AbstractLinops` module. It is an `intent(inout)` argument.
         !!
         !!  `X` : Array of types derived from one the base types provided by the `AbstractVectors`
         !!        module. It needs to be consistent with the type of `A`. On exit, it contains the
@@ -498,7 +498,7 @@ module lightkrylov_BaseKrylov
         !!  ### Arguments
         !!
         !!  `A` : Linear operator derived from one the base types provided by the 
-        !!        `AbstractLinops` module. It is an `intent(in)` argument.
+        !!        `AbstractLinops` module. It is an `intent(inout)` argument.
         !!
         !!  `U` : Array of types derived from one the base types provided by the `AbstractVectors`
         !!        module. It needs to be consistent with the type of `A`. On exit, it contains the
@@ -2695,7 +2695,7 @@ contains
     !-----------------------------------------
 
     subroutine arnoldi_rsp(A, X, H, info, kstart, kend, tol, transpose, blksize)
-        class(abstract_linop_rsp), intent(in) :: A
+        class(abstract_linop_rsp), intent(inout) :: A
         !! Linear operator to be factorized.
         class(abstract_vector_rsp), intent(inout) :: X(:)
         !! Orthogonal basis for the generated Krylov subspace.
@@ -2743,11 +2743,11 @@ contains
             ! Matrix-vector product.
             if (trans) then
                 do i = 1, p
-                    call A%rmatvec(X(kpm+i), X(kp+i))
+                    call A%apply_rmatvec(X(kpm+i), X(kp+i))
                 enddo
             else
                 do i = 1, p
-                    call A%matvec(X(kpm+i), X(kp+i))
+                    call A%apply_matvec(X(kpm+i), X(kp+i))
                 enddo
             endif
 
@@ -2780,7 +2780,7 @@ contains
     end subroutine arnoldi_rsp
 
     subroutine arnoldi_rdp(A, X, H, info, kstart, kend, tol, transpose, blksize)
-        class(abstract_linop_rdp), intent(in) :: A
+        class(abstract_linop_rdp), intent(inout) :: A
         !! Linear operator to be factorized.
         class(abstract_vector_rdp), intent(inout) :: X(:)
         !! Orthogonal basis for the generated Krylov subspace.
@@ -2828,11 +2828,11 @@ contains
             ! Matrix-vector product.
             if (trans) then
                 do i = 1, p
-                    call A%rmatvec(X(kpm+i), X(kp+i))
+                    call A%apply_rmatvec(X(kpm+i), X(kp+i))
                 enddo
             else
                 do i = 1, p
-                    call A%matvec(X(kpm+i), X(kp+i))
+                    call A%apply_matvec(X(kpm+i), X(kp+i))
                 enddo
             endif
 
@@ -2865,7 +2865,7 @@ contains
     end subroutine arnoldi_rdp
 
     subroutine arnoldi_csp(A, X, H, info, kstart, kend, tol, transpose, blksize)
-        class(abstract_linop_csp), intent(in) :: A
+        class(abstract_linop_csp), intent(inout) :: A
         !! Linear operator to be factorized.
         class(abstract_vector_csp), intent(inout) :: X(:)
         !! Orthogonal basis for the generated Krylov subspace.
@@ -2913,11 +2913,11 @@ contains
             ! Matrix-vector product.
             if (trans) then
                 do i = 1, p
-                    call A%rmatvec(X(kpm+i), X(kp+i))
+                    call A%apply_rmatvec(X(kpm+i), X(kp+i))
                 enddo
             else
                 do i = 1, p
-                    call A%matvec(X(kpm+i), X(kp+i))
+                    call A%apply_matvec(X(kpm+i), X(kp+i))
                 enddo
             endif
 
@@ -2950,7 +2950,7 @@ contains
     end subroutine arnoldi_csp
 
     subroutine arnoldi_cdp(A, X, H, info, kstart, kend, tol, transpose, blksize)
-        class(abstract_linop_cdp), intent(in) :: A
+        class(abstract_linop_cdp), intent(inout) :: A
         !! Linear operator to be factorized.
         class(abstract_vector_cdp), intent(inout) :: X(:)
         !! Orthogonal basis for the generated Krylov subspace.
@@ -2998,11 +2998,11 @@ contains
             ! Matrix-vector product.
             if (trans) then
                 do i = 1, p
-                    call A%rmatvec(X(kpm+i), X(kp+i))
+                    call A%apply_rmatvec(X(kpm+i), X(kp+i))
                 enddo
             else
                 do i = 1, p
-                    call A%matvec(X(kpm+i), X(kp+i))
+                    call A%apply_matvec(X(kpm+i), X(kp+i))
                 enddo
             endif
 
@@ -3041,7 +3041,7 @@ contains
     !---------------------------------------------
 
     subroutine lanczos_bidiagonalization_rsp(A, U, V, B, info, kstart, kend, tol)
-        class(abstract_linop_rsp), intent(in) :: A
+        class(abstract_linop_rsp), intent(inout) :: A
         !! Linear operator to be factorized.
         class(abstract_vector_rsp), intent(inout) :: U(:)
         !! Orthonormal basis for the column span of \(\mathbf{A}\). On entry, `U(1)` needs to be set to
@@ -3078,7 +3078,7 @@ contains
         ! Lanczos bidiagonalization.
         lanczos : do k = k_start, k_end
             ! Transpose matrix-vector product.
-            call A%rmatvec(U(k), V(k))
+            call A%apply_rmatvec(U(k), V(k))
 
             ! Full re-orthogonalization of the right Krylov subspace.
             if (k > 1) then
@@ -3097,7 +3097,7 @@ contains
             endif
 
             ! Matrix-vector product.
-            call A%matvec(V(k), U(k+1))
+            call A%apply_matvec(V(k), U(k+1))
 
             ! Full re-orthogonalization of the left Krylov subspace.
             call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.false.)
@@ -3119,7 +3119,7 @@ contains
     end subroutine lanczos_bidiagonalization_rsp
 
     subroutine lanczos_bidiagonalization_rdp(A, U, V, B, info, kstart, kend, tol)
-        class(abstract_linop_rdp), intent(in) :: A
+        class(abstract_linop_rdp), intent(inout) :: A
         !! Linear operator to be factorized.
         class(abstract_vector_rdp), intent(inout) :: U(:)
         !! Orthonormal basis for the column span of \(\mathbf{A}\). On entry, `U(1)` needs to be set to
@@ -3156,7 +3156,7 @@ contains
         ! Lanczos bidiagonalization.
         lanczos : do k = k_start, k_end
             ! Transpose matrix-vector product.
-            call A%rmatvec(U(k), V(k))
+            call A%apply_rmatvec(U(k), V(k))
 
             ! Full re-orthogonalization of the right Krylov subspace.
             if (k > 1) then
@@ -3175,7 +3175,7 @@ contains
             endif
 
             ! Matrix-vector product.
-            call A%matvec(V(k), U(k+1))
+            call A%apply_matvec(V(k), U(k+1))
 
             ! Full re-orthogonalization of the left Krylov subspace.
             call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.false.)
@@ -3197,7 +3197,7 @@ contains
     end subroutine lanczos_bidiagonalization_rdp
 
     subroutine lanczos_bidiagonalization_csp(A, U, V, B, info, kstart, kend, tol)
-        class(abstract_linop_csp), intent(in) :: A
+        class(abstract_linop_csp), intent(inout) :: A
         !! Linear operator to be factorized.
         class(abstract_vector_csp), intent(inout) :: U(:)
         !! Orthonormal basis for the column span of \(\mathbf{A}\). On entry, `U(1)` needs to be set to
@@ -3234,7 +3234,7 @@ contains
         ! Lanczos bidiagonalization.
         lanczos : do k = k_start, k_end
             ! Transpose matrix-vector product.
-            call A%rmatvec(U(k), V(k))
+            call A%apply_rmatvec(U(k), V(k))
 
             ! Full re-orthogonalization of the right Krylov subspace.
             if (k > 1) then
@@ -3253,7 +3253,7 @@ contains
             endif
 
             ! Matrix-vector product.
-            call A%matvec(V(k), U(k+1))
+            call A%apply_matvec(V(k), U(k+1))
 
             ! Full re-orthogonalization of the left Krylov subspace.
             call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.false.)
@@ -3275,7 +3275,7 @@ contains
     end subroutine lanczos_bidiagonalization_csp
 
     subroutine lanczos_bidiagonalization_cdp(A, U, V, B, info, kstart, kend, tol)
-        class(abstract_linop_cdp), intent(in) :: A
+        class(abstract_linop_cdp), intent(inout) :: A
         !! Linear operator to be factorized.
         class(abstract_vector_cdp), intent(inout) :: U(:)
         !! Orthonormal basis for the column span of \(\mathbf{A}\). On entry, `U(1)` needs to be set to
@@ -3312,7 +3312,7 @@ contains
         ! Lanczos bidiagonalization.
         lanczos : do k = k_start, k_end
             ! Transpose matrix-vector product.
-            call A%rmatvec(U(k), V(k))
+            call A%apply_rmatvec(U(k), V(k))
 
             ! Full re-orthogonalization of the right Krylov subspace.
             if (k > 1) then
@@ -3331,7 +3331,7 @@ contains
             endif
 
             ! Matrix-vector product.
-            call A%matvec(V(k), U(k+1))
+            call A%apply_matvec(V(k), U(k+1))
 
             ! Full re-orthogonalization of the left Krylov subspace.
             call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.false.)
@@ -3359,7 +3359,7 @@ contains
     !----------------------------------------------
     
     subroutine lanczos_tridiagonalization_rsp(A, X, T, info, kstart, kend, tol)
-        class(abstract_sym_linop_rsp), intent(in) :: A
+        class(abstract_sym_linop_rsp), intent(inout) :: A
         class(abstract_vector_rsp), intent(inout) :: X(:)
         real(sp), intent(inout) :: T(:, :)
         integer, intent(out) :: info
@@ -3383,7 +3383,7 @@ contains
         ! Lanczos tridiagonalization.
         lanczos: do k = k_start, k_end
             ! Matrix-vector product.
-            call A%matvec(X(k), X(k+1))
+            call A%apply_matvec(X(k), X(k+1))
             ! Update tridiagonal matrix.
             call update_tridiag_matrix_rsp(T, X, k)
             beta = X(k+1)%norm() ; T(k+1, k) = beta
@@ -3426,7 +3426,7 @@ contains
     end subroutine update_tridiag_matrix_rsp
 
     subroutine lanczos_tridiagonalization_rdp(A, X, T, info, kstart, kend, tol)
-        class(abstract_sym_linop_rdp), intent(in) :: A
+        class(abstract_sym_linop_rdp), intent(inout) :: A
         class(abstract_vector_rdp), intent(inout) :: X(:)
         real(dp), intent(inout) :: T(:, :)
         integer, intent(out) :: info
@@ -3450,7 +3450,7 @@ contains
         ! Lanczos tridiagonalization.
         lanczos: do k = k_start, k_end
             ! Matrix-vector product.
-            call A%matvec(X(k), X(k+1))
+            call A%apply_matvec(X(k), X(k+1))
             ! Update tridiagonal matrix.
             call update_tridiag_matrix_rdp(T, X, k)
             beta = X(k+1)%norm() ; T(k+1, k) = beta
@@ -3493,7 +3493,7 @@ contains
     end subroutine update_tridiag_matrix_rdp
 
     subroutine lanczos_tridiagonalization_csp(A, X, T, info, kstart, kend, tol)
-        class(abstract_hermitian_linop_csp), intent(in) :: A
+        class(abstract_hermitian_linop_csp), intent(inout) :: A
         class(abstract_vector_csp), intent(inout) :: X(:)
         complex(sp), intent(inout) :: T(:, :)
         integer, intent(out) :: info
@@ -3517,7 +3517,7 @@ contains
         ! Lanczos tridiagonalization.
         lanczos: do k = k_start, k_end
             ! Matrix-vector product.
-            call A%matvec(X(k), X(k+1))
+            call A%apply_matvec(X(k), X(k+1))
             ! Update tridiagonal matrix.
             call update_tridiag_matrix_csp(T, X, k)
             beta = X(k+1)%norm() ; T(k+1, k) = beta
@@ -3560,7 +3560,7 @@ contains
     end subroutine update_tridiag_matrix_csp
 
     subroutine lanczos_tridiagonalization_cdp(A, X, T, info, kstart, kend, tol)
-        class(abstract_hermitian_linop_cdp), intent(in) :: A
+        class(abstract_hermitian_linop_cdp), intent(inout) :: A
         class(abstract_vector_cdp), intent(inout) :: X(:)
         complex(dp), intent(inout) :: T(:, :)
         integer, intent(out) :: info
@@ -3584,7 +3584,7 @@ contains
         ! Lanczos tridiagonalization.
         lanczos: do k = k_start, k_end
             ! Matrix-vector product.
-            call A%matvec(X(k), X(k+1))
+            call A%apply_matvec(X(k), X(k+1))
             ! Update tridiagonal matrix.
             call update_tridiag_matrix_cdp(T, X, k)
             beta = X(k+1)%norm() ; T(k+1, k) = beta

--- a/src/BaseKrylov.fypp
+++ b/src/BaseKrylov.fypp
@@ -30,7 +30,8 @@ module lightkrylov_BaseKrylov
     implicit none
     private
     
-    character(len=128), parameter :: this_module = 'LightKrylov_BaseKrylov'
+    character(len=*), parameter :: this_module      = 'LK_BKrylov'
+    character(len=*), parameter :: this_module_long = 'LightKrylov_BaseKrylov'
 
     public :: qr
     public :: apply_permutation_matrix

--- a/src/BaseKrylov.fypp
+++ b/src/BaseKrylov.fypp
@@ -213,7 +213,7 @@ module lightkrylov_BaseKrylov
         !!
         !!  `A` : Linear operator derived from one the base types provided by the `AbstractLinops`
         !!        module. The operator needs to be square, i.e. the dimension of its domain and
-        !!        co-domain is the same. It is an `intent(in)` argument.
+        !!        co-domain is the same. It is an `intent(inout)` argument.
         !!
         !!  `X` : Array of types derived from one the base types provided by the `AbstractVectors`
         !!        module. It needs to be consistent with the type of `A`. On exit, it contains the
@@ -405,7 +405,7 @@ module lightkrylov_BaseKrylov
         !!  ### Arguments
         !!
         !!  `A` : Symmetric or Hermitian linear operator derived from one the base types 
-        !!        provided by the `AbstractLinops` module. It is an `intent(in)` argument.
+        !!        provided by the `AbstractLinops` module. It is an `intent(inout)` argument.
         !!
         !!  `X` : Array of types derived from one the base types provided by the `AbstractVectors`
         !!        module. It needs to be consistent with the type of `A`. On exit, it contains the
@@ -475,7 +475,7 @@ module lightkrylov_BaseKrylov
         !!  ### Arguments
         !!
         !!  `A` : Linear operator derived from one the base types provided by the 
-        !!        `AbstractLinops` module. It is an `intent(in)` argument.
+        !!        `AbstractLinops` module. It is an `intent(inout)` argument.
         !!
         !!  `U` : Array of types derived from one the base types provided by the `AbstractVectors`
         !!        module. It needs to be consistent with the type of `A`. On exit, it contains the
@@ -1112,7 +1112,7 @@ contains
 
     #:for kind, type in RC_KINDS_TYPES
     subroutine arnoldi_${type[0]}$${kind}$(A, X, H, info, kstart, kend, tol, transpose, blksize)
-        class(abstract_linop_${type[0]}$${kind}$), intent(in) :: A
+        class(abstract_linop_${type[0]}$${kind}$), intent(inout) :: A
         !! Linear operator to be factorized.
         class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: X(:)
         !! Orthogonal basis for the generated Krylov subspace.
@@ -1160,11 +1160,11 @@ contains
             ! Matrix-vector product.
             if (trans) then
                 do i = 1, p
-                    call A%rmatvec(X(kpm+i), X(kp+i))
+                    call A%apply_rmatvec(X(kpm+i), X(kp+i))
                 enddo
             else
                 do i = 1, p
-                    call A%matvec(X(kpm+i), X(kp+i))
+                    call A%apply_matvec(X(kpm+i), X(kp+i))
                 enddo
             endif
 
@@ -1205,7 +1205,7 @@ contains
 
     #:for kind, type in RC_KINDS_TYPES
     subroutine lanczos_bidiagonalization_${type[0]}$${kind}$(A, U, V, B, info, kstart, kend, tol)
-        class(abstract_linop_${type[0]}$${kind}$), intent(in) :: A
+        class(abstract_linop_${type[0]}$${kind}$), intent(inout) :: A
         !! Linear operator to be factorized.
         class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: U(:)
         !! Orthonormal basis for the column span of \(\mathbf{A}\). On entry, `U(1)` needs to be set to
@@ -1242,7 +1242,7 @@ contains
         ! Lanczos bidiagonalization.
         lanczos : do k = k_start, k_end
             ! Transpose matrix-vector product.
-            call A%rmatvec(U(k), V(k))
+            call A%apply_rmatvec(U(k), V(k))
 
             ! Full re-orthogonalization of the right Krylov subspace.
             if (k > 1) then
@@ -1261,7 +1261,7 @@ contains
             endif
 
             ! Matrix-vector product.
-            call A%matvec(V(k), U(k+1))
+            call A%apply_matvec(V(k), U(k+1))
 
             ! Full re-orthogonalization of the left Krylov subspace.
             call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.false.)
@@ -1292,9 +1292,9 @@ contains
     #:for kind, type in RC_KINDS_TYPES
     subroutine lanczos_tridiagonalization_${type[0]}$${kind}$(A, X, T, info, kstart, kend, tol)
         #:if type[0] == "r"
-        class(abstract_sym_linop_${type[0]}$${kind}$), intent(in) :: A
+        class(abstract_sym_linop_${type[0]}$${kind}$), intent(inout) :: A
         #:else
-        class(abstract_hermitian_linop_${type[0]}$${kind}$), intent(in) :: A
+        class(abstract_hermitian_linop_${type[0]}$${kind}$), intent(inout) :: A
         #:endif
         class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: X(:)
         ${type}$, intent(inout) :: T(:, :)
@@ -1319,7 +1319,7 @@ contains
         ! Lanczos tridiagonalization.
         lanczos: do k = k_start, k_end
             ! Matrix-vector product.
-            call A%matvec(X(k), X(k+1))
+            call A%apply_matvec(X(k), X(k+1))
             ! Update tridiagonal matrix.
             call update_tridiag_matrix_${type[0]}$${kind}$(T, X, k)
             beta = X(k+1)%norm() ; T(k+1, k) = beta

--- a/src/ExpmLib.f90
+++ b/src/ExpmLib.f90
@@ -28,6 +28,10 @@ module lightkrylov_expmlib
     public :: expm
     public :: kexpm
     public :: k_exptA
+    public :: k_exptA_rsp
+    public :: k_exptA_rdp
+    public :: k_exptA_csp
+    public :: k_exptA_cdp
 
     abstract interface
         subroutine abstract_exptA_rsp(vec_out, A, vec_in, tau, info, trans)

--- a/src/ExpmLib.f90
+++ b/src/ExpmLib.f90
@@ -20,7 +20,9 @@ module lightkrylov_expmlib
     implicit none
     private
     
-    character(len=128), parameter, private :: this_module= 'LightKrylov_ExpmLib'
+    character(len=*), parameter, private :: this_module      = 'LK_ExpmLib'
+    character(len=*), parameter, private :: this_module_long = 'LightKrylov_ExpmLib'
+
     public :: abstract_exptA_rsp
     public :: abstract_exptA_rdp
     public :: abstract_exptA_csp

--- a/src/ExpmLib.f90
+++ b/src/ExpmLib.f90
@@ -154,7 +154,7 @@ module lightkrylov_expmlib
         !!
         !!  `c` : Output vector (or vectors). It is an `intent(out)` argument.
         !!
-        !!  `A` : Linear operator to be exponentiated. It is an `intent(in)` argument.
+        !!  `A` : Linear operator to be exponentiated. It is an `intent(inout)` argument.
         !!
         !!  `b` : Vector to be multiplied by \( \exp(\tau A) \). It is an `intent(in)` argument.
         !!
@@ -278,7 +278,7 @@ contains
     subroutine kexpm_vec_rsp(c, A, b, tau, tol, info, trans, kdim)
         class(abstract_vector_rsp), intent(out) :: c
         !! Best approximation of \( \exp(\tau \mathbf{A}) \mathbf{b} \) in the computed Krylov subspace
-        class(abstract_linop_rsp), intent(in) :: A
+        class(abstract_linop_rsp), intent(inout) :: A
         !! Linear operator to be exponentiated.
         class(abstract_vector_rsp), intent(in) :: b
         !! Input vector on which to apply \( \exp(\tau \mathbf{A}) \).
@@ -386,7 +386,7 @@ contains
     subroutine kexpm_mat_rsp(C, A, B, tau, tol, info, trans, kdim)
         class(abstract_vector_rsp), intent(out) :: C(:)
         !! Best Krylov approximation of \( \mathbf{C} = \exp(\tau \mathbf{A}) \mathbf{B} \).
-        class(abstract_linop_rsp), intent(in) :: A
+        class(abstract_linop_rsp), intent(inout) :: A
         !! Linear operator to be exponentiated.
         class(abstract_vector_rsp), intent(in) :: B(:)
         !! Input matrix on which to apply \( \exp(\tau \mathbf{A}) \).
@@ -600,7 +600,7 @@ contains
     subroutine kexpm_vec_rdp(c, A, b, tau, tol, info, trans, kdim)
         class(abstract_vector_rdp), intent(out) :: c
         !! Best approximation of \( \exp(\tau \mathbf{A}) \mathbf{b} \) in the computed Krylov subspace
-        class(abstract_linop_rdp), intent(in) :: A
+        class(abstract_linop_rdp), intent(inout) :: A
         !! Linear operator to be exponentiated.
         class(abstract_vector_rdp), intent(in) :: b
         !! Input vector on which to apply \( \exp(\tau \mathbf{A}) \).
@@ -708,7 +708,7 @@ contains
     subroutine kexpm_mat_rdp(C, A, B, tau, tol, info, trans, kdim)
         class(abstract_vector_rdp), intent(out) :: C(:)
         !! Best Krylov approximation of \( \mathbf{C} = \exp(\tau \mathbf{A}) \mathbf{B} \).
-        class(abstract_linop_rdp), intent(in) :: A
+        class(abstract_linop_rdp), intent(inout) :: A
         !! Linear operator to be exponentiated.
         class(abstract_vector_rdp), intent(in) :: B(:)
         !! Input matrix on which to apply \( \exp(\tau \mathbf{A}) \).
@@ -922,7 +922,7 @@ contains
     subroutine kexpm_vec_csp(c, A, b, tau, tol, info, trans, kdim)
         class(abstract_vector_csp), intent(out) :: c
         !! Best approximation of \( \exp(\tau \mathbf{A}) \mathbf{b} \) in the computed Krylov subspace
-        class(abstract_linop_csp), intent(in) :: A
+        class(abstract_linop_csp), intent(inout) :: A
         !! Linear operator to be exponentiated.
         class(abstract_vector_csp), intent(in) :: b
         !! Input vector on which to apply \( \exp(\tau \mathbf{A}) \).
@@ -1030,7 +1030,7 @@ contains
     subroutine kexpm_mat_csp(C, A, B, tau, tol, info, trans, kdim)
         class(abstract_vector_csp), intent(out) :: C(:)
         !! Best Krylov approximation of \( \mathbf{C} = \exp(\tau \mathbf{A}) \mathbf{B} \).
-        class(abstract_linop_csp), intent(in) :: A
+        class(abstract_linop_csp), intent(inout) :: A
         !! Linear operator to be exponentiated.
         class(abstract_vector_csp), intent(in) :: B(:)
         !! Input matrix on which to apply \( \exp(\tau \mathbf{A}) \).
@@ -1244,7 +1244,7 @@ contains
     subroutine kexpm_vec_cdp(c, A, b, tau, tol, info, trans, kdim)
         class(abstract_vector_cdp), intent(out) :: c
         !! Best approximation of \( \exp(\tau \mathbf{A}) \mathbf{b} \) in the computed Krylov subspace
-        class(abstract_linop_cdp), intent(in) :: A
+        class(abstract_linop_cdp), intent(inout) :: A
         !! Linear operator to be exponentiated.
         class(abstract_vector_cdp), intent(in) :: b
         !! Input vector on which to apply \( \exp(\tau \mathbf{A}) \).
@@ -1352,7 +1352,7 @@ contains
     subroutine kexpm_mat_cdp(C, A, B, tau, tol, info, trans, kdim)
         class(abstract_vector_cdp), intent(out) :: C(:)
         !! Best Krylov approximation of \( \mathbf{C} = \exp(\tau \mathbf{A}) \mathbf{B} \).
-        class(abstract_linop_cdp), intent(in) :: A
+        class(abstract_linop_cdp), intent(inout) :: A
         !! Linear operator to be exponentiated.
         class(abstract_vector_cdp), intent(in) :: B(:)
         !! Input matrix on which to apply \( \exp(\tau \mathbf{A}) \).

--- a/src/ExpmLib.fypp
+++ b/src/ExpmLib.fypp
@@ -29,6 +29,9 @@ module lightkrylov_expmlib
     public :: expm
     public :: kexpm
     public :: k_exptA
+    #:for kind, type in RC_KINDS_TYPES
+    public :: k_exptA_${type[0]}$${kind}$
+    #:endfor
 
     abstract interface
         #:for kind, type in RC_KINDS_TYPES

--- a/src/ExpmLib.fypp
+++ b/src/ExpmLib.fypp
@@ -22,7 +22,9 @@ module lightkrylov_expmlib
     implicit none
     private
     
-    character(len=128), parameter, private :: this_module= 'LightKrylov_ExpmLib'
+    character(len=*), parameter, private :: this_module      = 'LK_ExpmLib'
+    character(len=*), parameter, private :: this_module_long = 'LightKrylov_ExpmLib'
+
     #:for kind, type in RC_KINDS_TYPES
     public :: abstract_exptA_${type[0]}$${kind}$
     #:endfor

--- a/src/ExpmLib.fypp
+++ b/src/ExpmLib.fypp
@@ -98,7 +98,7 @@ module lightkrylov_expmlib
         !!
         !!  `c` : Output vector (or vectors). It is an `intent(out)` argument.
         !!
-        !!  `A` : Linear operator to be exponentiated. It is an `intent(in)` argument.
+        !!  `A` : Linear operator to be exponentiated. It is an `intent(inout)` argument.
         !!
         !!  `b` : Vector to be multiplied by \( \exp(\tau A) \). It is an `intent(in)` argument.
         !!
@@ -218,7 +218,7 @@ contains
     subroutine kexpm_vec_${type[0]}$${kind}$(c, A, b, tau, tol, info, trans, kdim)
         class(abstract_vector_${type[0]}$${kind}$), intent(out) :: c
         !! Best approximation of \( \exp(\tau \mathbf{A}) \mathbf{b} \) in the computed Krylov subspace
-        class(abstract_linop_${type[0]}$${kind}$), intent(in) :: A
+        class(abstract_linop_${type[0]}$${kind}$), intent(inout) :: A
         !! Linear operator to be exponentiated.
         class(abstract_vector_${type[0]}$${kind}$), intent(in) :: b
         !! Input vector on which to apply \( \exp(\tau \mathbf{A}) \).
@@ -326,7 +326,7 @@ contains
     subroutine kexpm_mat_${type[0]}$${kind}$(C, A, B, tau, tol, info, trans, kdim)
         class(abstract_vector_${type[0]}$${kind}$), intent(out) :: C(:)
         !! Best Krylov approximation of \( \mathbf{C} = \exp(\tau \mathbf{A}) \mathbf{B} \).
-        class(abstract_linop_${type[0]}$${kind}$), intent(in) :: A
+        class(abstract_linop_${type[0]}$${kind}$), intent(inout) :: A
         !! Linear operator to be exponentiated.
         class(abstract_vector_${type[0]}$${kind}$), intent(in) :: B(:)
         !! Input matrix on which to apply \( \exp(\tau \mathbf{A}) \).

--- a/src/IterativeSolvers.f90
+++ b/src/IterativeSolvers.f90
@@ -38,7 +38,8 @@ module lightkrylov_IterativeSolvers
     implicit none
     private
 
-    character(len=128), parameter :: this_module = 'LightKrylov_IterativeSolvers'
+    character(len=*), parameter :: this_module      = 'LK_Solvers'
+    character(len=*), parameter :: this_module_long = 'LightKrylov_IterativeSolvers'
 
     public :: abstract_linear_solver_rsp
     public :: abstract_linear_solver_rdp

--- a/src/IterativeSolvers.f90
+++ b/src/IterativeSolvers.f90
@@ -2027,15 +2027,13 @@ contains
     !-----     GENERALIZED MINIMUM RESIDUAL METHOD     -----
     !-------------------------------------------------------
 
-    subroutine gmres_rsp(A, b, x, meta, info, rtol, atol, preconditioner, options, transpose)
+    subroutine gmres_rsp(A, b, x, info, rtol, atol, preconditioner, options, transpose, meta)
         class(abstract_linop_rsp), intent(in) :: A
         !! Linear operator to be inverted.
         class(abstract_vector_rsp), intent(in) :: b
         !! Right-hand side vector.
         class(abstract_vector_rsp), intent(inout) :: x
         !! Solution vector.
-        class(abstract_metadata), intent(out) :: meta
-        !! Metadata.
         integer, intent(out) :: info
         !! Information flag.
         real(sp), optional, intent(in) :: rtol
@@ -2048,6 +2046,8 @@ contains
         !! GMRES options.   
         logical, optional, intent(in) :: transpose
         !! Whether \(\mathbf{A}\) or \(\mathbf{A}^H\) is being used.
+        class(abstract_metadata), optional, intent(out) :: meta
+        !! Metadata.
 
         !--------------------------------------
         !-----     Internal variables     -----
@@ -2203,32 +2203,36 @@ contains
             call logger%log_information(msg, module=this_module, procedure='gmres_rsp')
 
             ! Exit gmres if desired accuracy is reached.
-            if (abs(beta) <= tol) gmres_meta%converged = .true.; exit gmres_iter
-
+            if (abs(beta) <= tol) then
+               gmres_meta%converged = .true.
+               exit gmres_iter
+            end if
         enddo gmres_iter
 
         ! Returns the number of iterations.
-        info = niter
+        info = gmres_meta%n_iter
         gmres_meta%info = info
 
+        print *, 'GMRES', info
+
         ! Set metadata output
-        select type(meta)
-            type is (gmres_sp_metadata)
-                meta = gmres_meta
-        end select
+        if (present(meta)) then
+           select type(meta)
+                 type is (gmres_sp_metadata)
+                    meta = gmres_meta
+           end select
+        end if
 
         return
     end subroutine gmres_rsp
 
-    subroutine gmres_rdp(A, b, x, meta, info, rtol, atol, preconditioner, options, transpose)
+    subroutine gmres_rdp(A, b, x, info, rtol, atol, preconditioner, options, transpose, meta)
         class(abstract_linop_rdp), intent(in) :: A
         !! Linear operator to be inverted.
         class(abstract_vector_rdp), intent(in) :: b
         !! Right-hand side vector.
         class(abstract_vector_rdp), intent(inout) :: x
         !! Solution vector.
-        class(abstract_metadata), intent(out) :: meta
-        !! Metadata.
         integer, intent(out) :: info
         !! Information flag.
         real(dp), optional, intent(in) :: rtol
@@ -2241,6 +2245,8 @@ contains
         !! GMRES options.   
         logical, optional, intent(in) :: transpose
         !! Whether \(\mathbf{A}\) or \(\mathbf{A}^H\) is being used.
+        class(abstract_metadata), optional, intent(out) :: meta
+        !! Metadata.
 
         !--------------------------------------
         !-----     Internal variables     -----
@@ -2396,32 +2402,36 @@ contains
             call logger%log_information(msg, module=this_module, procedure='gmres_rdp')
 
             ! Exit gmres if desired accuracy is reached.
-            if (abs(beta) <= tol) gmres_meta%converged = .true.; exit gmres_iter
-
+            if (abs(beta) <= tol) then
+               gmres_meta%converged = .true.
+               exit gmres_iter
+            end if
         enddo gmres_iter
 
         ! Returns the number of iterations.
-        info = niter
+        info = gmres_meta%n_iter
         gmres_meta%info = info
 
+        print *, 'GMRES', info
+
         ! Set metadata output
-        select type(meta)
-            type is (gmres_dp_metadata)
-                meta = gmres_meta
-        end select
+        if (present(meta)) then
+           select type(meta)
+                 type is (gmres_dp_metadata)
+                    meta = gmres_meta
+           end select
+        end if
 
         return
     end subroutine gmres_rdp
 
-    subroutine gmres_csp(A, b, x, meta, info, rtol, atol, preconditioner, options, transpose)
+    subroutine gmres_csp(A, b, x, info, rtol, atol, preconditioner, options, transpose, meta)
         class(abstract_linop_csp), intent(in) :: A
         !! Linear operator to be inverted.
         class(abstract_vector_csp), intent(in) :: b
         !! Right-hand side vector.
         class(abstract_vector_csp), intent(inout) :: x
         !! Solution vector.
-        class(abstract_metadata), intent(out) :: meta
-        !! Metadata.
         integer, intent(out) :: info
         !! Information flag.
         real(sp), optional, intent(in) :: rtol
@@ -2434,6 +2444,8 @@ contains
         !! GMRES options.   
         logical, optional, intent(in) :: transpose
         !! Whether \(\mathbf{A}\) or \(\mathbf{A}^H\) is being used.
+        class(abstract_metadata), optional, intent(out) :: meta
+        !! Metadata.
 
         !--------------------------------------
         !-----     Internal variables     -----
@@ -2589,32 +2601,36 @@ contains
             call logger%log_information(msg, module=this_module, procedure='gmres_csp')
 
             ! Exit gmres if desired accuracy is reached.
-            if (abs(beta) <= tol) gmres_meta%converged = .true.; exit gmres_iter
-
+            if (abs(beta) <= tol) then
+               gmres_meta%converged = .true.
+               exit gmres_iter
+            end if
         enddo gmres_iter
 
         ! Returns the number of iterations.
-        info = niter
+        info = gmres_meta%n_iter
         gmres_meta%info = info
 
+        print *, 'GMRES', info
+
         ! Set metadata output
-        select type(meta)
-            type is (gmres_sp_metadata)
-                meta = gmres_meta
-        end select
+        if (present(meta)) then
+           select type(meta)
+                 type is (gmres_sp_metadata)
+                    meta = gmres_meta
+           end select
+        end if
 
         return
     end subroutine gmres_csp
 
-    subroutine gmres_cdp(A, b, x, meta, info, rtol, atol, preconditioner, options, transpose)
+    subroutine gmres_cdp(A, b, x, info, rtol, atol, preconditioner, options, transpose, meta)
         class(abstract_linop_cdp), intent(in) :: A
         !! Linear operator to be inverted.
         class(abstract_vector_cdp), intent(in) :: b
         !! Right-hand side vector.
         class(abstract_vector_cdp), intent(inout) :: x
         !! Solution vector.
-        class(abstract_metadata), intent(out) :: meta
-        !! Metadata.
         integer, intent(out) :: info
         !! Information flag.
         real(dp), optional, intent(in) :: rtol
@@ -2627,6 +2643,8 @@ contains
         !! GMRES options.   
         logical, optional, intent(in) :: transpose
         !! Whether \(\mathbf{A}\) or \(\mathbf{A}^H\) is being used.
+        class(abstract_metadata), optional, intent(out) :: meta
+        !! Metadata.
 
         !--------------------------------------
         !-----     Internal variables     -----
@@ -2782,19 +2800,25 @@ contains
             call logger%log_information(msg, module=this_module, procedure='gmres_cdp')
 
             ! Exit gmres if desired accuracy is reached.
-            if (abs(beta) <= tol) gmres_meta%converged = .true.; exit gmres_iter
-
+            if (abs(beta) <= tol) then
+               gmres_meta%converged = .true.
+               exit gmres_iter
+            end if
         enddo gmres_iter
 
         ! Returns the number of iterations.
-        info = niter
+        info = gmres_meta%n_iter
         gmres_meta%info = info
 
+        print *, 'GMRES', info
+
         ! Set metadata output
-        select type(meta)
-            type is (gmres_dp_metadata)
-                meta = gmres_meta
-        end select
+        if (present(meta)) then
+           select type(meta)
+                 type is (gmres_dp_metadata)
+                    meta = gmres_meta
+           end select
+        end if
 
         return
     end subroutine gmres_cdp
@@ -2807,15 +2831,13 @@ contains
     !-----     CONJUGATE GRADIENT METHOD     -----
     !---------------------------------------------
 
-    subroutine cg_rsp(A, b, x, meta, info, rtol, atol, preconditioner, options)
+    subroutine cg_rsp(A, b, x, info, rtol, atol, preconditioner, options, meta)
         class(abstract_sym_linop_rsp), intent(in) :: A
         !! Linear operator to be inverted.
         class(abstract_vector_rsp), intent(in) :: b
         !! Right-hand side vector.
         class(abstract_vector_rsp), intent(inout) :: x
         !! Solution vector.
-        class(abstract_metadata), intent(out) :: meta
-        !! Metadata.
         integer, intent(out) :: info
         !! Information flag.
         real(sp), optional, intent(in) :: rtol
@@ -2826,6 +2848,8 @@ contains
         !! Preconditioner (not yet supported).
         type(cg_sp_opts), optional, intent(in) :: options
         !! Options for the conjugate gradient solver.
+        class(abstract_metadata), optional, intent(out) :: meta
+        !! Metadata.
 
         !----------------------------------------
         !-----     Internal variables      ------
@@ -2894,10 +2918,13 @@ contains
             residual = sqrt(r_dot_r_new)
 
             ! Save metadata.
-            cg_meta%n_iter  = cg_meta%n_iter + 1
+            cg_meta%n_iter = cg_meta%n_iter + 1
             cg_meta%res(cg_meta%n_iter+1) = residual
 
-            if (residual < tol) cg_meta%converged = .true.; exit cg_loop
+            if (residual < tol) then
+               cg_meta%converged = .true.
+               exit cg_loop
+            end if
 
             ! Compute new direction beta = r_dot_r_new / r_dot_r_old.
             beta = r_dot_r_new / r_dot_r_old
@@ -2910,26 +2937,28 @@ contains
             call logger%log_information(msg, module=this_module, procedure='cg_rsp')
         enddo cg_loop
 
+        ! Set and copy info flag for completeness
         info = cg_meta%n_iter
+        cg_meta%info = info
 
         ! Set metadata output
-        select type(meta)
-            type is (cg_sp_metadata)
-                meta = cg_meta
-        end select
+        if (present(meta)) then
+           select type(meta)
+               type is (cg_sp_metadata)
+                   meta = cg_meta
+           end select
+        end if
         
         return
     end subroutine cg_rsp
 
-    subroutine cg_rdp(A, b, x, meta, info, rtol, atol, preconditioner, options)
+    subroutine cg_rdp(A, b, x, info, rtol, atol, preconditioner, options, meta)
         class(abstract_sym_linop_rdp), intent(in) :: A
         !! Linear operator to be inverted.
         class(abstract_vector_rdp), intent(in) :: b
         !! Right-hand side vector.
         class(abstract_vector_rdp), intent(inout) :: x
         !! Solution vector.
-        class(abstract_metadata), intent(out) :: meta
-        !! Metadata.
         integer, intent(out) :: info
         !! Information flag.
         real(dp), optional, intent(in) :: rtol
@@ -2940,6 +2969,8 @@ contains
         !! Preconditioner (not yet supported).
         type(cg_dp_opts), optional, intent(in) :: options
         !! Options for the conjugate gradient solver.
+        class(abstract_metadata), optional, intent(out) :: meta
+        !! Metadata.
 
         !----------------------------------------
         !-----     Internal variables      ------
@@ -3008,10 +3039,13 @@ contains
             residual = sqrt(r_dot_r_new)
 
             ! Save metadata.
-            cg_meta%n_iter  = cg_meta%n_iter + 1
+            cg_meta%n_iter = cg_meta%n_iter + 1
             cg_meta%res(cg_meta%n_iter+1) = residual
 
-            if (residual < tol) cg_meta%converged = .true.; exit cg_loop
+            if (residual < tol) then
+               cg_meta%converged = .true.
+               exit cg_loop
+            end if
 
             ! Compute new direction beta = r_dot_r_new / r_dot_r_old.
             beta = r_dot_r_new / r_dot_r_old
@@ -3024,26 +3058,28 @@ contains
             call logger%log_information(msg, module=this_module, procedure='cg_rdp')
         enddo cg_loop
 
+        ! Set and copy info flag for completeness
         info = cg_meta%n_iter
+        cg_meta%info = info
 
         ! Set metadata output
-        select type(meta)
-            type is (cg_dp_metadata)
-                meta = cg_meta
-        end select
+        if (present(meta)) then
+           select type(meta)
+               type is (cg_dp_metadata)
+                   meta = cg_meta
+           end select
+        end if
         
         return
     end subroutine cg_rdp
 
-    subroutine cg_csp(A, b, x, meta, info, rtol, atol, preconditioner, options)
+    subroutine cg_csp(A, b, x, info, rtol, atol, preconditioner, options, meta)
         class(abstract_hermitian_linop_csp), intent(in) :: A
         !! Linear operator to be inverted.
         class(abstract_vector_csp), intent(in) :: b
         !! Right-hand side vector.
         class(abstract_vector_csp), intent(inout) :: x
         !! Solution vector.
-        class(abstract_metadata), intent(out) :: meta
-        !! Metadata.
         integer, intent(out) :: info
         !! Information flag.
         real(sp), optional, intent(in) :: rtol
@@ -3054,6 +3090,8 @@ contains
         !! Preconditioner (not yet supported).
         type(cg_sp_opts), optional, intent(in) :: options
         !! Options for the conjugate gradient solver.
+        class(abstract_metadata), optional, intent(out) :: meta
+        !! Metadata.
 
         !----------------------------------------
         !-----     Internal variables      ------
@@ -3122,10 +3160,13 @@ contains
             residual = sqrt(abs(r_dot_r_new))
 
             ! Save metadata.
-            cg_meta%n_iter  = cg_meta%n_iter + 1
+            cg_meta%n_iter = cg_meta%n_iter + 1
             cg_meta%res(cg_meta%n_iter+1) = residual
 
-            if (residual < tol) cg_meta%converged = .true.; exit cg_loop
+            if (residual < tol) then
+               cg_meta%converged = .true.
+               exit cg_loop
+            end if
 
             ! Compute new direction beta = r_dot_r_new / r_dot_r_old.
             beta = r_dot_r_new / r_dot_r_old
@@ -3138,26 +3179,28 @@ contains
             call logger%log_information(msg, module=this_module, procedure='cg_csp')
         enddo cg_loop
 
+        ! Set and copy info flag for completeness
         info = cg_meta%n_iter
+        cg_meta%info = info
 
         ! Set metadata output
-        select type(meta)
-            type is (cg_sp_metadata)
-                meta = cg_meta
-        end select
+        if (present(meta)) then
+           select type(meta)
+               type is (cg_sp_metadata)
+                   meta = cg_meta
+           end select
+        end if
         
         return
     end subroutine cg_csp
 
-    subroutine cg_cdp(A, b, x, meta, info, rtol, atol, preconditioner, options)
+    subroutine cg_cdp(A, b, x, info, rtol, atol, preconditioner, options, meta)
         class(abstract_hermitian_linop_cdp), intent(in) :: A
         !! Linear operator to be inverted.
         class(abstract_vector_cdp), intent(in) :: b
         !! Right-hand side vector.
         class(abstract_vector_cdp), intent(inout) :: x
         !! Solution vector.
-        class(abstract_metadata), intent(out) :: meta
-        !! Metadata.
         integer, intent(out) :: info
         !! Information flag.
         real(dp), optional, intent(in) :: rtol
@@ -3168,6 +3211,8 @@ contains
         !! Preconditioner (not yet supported).
         type(cg_dp_opts), optional, intent(in) :: options
         !! Options for the conjugate gradient solver.
+        class(abstract_metadata), optional, intent(out) :: meta
+        !! Metadata.
 
         !----------------------------------------
         !-----     Internal variables      ------
@@ -3236,10 +3281,13 @@ contains
             residual = sqrt(abs(r_dot_r_new))
 
             ! Save metadata.
-            cg_meta%n_iter  = cg_meta%n_iter + 1
+            cg_meta%n_iter = cg_meta%n_iter + 1
             cg_meta%res(cg_meta%n_iter+1) = residual
 
-            if (residual < tol) cg_meta%converged = .true.; exit cg_loop
+            if (residual < tol) then
+               cg_meta%converged = .true.
+               exit cg_loop
+            end if
 
             ! Compute new direction beta = r_dot_r_new / r_dot_r_old.
             beta = r_dot_r_new / r_dot_r_old
@@ -3252,13 +3300,17 @@ contains
             call logger%log_information(msg, module=this_module, procedure='cg_cdp')
         enddo cg_loop
 
+        ! Set and copy info flag for completeness
         info = cg_meta%n_iter
+        cg_meta%info = info
 
         ! Set metadata output
-        select type(meta)
-            type is (cg_dp_metadata)
-                meta = cg_meta
-        end select
+        if (present(meta)) then
+           select type(meta)
+               type is (cg_dp_metadata)
+                   meta = cg_meta
+           end select
+        end if
         
         return
     end subroutine cg_cdp

--- a/src/IterativeSolvers.f90
+++ b/src/IterativeSolvers.f90
@@ -2110,8 +2110,9 @@ contains
         allocate(alpha(kdim)) ; alpha = 0.0_sp
         allocate(e(kdim+1)) ; e = 0.0_sp
 
-        ! Initialize meta
+        ! Initialize metadata and & reset matvec counter
         gmres_meta = gmres_sp_metadata()
+        call A%reset_counter(trans, 'gmres%init')
 
         info = 0
 
@@ -2222,6 +2223,8 @@ contains
            end select
         end if
 
+        call A%reset_counter(trans, 'gmres%post')
+        
         return
     end subroutine gmres_rsp
 
@@ -2308,8 +2311,9 @@ contains
         allocate(alpha(kdim)) ; alpha = 0.0_dp
         allocate(e(kdim+1)) ; e = 0.0_dp
 
-        ! Initialize meta
+        ! Initialize metadata and & reset matvec counter
         gmres_meta = gmres_dp_metadata()
+        call A%reset_counter(trans, 'gmres%init')
 
         info = 0
 
@@ -2420,6 +2424,8 @@ contains
            end select
         end if
 
+        call A%reset_counter(trans, 'gmres%post')
+        
         return
     end subroutine gmres_rdp
 
@@ -2506,8 +2512,9 @@ contains
         allocate(alpha(kdim)) ; alpha = 0.0_sp
         allocate(e(kdim+1)) ; e = 0.0_sp
 
-        ! Initialize meta
+        ! Initialize metadata and & reset matvec counter
         gmres_meta = gmres_sp_metadata()
+        call A%reset_counter(trans, 'gmres%init')
 
         info = 0
 
@@ -2618,6 +2625,8 @@ contains
            end select
         end if
 
+        call A%reset_counter(trans, 'gmres%post')
+        
         return
     end subroutine gmres_csp
 
@@ -2704,8 +2713,9 @@ contains
         allocate(alpha(kdim)) ; alpha = 0.0_dp
         allocate(e(kdim+1)) ; e = 0.0_dp
 
-        ! Initialize meta
+        ! Initialize metadata and & reset matvec counter
         gmres_meta = gmres_dp_metadata()
+        call A%reset_counter(trans, 'gmres%init')
 
         info = 0
 
@@ -2816,6 +2826,8 @@ contains
            end select
         end if
 
+        call A%reset_counter(trans, 'gmres%post')
+        
         return
     end subroutine gmres_cdp
 
@@ -2881,8 +2893,9 @@ contains
         allocate(p, source=b)  ; call p%zero()
         allocate(Ap, source=b) ; call Ap%zero()
 
-         ! Initialize meta
+         ! Initialize meta & reset matvec counter
         cg_meta = cg_sp_metadata()
+        call A%reset_counter(.false., 'cg%init')
 
         info = 0
 
@@ -2945,7 +2958,9 @@ contains
                    meta = cg_meta
            end select
         end if
-        
+
+        call A%reset_counter(.false., 'cg%post')
+
         return
     end subroutine cg_rsp
 
@@ -3003,8 +3018,9 @@ contains
         allocate(p, source=b)  ; call p%zero()
         allocate(Ap, source=b) ; call Ap%zero()
 
-         ! Initialize meta
+         ! Initialize meta & reset matvec counter
         cg_meta = cg_dp_metadata()
+        call A%reset_counter(.false., 'cg%init')
 
         info = 0
 
@@ -3067,7 +3083,9 @@ contains
                    meta = cg_meta
            end select
         end if
-        
+
+        call A%reset_counter(.false., 'cg%post')
+
         return
     end subroutine cg_rdp
 
@@ -3125,8 +3143,9 @@ contains
         allocate(p, source=b)  ; call p%zero()
         allocate(Ap, source=b) ; call Ap%zero()
 
-         ! Initialize meta
+         ! Initialize meta & reset matvec counter
         cg_meta = cg_sp_metadata()
+        call A%reset_counter(.false., 'cg%init')
 
         info = 0
 
@@ -3189,7 +3208,9 @@ contains
                    meta = cg_meta
            end select
         end if
-        
+
+        call A%reset_counter(.false., 'cg%post')
+
         return
     end subroutine cg_csp
 
@@ -3247,8 +3268,9 @@ contains
         allocate(p, source=b)  ; call p%zero()
         allocate(Ap, source=b) ; call Ap%zero()
 
-         ! Initialize meta
+         ! Initialize meta & reset matvec counter
         cg_meta = cg_dp_metadata()
+        call A%reset_counter(.false., 'cg%init')
 
         info = 0
 
@@ -3311,7 +3333,9 @@ contains
                    meta = cg_meta
            end select
         end if
-        
+
+        call A%reset_counter(.false., 'cg%post')
+
         return
     end subroutine cg_cdp
 

--- a/src/IterativeSolvers.f90
+++ b/src/IterativeSolvers.f90
@@ -114,7 +114,7 @@ module lightkrylov_IterativeSolvers
         !!
         !!  `A` : Linear operator derived from `abstract_sym_linop_rsp`, `abstract_sym_linop_rdp`,
         !!        `abstract_hermitian_linop_csp` or `abstract_hermitian_linop_cdp` whose leading
-        !!        eigenpairs need to be computed. It is an `intent(in)` argument.
+        !!        eigenpairs need to be computed. It is an `intent(inout)` argument.
         !!
         !!  `X` : Array of `abstract_vectors` with the same type and kind as `A`. On exit, it
         !!        contains the leading eigenvectors of `A`. Note that the dimension of `X` fixes
@@ -177,7 +177,7 @@ module lightkrylov_IterativeSolvers
         !!
         !!  `A` : Linear operator derived from `abstract_sym_linop_rsp`, `abstract_sym_linop_rdp`,
         !!        `abstract_hermitian_linop_csp` or `abstract_hermitian_linop_cdp` whose leading
-        !!        eigenpairs need to be computed. It is an `intent(in)` argument.
+        !!        eigenpairs need to be computed. It is an `intent(inout)` argument.
         !!
         !!  `X` : Array of `abstract_vectors` with the same type and kind as `A`. On exit, it
         !!        contains the leading eigenvectors of `A`. Note that the dimension of `X` fixes
@@ -246,7 +246,7 @@ module lightkrylov_IterativeSolvers
         !!
         !!  `A` : Linear operator derived from `abstract_sym_linop_rsp`, `abstract_sym_linop_rdp`,
         !!        `abstract_hermitian_linop_csp` or `abstract_hermitian_linop_cdp` whose leading
-        !!        eigenpairs need to be computed. It is an `intent(in)` argument.
+        !!        eigenpairs need to be computed. It is an `intent(inout)` argument.
         !!
         !!  `U` : Array of `abstract_vectors` with the same type and kind as `A`. On exit, it
         !!        contains the left singular vectors of `A`. Note that the dimension of `U` fixes
@@ -303,7 +303,7 @@ module lightkrylov_IterativeSolvers
         !!  ### Arguments
         !!
         !!  `A` : Linear operator derived from one of the `abstract_linop` provided by the
-        !!  `AbstractLinops` module. It is an `intent(in)` argument.
+        !!  `AbstractLinops` module. It is an `intent(inout)` argument.
         !!
         !!  `b` : Right-hand side vector derived from one the `abstract_vector` types provided
         !!  by the `AbstractVectors` module. It needs to have the same type and kind as `A`.
@@ -362,7 +362,7 @@ module lightkrylov_IterativeSolvers
         !!
         !!  `A` : Linear operator derived from one of the `abstract_sym_linop` or
         !!  `abstract_hermitian_linop` types provided by the `AbstractLinops` module. It is an
-        !!  `intent(in)` argument.
+        !!  `intent(inout)` argument.
         !!
         !!  `b` : Right-hand side vector derived from one the `abstract_vector` types provided
         !!  by the `AbstractVectors` module. It needs to have the same type and kind as `A`.
@@ -479,7 +479,7 @@ module lightkrylov_IterativeSolvers
         subroutine abstract_linear_solver_rsp(A, b, x, info, rtol, atol, preconditioner, options, transpose, meta)
             !! Abstract interface to use a user-defined linear solver in `LightKrylov`.
             import abstract_linop_rsp, abstract_vector_rsp, abstract_opts, abstract_metadata, abstract_precond_rsp, sp
-            class(abstract_linop_rsp), intent(in) :: A
+            class(abstract_linop_rsp), intent(inout) :: A
             !! Linear operator to invert.
             class(abstract_vector_rsp), intent(in) :: b
             !! Right-hand side vector.
@@ -504,7 +504,7 @@ module lightkrylov_IterativeSolvers
         subroutine abstract_linear_solver_rdp(A, b, x, info, rtol, atol, preconditioner, options, transpose, meta)
             !! Abstract interface to use a user-defined linear solver in `LightKrylov`.
             import abstract_linop_rdp, abstract_vector_rdp, abstract_opts, abstract_metadata, abstract_precond_rdp, dp
-            class(abstract_linop_rdp), intent(in) :: A
+            class(abstract_linop_rdp), intent(inout) :: A
             !! Linear operator to invert.
             class(abstract_vector_rdp), intent(in) :: b
             !! Right-hand side vector.
@@ -529,7 +529,7 @@ module lightkrylov_IterativeSolvers
         subroutine abstract_linear_solver_csp(A, b, x, info, rtol, atol, preconditioner, options, transpose, meta)
             !! Abstract interface to use a user-defined linear solver in `LightKrylov`.
             import abstract_linop_csp, abstract_vector_csp, abstract_opts, abstract_metadata, abstract_precond_csp, sp
-            class(abstract_linop_csp), intent(in) :: A
+            class(abstract_linop_csp), intent(inout) :: A
             !! Linear operator to invert.
             class(abstract_vector_csp), intent(in) :: b
             !! Right-hand side vector.
@@ -554,7 +554,7 @@ module lightkrylov_IterativeSolvers
         subroutine abstract_linear_solver_cdp(A, b, x, info, rtol, atol, preconditioner, options, transpose, meta)
             !! Abstract interface to use a user-defined linear solver in `LightKrylov`.
             import abstract_linop_cdp, abstract_vector_cdp, abstract_opts, abstract_metadata, abstract_precond_cdp, dp
-            class(abstract_linop_cdp), intent(in) :: A
+            class(abstract_linop_cdp), intent(inout) :: A
             !! Linear operator to invert.
             class(abstract_vector_cdp), intent(in) :: b
             !! Right-hand side vector.
@@ -693,7 +693,7 @@ contains
     !---------------------------------------------------
 
     subroutine eigs_rsp(A, X, eigvals, residuals, info, kdim, select, tolerance, transpose)
-        class(abstract_linop_rsp), intent(in) :: A
+        class(abstract_linop_rsp), intent(inout) :: A
         !! Linear operator whose leading eigenpairs need to be computed.
         class(abstract_vector_rsp), intent(out) :: X(:)
         !! Leading eigenvectors of \(\mathbf{A}\).
@@ -834,7 +834,7 @@ contains
     end subroutine eigs_rsp
 
     subroutine eigs_rdp(A, X, eigvals, residuals, info, kdim, select, tolerance, transpose)
-        class(abstract_linop_rdp), intent(in) :: A
+        class(abstract_linop_rdp), intent(inout) :: A
         !! Linear operator whose leading eigenpairs need to be computed.
         class(abstract_vector_rdp), intent(out) :: X(:)
         !! Leading eigenvectors of \(\mathbf{A}\).
@@ -975,7 +975,7 @@ contains
     end subroutine eigs_rdp
 
     subroutine eigs_csp(A, X, eigvals, residuals, info, kdim, select, tolerance, transpose)
-        class(abstract_linop_csp), intent(in) :: A
+        class(abstract_linop_csp), intent(inout) :: A
         !! Linear operator whose leading eigenpairs need to be computed.
         class(abstract_vector_csp), intent(out) :: X(:)
         !! Leading eigenvectors of \(\mathbf{A}\).
@@ -1106,7 +1106,7 @@ contains
     end subroutine eigs_csp
 
     subroutine eigs_cdp(A, X, eigvals, residuals, info, kdim, select, tolerance, transpose)
-        class(abstract_linop_cdp), intent(in) :: A
+        class(abstract_linop_cdp), intent(inout) :: A
         !! Linear operator whose leading eigenpairs need to be computed.
         class(abstract_vector_cdp), intent(out) :: X(:)
         !! Leading eigenvectors of \(\mathbf{A}\).
@@ -1242,7 +1242,7 @@ contains
     !-----------------------------------------------------------------------------
 
     subroutine eighs_rsp(A, X, eigvals, residuals, info, kdim, tolerance)
-        class(abstract_sym_linop_rsp), intent(in) :: A
+        class(abstract_sym_linop_rsp), intent(inout) :: A
         !! Linear operator whose leading eigenpairs need to be computed.
         class(abstract_vector_rsp), intent(out) :: X(:)
         !! Leading eigevectors of \( \mathbf{A} \).
@@ -1342,7 +1342,7 @@ contains
     end subroutine eighs_rsp
 
     subroutine eighs_rdp(A, X, eigvals, residuals, info, kdim, tolerance)
-        class(abstract_sym_linop_rdp), intent(in) :: A
+        class(abstract_sym_linop_rdp), intent(inout) :: A
         !! Linear operator whose leading eigenpairs need to be computed.
         class(abstract_vector_rdp), intent(out) :: X(:)
         !! Leading eigevectors of \( \mathbf{A} \).
@@ -1442,7 +1442,7 @@ contains
     end subroutine eighs_rdp
 
     subroutine eighs_csp(A, X, eigvals, residuals, info, kdim, tolerance)
-        class(abstract_hermitian_linop_csp), intent(in) :: A
+        class(abstract_hermitian_linop_csp), intent(inout) :: A
         !! Linear operator whose leading eigenpairs need to be computed.
         class(abstract_vector_csp), intent(out) :: X(:)
         !! Leading eigevectors of \( \mathbf{A} \).
@@ -1542,7 +1542,7 @@ contains
     end subroutine eighs_csp
 
     subroutine eighs_cdp(A, X, eigvals, residuals, info, kdim, tolerance)
-        class(abstract_hermitian_linop_cdp), intent(in) :: A
+        class(abstract_hermitian_linop_cdp), intent(inout) :: A
         !! Linear operator whose leading eigenpairs need to be computed.
         class(abstract_vector_cdp), intent(out) :: X(:)
         !! Leading eigevectors of \( \mathbf{A} \).
@@ -1647,7 +1647,7 @@ contains
     !------------------------------------------------
 
     subroutine svds_rsp(A, U, S, V, residuals, info, kdim, tolerance)
-        class(abstract_linop_rsp), intent(in) :: A
+        class(abstract_linop_rsp), intent(inout) :: A
         !! Linear operator whose leading singular triplets need to be computed.
         class(abstract_vector_rsp), intent(out) :: U(:)
         !! Leading left singular vectors.
@@ -1741,7 +1741,7 @@ contains
     end subroutine svds_rsp
 
     subroutine svds_rdp(A, U, S, V, residuals, info, kdim, tolerance)
-        class(abstract_linop_rdp), intent(in) :: A
+        class(abstract_linop_rdp), intent(inout) :: A
         !! Linear operator whose leading singular triplets need to be computed.
         class(abstract_vector_rdp), intent(out) :: U(:)
         !! Leading left singular vectors.
@@ -1835,7 +1835,7 @@ contains
     end subroutine svds_rdp
 
     subroutine svds_csp(A, U, S, V, residuals, info, kdim, tolerance)
-        class(abstract_linop_csp), intent(in) :: A
+        class(abstract_linop_csp), intent(inout) :: A
         !! Linear operator whose leading singular triplets need to be computed.
         class(abstract_vector_csp), intent(out) :: U(:)
         !! Leading left singular vectors.
@@ -1929,7 +1929,7 @@ contains
     end subroutine svds_csp
 
     subroutine svds_cdp(A, U, S, V, residuals, info, kdim, tolerance)
-        class(abstract_linop_cdp), intent(in) :: A
+        class(abstract_linop_cdp), intent(inout) :: A
         !! Linear operator whose leading singular triplets need to be computed.
         class(abstract_vector_cdp), intent(out) :: U(:)
         !! Leading left singular vectors.
@@ -2028,7 +2028,7 @@ contains
     !-------------------------------------------------------
 
     subroutine gmres_rsp(A, b, x, info, rtol, atol, preconditioner, options, transpose, meta)
-        class(abstract_linop_rsp), intent(in) :: A
+        class(abstract_linop_rsp), intent(inout) :: A
         !! Linear operator to be inverted.
         class(abstract_vector_rsp), intent(in) :: b
         !! Right-hand side vector.
@@ -2112,22 +2112,21 @@ contains
 
         ! Initialize meta
         gmres_meta = gmres_sp_metadata()
-        allocate(gmres_meta%res(opts%maxiter*kdim+1)); gmres_meta%res = 0.0_sp
 
         info = 0
 
         ! Initial Krylov vector.
         if (x%norm() > 0) then
             if (trans) then
-                call A%rmatvec(x, V(1)); gmres_meta%n_Ax = gmres_meta%n_Ax + 1
+                call A%apply_rmatvec(x, V(1))
             else
-                call A%matvec(x, V(1)); gmres_meta%n_Ax = gmres_meta%n_Ax + 1
+                call A%apply_matvec(x, V(1))
             endif
         endif
 
         call V(1)%sub(b) ; call V(1)%chsgn()
         beta = V(1)%norm() ; call V(1)%scal(one_rsp/beta)
-        gmres_meta%res(1) = beta
+        allocate(gmres_meta%res(1)); gmres_meta%res(1) = abs(beta)
 
         ! Iterative solver.
         gmres_iter : do i = 1, maxiter
@@ -2142,9 +2141,9 @@ contains
 
                 ! Matrix-vector product.
                 if (trans) then
-                    call A%rmatvec(wrk, V(k+1)); gmres_meta%n_Ax = gmres_meta%n_Ax + 1
+                    call A%apply_rmatvec(wrk, V(k+1))
                 else
-                    call A%matvec(wrk, V(k+1)); gmres_meta%n_Ax = gmres_meta%n_Ax + 1
+                    call A%apply_matvec(wrk, V(k+1))
                 endif
 
                 ! Double Gram-Schmid orthogonalization
@@ -2166,7 +2165,7 @@ contains
                 ! Save metadata.
                 gmres_meta%n_iter  = gmres_meta%n_iter + 1
                 gmres_meta%n_inner = gmres_meta%n_inner + 1
-                gmres_meta%res(gmres_meta%n_iter+1) = beta
+                gmres_meta%res = [ gmres_meta%res, abs(beta) ]
 
                 ! Check convergence.
                 write(msg,'(A,I3,2(A,E9.2))') 'GMRES(k)   inner step ', k, ': |res|= ', &
@@ -2184,9 +2183,9 @@ contains
 
             ! Recompute residual for sanity check.
             if (trans) then
-                call A%rmatvec(x, v(1)); gmres_meta%n_Ax = gmres_meta%n_Ax + 1
+                call A%apply_rmatvec(x, v(1))
             else
-                call A%matvec(x, v(1)); gmres_meta%n_Ax = gmres_meta%n_Ax + 1
+                call A%apply_matvec(x, v(1))
             endif
             call v(1)%sub(b) ; call v(1)%chsgn()
 
@@ -2196,7 +2195,7 @@ contains
             ! Save metadata.
             gmres_meta%n_iter  = gmres_meta%n_iter + 1
             gmres_meta%n_outer = gmres_meta%n_outer + 1
-            gmres_meta%res(gmres_meta%n_iter) = beta
+            gmres_meta%res = [ gmres_meta%res, abs(beta) ]
 
             write(msg,'(A,I3,2(A,E9.2))') 'GMRES(k) outer step   ', i, ': |res|= ', &
                             & abs(beta), ', tol= ', tol
@@ -2213,7 +2212,7 @@ contains
         info = gmres_meta%n_iter
         gmres_meta%info = info
 
-        print *, 'GMRES', info
+        if (opts%if_print_metadata) call gmres_meta%print()
 
         ! Set metadata output
         if (present(meta)) then
@@ -2227,7 +2226,7 @@ contains
     end subroutine gmres_rsp
 
     subroutine gmres_rdp(A, b, x, info, rtol, atol, preconditioner, options, transpose, meta)
-        class(abstract_linop_rdp), intent(in) :: A
+        class(abstract_linop_rdp), intent(inout) :: A
         !! Linear operator to be inverted.
         class(abstract_vector_rdp), intent(in) :: b
         !! Right-hand side vector.
@@ -2311,22 +2310,21 @@ contains
 
         ! Initialize meta
         gmres_meta = gmres_dp_metadata()
-        allocate(gmres_meta%res(opts%maxiter*kdim+1)); gmres_meta%res = 0.0_dp
 
         info = 0
 
         ! Initial Krylov vector.
         if (x%norm() > 0) then
             if (trans) then
-                call A%rmatvec(x, V(1)); gmres_meta%n_Ax = gmres_meta%n_Ax + 1
+                call A%apply_rmatvec(x, V(1))
             else
-                call A%matvec(x, V(1)); gmres_meta%n_Ax = gmres_meta%n_Ax + 1
+                call A%apply_matvec(x, V(1))
             endif
         endif
 
         call V(1)%sub(b) ; call V(1)%chsgn()
         beta = V(1)%norm() ; call V(1)%scal(one_rdp/beta)
-        gmres_meta%res(1) = beta
+        allocate(gmres_meta%res(1)); gmres_meta%res(1) = abs(beta)
 
         ! Iterative solver.
         gmres_iter : do i = 1, maxiter
@@ -2341,9 +2339,9 @@ contains
 
                 ! Matrix-vector product.
                 if (trans) then
-                    call A%rmatvec(wrk, V(k+1)); gmres_meta%n_Ax = gmres_meta%n_Ax + 1
+                    call A%apply_rmatvec(wrk, V(k+1))
                 else
-                    call A%matvec(wrk, V(k+1)); gmres_meta%n_Ax = gmres_meta%n_Ax + 1
+                    call A%apply_matvec(wrk, V(k+1))
                 endif
 
                 ! Double Gram-Schmid orthogonalization
@@ -2365,7 +2363,7 @@ contains
                 ! Save metadata.
                 gmres_meta%n_iter  = gmres_meta%n_iter + 1
                 gmres_meta%n_inner = gmres_meta%n_inner + 1
-                gmres_meta%res(gmres_meta%n_iter+1) = beta
+                gmres_meta%res = [ gmres_meta%res, abs(beta) ]
 
                 ! Check convergence.
                 write(msg,'(A,I3,2(A,E9.2))') 'GMRES(k)   inner step ', k, ': |res|= ', &
@@ -2383,9 +2381,9 @@ contains
 
             ! Recompute residual for sanity check.
             if (trans) then
-                call A%rmatvec(x, v(1)); gmres_meta%n_Ax = gmres_meta%n_Ax + 1
+                call A%apply_rmatvec(x, v(1))
             else
-                call A%matvec(x, v(1)); gmres_meta%n_Ax = gmres_meta%n_Ax + 1
+                call A%apply_matvec(x, v(1))
             endif
             call v(1)%sub(b) ; call v(1)%chsgn()
 
@@ -2395,7 +2393,7 @@ contains
             ! Save metadata.
             gmres_meta%n_iter  = gmres_meta%n_iter + 1
             gmres_meta%n_outer = gmres_meta%n_outer + 1
-            gmres_meta%res(gmres_meta%n_iter) = beta
+            gmres_meta%res = [ gmres_meta%res, abs(beta) ]
 
             write(msg,'(A,I3,2(A,E9.2))') 'GMRES(k) outer step   ', i, ': |res|= ', &
                             & abs(beta), ', tol= ', tol
@@ -2412,7 +2410,7 @@ contains
         info = gmres_meta%n_iter
         gmres_meta%info = info
 
-        print *, 'GMRES', info
+        if (opts%if_print_metadata) call gmres_meta%print()
 
         ! Set metadata output
         if (present(meta)) then
@@ -2426,7 +2424,7 @@ contains
     end subroutine gmres_rdp
 
     subroutine gmres_csp(A, b, x, info, rtol, atol, preconditioner, options, transpose, meta)
-        class(abstract_linop_csp), intent(in) :: A
+        class(abstract_linop_csp), intent(inout) :: A
         !! Linear operator to be inverted.
         class(abstract_vector_csp), intent(in) :: b
         !! Right-hand side vector.
@@ -2510,22 +2508,21 @@ contains
 
         ! Initialize meta
         gmres_meta = gmres_sp_metadata()
-        allocate(gmres_meta%res(opts%maxiter*kdim+1)); gmres_meta%res = 0.0_sp
 
         info = 0
 
         ! Initial Krylov vector.
         if (x%norm() > 0) then
             if (trans) then
-                call A%rmatvec(x, V(1)); gmres_meta%n_Ax = gmres_meta%n_Ax + 1
+                call A%apply_rmatvec(x, V(1))
             else
-                call A%matvec(x, V(1)); gmres_meta%n_Ax = gmres_meta%n_Ax + 1
+                call A%apply_matvec(x, V(1))
             endif
         endif
 
         call V(1)%sub(b) ; call V(1)%chsgn()
         beta = V(1)%norm() ; call V(1)%scal(one_csp/beta)
-        gmres_meta%res(1) = beta
+        allocate(gmres_meta%res(1)); gmres_meta%res(1) = abs(beta)
 
         ! Iterative solver.
         gmres_iter : do i = 1, maxiter
@@ -2540,9 +2537,9 @@ contains
 
                 ! Matrix-vector product.
                 if (trans) then
-                    call A%rmatvec(wrk, V(k+1)); gmres_meta%n_Ax = gmres_meta%n_Ax + 1
+                    call A%apply_rmatvec(wrk, V(k+1))
                 else
-                    call A%matvec(wrk, V(k+1)); gmres_meta%n_Ax = gmres_meta%n_Ax + 1
+                    call A%apply_matvec(wrk, V(k+1))
                 endif
 
                 ! Double Gram-Schmid orthogonalization
@@ -2564,7 +2561,7 @@ contains
                 ! Save metadata.
                 gmres_meta%n_iter  = gmres_meta%n_iter + 1
                 gmres_meta%n_inner = gmres_meta%n_inner + 1
-                gmres_meta%res(gmres_meta%n_iter+1) = beta
+                gmres_meta%res = [ gmres_meta%res, abs(beta) ]
 
                 ! Check convergence.
                 write(msg,'(A,I3,2(A,E9.2))') 'GMRES(k)   inner step ', k, ': |res|= ', &
@@ -2582,9 +2579,9 @@ contains
 
             ! Recompute residual for sanity check.
             if (trans) then
-                call A%rmatvec(x, v(1)); gmres_meta%n_Ax = gmres_meta%n_Ax + 1
+                call A%apply_rmatvec(x, v(1))
             else
-                call A%matvec(x, v(1)); gmres_meta%n_Ax = gmres_meta%n_Ax + 1
+                call A%apply_matvec(x, v(1))
             endif
             call v(1)%sub(b) ; call v(1)%chsgn()
 
@@ -2594,7 +2591,7 @@ contains
             ! Save metadata.
             gmres_meta%n_iter  = gmres_meta%n_iter + 1
             gmres_meta%n_outer = gmres_meta%n_outer + 1
-            gmres_meta%res(gmres_meta%n_iter) = beta
+            gmres_meta%res = [ gmres_meta%res, abs(beta) ]
 
             write(msg,'(A,I3,2(A,E9.2))') 'GMRES(k) outer step   ', i, ': |res|= ', &
                             & abs(beta), ', tol= ', tol
@@ -2611,7 +2608,7 @@ contains
         info = gmres_meta%n_iter
         gmres_meta%info = info
 
-        print *, 'GMRES', info
+        if (opts%if_print_metadata) call gmres_meta%print()
 
         ! Set metadata output
         if (present(meta)) then
@@ -2625,7 +2622,7 @@ contains
     end subroutine gmres_csp
 
     subroutine gmres_cdp(A, b, x, info, rtol, atol, preconditioner, options, transpose, meta)
-        class(abstract_linop_cdp), intent(in) :: A
+        class(abstract_linop_cdp), intent(inout) :: A
         !! Linear operator to be inverted.
         class(abstract_vector_cdp), intent(in) :: b
         !! Right-hand side vector.
@@ -2709,22 +2706,21 @@ contains
 
         ! Initialize meta
         gmres_meta = gmres_dp_metadata()
-        allocate(gmres_meta%res(opts%maxiter*kdim+1)); gmres_meta%res = 0.0_dp
 
         info = 0
 
         ! Initial Krylov vector.
         if (x%norm() > 0) then
             if (trans) then
-                call A%rmatvec(x, V(1)); gmres_meta%n_Ax = gmres_meta%n_Ax + 1
+                call A%apply_rmatvec(x, V(1))
             else
-                call A%matvec(x, V(1)); gmres_meta%n_Ax = gmres_meta%n_Ax + 1
+                call A%apply_matvec(x, V(1))
             endif
         endif
 
         call V(1)%sub(b) ; call V(1)%chsgn()
         beta = V(1)%norm() ; call V(1)%scal(one_cdp/beta)
-        gmres_meta%res(1) = beta
+        allocate(gmres_meta%res(1)); gmres_meta%res(1) = abs(beta)
 
         ! Iterative solver.
         gmres_iter : do i = 1, maxiter
@@ -2739,9 +2735,9 @@ contains
 
                 ! Matrix-vector product.
                 if (trans) then
-                    call A%rmatvec(wrk, V(k+1)); gmres_meta%n_Ax = gmres_meta%n_Ax + 1
+                    call A%apply_rmatvec(wrk, V(k+1))
                 else
-                    call A%matvec(wrk, V(k+1)); gmres_meta%n_Ax = gmres_meta%n_Ax + 1
+                    call A%apply_matvec(wrk, V(k+1))
                 endif
 
                 ! Double Gram-Schmid orthogonalization
@@ -2763,7 +2759,7 @@ contains
                 ! Save metadata.
                 gmres_meta%n_iter  = gmres_meta%n_iter + 1
                 gmres_meta%n_inner = gmres_meta%n_inner + 1
-                gmres_meta%res(gmres_meta%n_iter+1) = beta
+                gmres_meta%res = [ gmres_meta%res, abs(beta) ]
 
                 ! Check convergence.
                 write(msg,'(A,I3,2(A,E9.2))') 'GMRES(k)   inner step ', k, ': |res|= ', &
@@ -2781,9 +2777,9 @@ contains
 
             ! Recompute residual for sanity check.
             if (trans) then
-                call A%rmatvec(x, v(1)); gmres_meta%n_Ax = gmres_meta%n_Ax + 1
+                call A%apply_rmatvec(x, v(1))
             else
-                call A%matvec(x, v(1)); gmres_meta%n_Ax = gmres_meta%n_Ax + 1
+                call A%apply_matvec(x, v(1))
             endif
             call v(1)%sub(b) ; call v(1)%chsgn()
 
@@ -2793,7 +2789,7 @@ contains
             ! Save metadata.
             gmres_meta%n_iter  = gmres_meta%n_iter + 1
             gmres_meta%n_outer = gmres_meta%n_outer + 1
-            gmres_meta%res(gmres_meta%n_iter) = beta
+            gmres_meta%res = [ gmres_meta%res, abs(beta) ]
 
             write(msg,'(A,I3,2(A,E9.2))') 'GMRES(k) outer step   ', i, ': |res|= ', &
                             & abs(beta), ', tol= ', tol
@@ -2810,7 +2806,7 @@ contains
         info = gmres_meta%n_iter
         gmres_meta%info = info
 
-        print *, 'GMRES', info
+        if (opts%if_print_metadata) call gmres_meta%print()
 
         ! Set metadata output
         if (present(meta)) then
@@ -2832,7 +2828,7 @@ contains
     !---------------------------------------------
 
     subroutine cg_rsp(A, b, x, info, rtol, atol, preconditioner, options, meta)
-        class(abstract_sym_linop_rsp), intent(in) :: A
+        class(abstract_sym_linop_rsp), intent(inout) :: A
         !! Linear operator to be inverted.
         class(abstract_vector_rsp), intent(in) :: b
         !! Right-hand side vector.
@@ -2887,12 +2883,11 @@ contains
 
          ! Initialize meta
         cg_meta = cg_sp_metadata()
-        allocate(cg_meta%res(opts%maxiter+1)); cg_meta%res = 0.0_sp
 
         info = 0
 
         ! Compute initial residual r = b - Ax.
-        if (x%norm() > 0) call A%matvec(x, r); cg_meta%n_Ax = cg_meta%n_Ax + 1
+        if (x%norm() > 0) call A%apply_matvec(x, r)
         call r%sub(b) ; call r%chsgn()
 
         ! Initialize direction vector.
@@ -2900,12 +2895,12 @@ contains
 
         ! Initialize dot product of residual r_dot_r_old = r' * r
         r_dot_r_old = r%dot(r)
-        cg_meta%res(1) = sqrt(abs(r_dot_r_old))
+        allocate(cg_meta%res(1)); cg_meta%res(1) = sqrt(abs(r_dot_r_old))
 
         ! Conjugate gradient iteration.
         cg_loop: do i = 1, maxiter
             ! Compute A @ p
-            call A%matvec(p, Ap); cg_meta%n_Ax = cg_meta%n_Ax + 1
+            call A%apply_matvec(p, Ap)
             ! Compute step size.
             alpha = r_dot_r_old / p%dot(Ap)
             ! Update solution x = x + alpha*p
@@ -2919,7 +2914,7 @@ contains
 
             ! Save metadata.
             cg_meta%n_iter = cg_meta%n_iter + 1
-            cg_meta%res(cg_meta%n_iter+1) = residual
+            cg_meta%res = [ cg_meta%res, residual ]
 
             if (residual < tol) then
                cg_meta%converged = .true.
@@ -2941,6 +2936,8 @@ contains
         info = cg_meta%n_iter
         cg_meta%info = info
 
+        if (opts%if_print_metadata) call cg_meta%print()
+
         ! Set metadata output
         if (present(meta)) then
            select type(meta)
@@ -2953,7 +2950,7 @@ contains
     end subroutine cg_rsp
 
     subroutine cg_rdp(A, b, x, info, rtol, atol, preconditioner, options, meta)
-        class(abstract_sym_linop_rdp), intent(in) :: A
+        class(abstract_sym_linop_rdp), intent(inout) :: A
         !! Linear operator to be inverted.
         class(abstract_vector_rdp), intent(in) :: b
         !! Right-hand side vector.
@@ -3008,12 +3005,11 @@ contains
 
          ! Initialize meta
         cg_meta = cg_dp_metadata()
-        allocate(cg_meta%res(opts%maxiter+1)); cg_meta%res = 0.0_dp
 
         info = 0
 
         ! Compute initial residual r = b - Ax.
-        if (x%norm() > 0) call A%matvec(x, r); cg_meta%n_Ax = cg_meta%n_Ax + 1
+        if (x%norm() > 0) call A%apply_matvec(x, r)
         call r%sub(b) ; call r%chsgn()
 
         ! Initialize direction vector.
@@ -3021,12 +3017,12 @@ contains
 
         ! Initialize dot product of residual r_dot_r_old = r' * r
         r_dot_r_old = r%dot(r)
-        cg_meta%res(1) = sqrt(abs(r_dot_r_old))
+        allocate(cg_meta%res(1)); cg_meta%res(1) = sqrt(abs(r_dot_r_old))
 
         ! Conjugate gradient iteration.
         cg_loop: do i = 1, maxiter
             ! Compute A @ p
-            call A%matvec(p, Ap); cg_meta%n_Ax = cg_meta%n_Ax + 1
+            call A%apply_matvec(p, Ap)
             ! Compute step size.
             alpha = r_dot_r_old / p%dot(Ap)
             ! Update solution x = x + alpha*p
@@ -3040,7 +3036,7 @@ contains
 
             ! Save metadata.
             cg_meta%n_iter = cg_meta%n_iter + 1
-            cg_meta%res(cg_meta%n_iter+1) = residual
+            cg_meta%res = [ cg_meta%res, residual ]
 
             if (residual < tol) then
                cg_meta%converged = .true.
@@ -3062,6 +3058,8 @@ contains
         info = cg_meta%n_iter
         cg_meta%info = info
 
+        if (opts%if_print_metadata) call cg_meta%print()
+
         ! Set metadata output
         if (present(meta)) then
            select type(meta)
@@ -3074,7 +3072,7 @@ contains
     end subroutine cg_rdp
 
     subroutine cg_csp(A, b, x, info, rtol, atol, preconditioner, options, meta)
-        class(abstract_hermitian_linop_csp), intent(in) :: A
+        class(abstract_hermitian_linop_csp), intent(inout) :: A
         !! Linear operator to be inverted.
         class(abstract_vector_csp), intent(in) :: b
         !! Right-hand side vector.
@@ -3129,12 +3127,11 @@ contains
 
          ! Initialize meta
         cg_meta = cg_sp_metadata()
-        allocate(cg_meta%res(opts%maxiter+1)); cg_meta%res = 0.0_sp
 
         info = 0
 
         ! Compute initial residual r = b - Ax.
-        if (x%norm() > 0) call A%matvec(x, r); cg_meta%n_Ax = cg_meta%n_Ax + 1
+        if (x%norm() > 0) call A%apply_matvec(x, r)
         call r%sub(b) ; call r%chsgn()
 
         ! Initialize direction vector.
@@ -3142,12 +3139,12 @@ contains
 
         ! Initialize dot product of residual r_dot_r_old = r' * r
         r_dot_r_old = r%dot(r)
-        cg_meta%res(1) = sqrt(abs(r_dot_r_old))
+        allocate(cg_meta%res(1)); cg_meta%res(1) = sqrt(abs(r_dot_r_old))
 
         ! Conjugate gradient iteration.
         cg_loop: do i = 1, maxiter
             ! Compute A @ p
-            call A%matvec(p, Ap); cg_meta%n_Ax = cg_meta%n_Ax + 1
+            call A%apply_matvec(p, Ap)
             ! Compute step size.
             alpha = r_dot_r_old / p%dot(Ap)
             ! Update solution x = x + alpha*p
@@ -3161,7 +3158,7 @@ contains
 
             ! Save metadata.
             cg_meta%n_iter = cg_meta%n_iter + 1
-            cg_meta%res(cg_meta%n_iter+1) = residual
+            cg_meta%res = [ cg_meta%res, residual ]
 
             if (residual < tol) then
                cg_meta%converged = .true.
@@ -3183,6 +3180,8 @@ contains
         info = cg_meta%n_iter
         cg_meta%info = info
 
+        if (opts%if_print_metadata) call cg_meta%print()
+
         ! Set metadata output
         if (present(meta)) then
            select type(meta)
@@ -3195,7 +3194,7 @@ contains
     end subroutine cg_csp
 
     subroutine cg_cdp(A, b, x, info, rtol, atol, preconditioner, options, meta)
-        class(abstract_hermitian_linop_cdp), intent(in) :: A
+        class(abstract_hermitian_linop_cdp), intent(inout) :: A
         !! Linear operator to be inverted.
         class(abstract_vector_cdp), intent(in) :: b
         !! Right-hand side vector.
@@ -3250,12 +3249,11 @@ contains
 
          ! Initialize meta
         cg_meta = cg_dp_metadata()
-        allocate(cg_meta%res(opts%maxiter+1)); cg_meta%res = 0.0_dp
 
         info = 0
 
         ! Compute initial residual r = b - Ax.
-        if (x%norm() > 0) call A%matvec(x, r); cg_meta%n_Ax = cg_meta%n_Ax + 1
+        if (x%norm() > 0) call A%apply_matvec(x, r)
         call r%sub(b) ; call r%chsgn()
 
         ! Initialize direction vector.
@@ -3263,12 +3261,12 @@ contains
 
         ! Initialize dot product of residual r_dot_r_old = r' * r
         r_dot_r_old = r%dot(r)
-        cg_meta%res(1) = sqrt(abs(r_dot_r_old))
+        allocate(cg_meta%res(1)); cg_meta%res(1) = sqrt(abs(r_dot_r_old))
 
         ! Conjugate gradient iteration.
         cg_loop: do i = 1, maxiter
             ! Compute A @ p
-            call A%matvec(p, Ap); cg_meta%n_Ax = cg_meta%n_Ax + 1
+            call A%apply_matvec(p, Ap)
             ! Compute step size.
             alpha = r_dot_r_old / p%dot(Ap)
             ! Update solution x = x + alpha*p
@@ -3282,7 +3280,7 @@ contains
 
             ! Save metadata.
             cg_meta%n_iter = cg_meta%n_iter + 1
-            cg_meta%res(cg_meta%n_iter+1) = residual
+            cg_meta%res = [ cg_meta%res, residual ]
 
             if (residual < tol) then
                cg_meta%converged = .true.
@@ -3303,6 +3301,8 @@ contains
         ! Set and copy info flag for completeness
         info = cg_meta%n_iter
         cg_meta%info = info
+
+        if (opts%if_print_metadata) call cg_meta%print()
 
         ! Set metadata output
         if (present(meta)) then

--- a/src/IterativeSolvers.fypp
+++ b/src/IterativeSolvers.fypp
@@ -964,8 +964,9 @@ contains
         allocate(alpha(kdim)) ; alpha = 0.0_${kind}$
         allocate(e(kdim+1)) ; e = 0.0_${kind}$
 
-        ! Initialize meta
+        ! Initialize metadata and & reset matvec counter
         gmres_meta = gmres_${kind}$_metadata()
+        call A%reset_counter(trans, 'gmres%init')
 
         info = 0
 
@@ -1076,6 +1077,8 @@ contains
            end select
         end if
 
+        call A%reset_counter(trans, 'gmres%post')
+        
         return
     end subroutine gmres_${type[0]}$${kind}$
 
@@ -1147,8 +1150,9 @@ contains
         allocate(p, source=b)  ; call p%zero()
         allocate(Ap, source=b) ; call Ap%zero()
 
-         ! Initialize meta
+         ! Initialize meta & reset matvec counter
         cg_meta = cg_${kind}$_metadata()
+        call A%reset_counter(.false., 'cg%init')
 
         info = 0
 
@@ -1215,7 +1219,9 @@ contains
                    meta = cg_meta
            end select
         end if
-        
+
+        call A%reset_counter(.false., 'cg%post')
+
         return
     end subroutine cg_${type[0]}$${kind}$
 

--- a/src/IterativeSolvers.fypp
+++ b/src/IterativeSolvers.fypp
@@ -40,7 +40,8 @@ module lightkrylov_IterativeSolvers
     implicit none
     private
 
-    character(len=128), parameter :: this_module = 'LightKrylov_IterativeSolvers'
+    character(len=*), parameter :: this_module      = 'LK_Solvers'
+    character(len=*), parameter :: this_module_long = 'LightKrylov_IterativeSolvers'
 
     #:for kind, type in RC_KINDS_TYPES
     public :: abstract_linear_solver_${type[0]}$${kind}$

--- a/src/IterativeSolvers.fypp
+++ b/src/IterativeSolvers.fypp
@@ -881,15 +881,13 @@ contains
     !-------------------------------------------------------
 
     #:for kind, type in RC_KINDS_TYPES
-    subroutine gmres_${type[0]}$${kind}$(A, b, x, meta, info, rtol, atol, preconditioner, options, transpose)
+    subroutine gmres_${type[0]}$${kind}$(A, b, x, info, rtol, atol, preconditioner, options, transpose, meta)
         class(abstract_linop_${type[0]}$${kind}$), intent(in) :: A
         !! Linear operator to be inverted.
         class(abstract_vector_${type[0]}$${kind}$), intent(in) :: b
         !! Right-hand side vector.
         class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: x
         !! Solution vector.
-        class(abstract_metadata), intent(out) :: meta
-        !! Metadata.
         integer, intent(out) :: info
         !! Information flag.
         real(${kind}$), optional, intent(in) :: rtol
@@ -902,6 +900,8 @@ contains
         !! GMRES options.   
         logical, optional, intent(in) :: transpose
         !! Whether \(\mathbf{A}\) or \(\mathbf{A}^H\) is being used.
+        class(abstract_metadata), optional, intent(out) :: meta
+        !! Metadata.
 
         !--------------------------------------
         !-----     Internal variables     -----
@@ -1057,19 +1057,23 @@ contains
             call logger%log_information(msg, module=this_module, procedure='gmres_${type[0]}$${kind}$')
 
             ! Exit gmres if desired accuracy is reached.
-            if (abs(beta) <= tol) gmres_meta%converged = .true.; exit gmres_iter
-
+            if (abs(beta) <= tol) then
+               gmres_meta%converged = .true.
+               exit gmres_iter
+            end if
         enddo gmres_iter
 
         ! Returns the number of iterations.
-        info = niter
+        info = gmres_meta%n_iter
         gmres_meta%info = info
 
         ! Set metadata output
-        select type(meta)
-            type is (gmres_${kind}$_metadata)
-                meta = gmres_meta
-        end select
+        if (present(meta)) then
+           select type(meta)
+                 type is (gmres_${kind}$_metadata)
+                    meta = gmres_meta
+           end select
+        end if
 
         return
     end subroutine gmres_${type[0]}$${kind}$
@@ -1084,7 +1088,7 @@ contains
     !---------------------------------------------
 
     #:for kind, type in RC_KINDS_TYPES
-    subroutine cg_${type[0]}$${kind}$(A, b, x, meta, info, rtol, atol, preconditioner, options)
+    subroutine cg_${type[0]}$${kind}$(A, b, x, info, rtol, atol, preconditioner, options, meta)
         #:if type[0] == "r"
         class(abstract_sym_linop_${type[0]}$${kind}$), intent(in) :: A
         #:else
@@ -1095,8 +1099,6 @@ contains
         !! Right-hand side vector.
         class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: x
         !! Solution vector.
-        class(abstract_metadata), intent(out) :: meta
-        !! Metadata.
         integer, intent(out) :: info
         !! Information flag.
         real(${kind}$), optional, intent(in) :: rtol
@@ -1107,6 +1109,8 @@ contains
         !! Preconditioner (not yet supported).
         type(cg_${kind}$_opts), optional, intent(in) :: options
         !! Options for the conjugate gradient solver.
+        class(abstract_metadata), optional, intent(out) :: meta
+        !! Metadata.
 
         !----------------------------------------
         !-----     Internal variables      ------
@@ -1179,10 +1183,13 @@ contains
             #:endif
 
             ! Save metadata.
-            cg_meta%n_iter  = cg_meta%n_iter + 1
+            cg_meta%n_iter = cg_meta%n_iter + 1
             cg_meta%res(cg_meta%n_iter+1) = residual
 
-            if (residual < tol) cg_meta%converged = .true.; exit cg_loop
+            if (residual < tol) then
+               cg_meta%converged = .true.
+               exit cg_loop
+            end if
 
             ! Compute new direction beta = r_dot_r_new / r_dot_r_old.
             beta = r_dot_r_new / r_dot_r_old
@@ -1195,13 +1202,17 @@ contains
             call logger%log_information(msg, module=this_module, procedure='cg_${type[0]}$${kind}$')
         enddo cg_loop
 
+        ! Set and copy info flag for completeness
         info = cg_meta%n_iter
+        cg_meta%info = info
 
         ! Set metadata output
-        select type(meta)
-            type is (cg_${kind}$_metadata)
-                meta = cg_meta
-        end select
+        if (present(meta)) then
+           select type(meta)
+               type is (cg_${kind}$_metadata)
+                   meta = cg_meta
+           end select
+        end if
         
         return
     end subroutine cg_${type[0]}$${kind}$

--- a/src/IterativeSolvers.fypp
+++ b/src/IterativeSolvers.fypp
@@ -423,10 +423,9 @@ module lightkrylov_IterativeSolvers
 
     abstract interface
     #:for kind, type in RC_KINDS_TYPES
-        subroutine abstract_linear_solver_${type[0]}$${kind}$(A, b, x, info, rtol, atol, preconditioner, options, transpose)
+        subroutine abstract_linear_solver_${type[0]}$${kind}$(A, b, x, info, rtol, atol, preconditioner, options, transpose, meta)
             !! Abstract interface to use a user-defined linear solver in `LightKrylov`.
-            import abstract_linop_${type[0]}$${kind}$, abstract_vector_${type[0]}$${kind}$, abstract_opts, abstract_precond_${type[0]}$${kind}$, ${kind}$
-
+            import abstract_linop_${type[0]}$${kind}$, abstract_vector_${type[0]}$${kind}$, abstract_opts, abstract_metadata, abstract_precond_${type[0]}$${kind}$, ${kind}$
             class(abstract_linop_${type[0]}$${kind}$), intent(in) :: A
             !! Linear operator to invert.
             class(abstract_vector_${type[0]}$${kind}$), intent(in) :: b
@@ -445,6 +444,8 @@ module lightkrylov_IterativeSolvers
             !! Options passed to the linear solver.
             logical, optional, intent(in) :: transpose
             !! Determine whether \(\mathbf{A}\) (`.false.`) or \(\mathbf{A}^T\) (`.true.`) is being used.
+            class(abstract_metadata), optional, intent(out) :: meta
+            !! Metadata.
         end subroutine abstract_linear_solver_${type[0]}$${kind}$
 
     #:endfor
@@ -880,13 +881,15 @@ contains
     !-------------------------------------------------------
 
     #:for kind, type in RC_KINDS_TYPES
-    subroutine gmres_${type[0]}$${kind}$(A, b, x, info, rtol, atol, preconditioner, options, transpose)
+    subroutine gmres_${type[0]}$${kind}$(A, b, x, meta, info, rtol, atol, preconditioner, options, transpose)
         class(abstract_linop_${type[0]}$${kind}$), intent(in) :: A
         !! Linear operator to be inverted.
         class(abstract_vector_${type[0]}$${kind}$), intent(in) :: b
         !! Right-hand side vector.
         class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: x
         !! Solution vector.
+        class(abstract_metadata), intent(out) :: meta
+        !! Metadata.
         integer, intent(out) :: info
         !! Information flag.
         real(${kind}$), optional, intent(in) :: rtol
@@ -908,7 +911,8 @@ contains
         integer :: kdim, maxiter
         real(${kind}$) :: tol, rtol_, atol_
         logical :: trans
-        type(gmres_${kind}$_opts) :: opts
+        type(gmres_${kind}$_opts)     :: opts
+        type(gmres_${kind}$_metadata) :: gmres_meta
 
         ! Krylov subspace
         class(abstract_vector_${type[0]}$${kind}$), allocatable :: V(:)
@@ -960,19 +964,24 @@ contains
         allocate(alpha(kdim)) ; alpha = 0.0_${kind}$
         allocate(e(kdim+1)) ; e = 0.0_${kind}$
 
-        info = 0 ; niter = 0
+        ! Initialize meta
+        gmres_meta = gmres_${kind}$_metadata()
+        allocate(gmres_meta%res(opts%maxiter*kdim+1)); gmres_meta%res = 0.0_${kind}$
+
+        info = 0
 
         ! Initial Krylov vector.
         if (x%norm() > 0) then
             if (trans) then
-                call A%rmatvec(x, V(1))
+                call A%rmatvec(x, V(1)); gmres_meta%n_Ax = gmres_meta%n_Ax + 1
             else
-                call A%matvec(x, V(1))
+                call A%matvec(x, V(1)); gmres_meta%n_Ax = gmres_meta%n_Ax + 1
             endif
         endif
 
         call V(1)%sub(b) ; call V(1)%chsgn()
         beta = V(1)%norm() ; call V(1)%scal(one_${type[0]}$${kind}$/beta)
+        gmres_meta%res(1) = beta
 
         ! Iterative solver.
         gmres_iter : do i = 1, maxiter
@@ -987,9 +996,9 @@ contains
 
                 ! Matrix-vector product.
                 if (trans) then
-                    call A%rmatvec(wrk, V(k+1))
+                    call A%rmatvec(wrk, V(k+1)); gmres_meta%n_Ax = gmres_meta%n_Ax + 1
                 else
-                    call A%matvec(wrk, V(k+1))
+                    call A%matvec(wrk, V(k+1)); gmres_meta%n_Ax = gmres_meta%n_Ax + 1
                 endif
 
                 ! Double Gram-Schmid orthogonalization
@@ -1008,14 +1017,17 @@ contains
                 ! Compute residual.
                 beta = norm2(abs(e(:k+1) - matmul(H(:k+1, :k), y(:k))))
 
-                ! Current number of iterations performed.
-                niter = niter + 1
+                ! Save metadata.
+                gmres_meta%n_iter  = gmres_meta%n_iter + 1
+                gmres_meta%n_inner = gmres_meta%n_inner + 1
+                gmres_meta%res(gmres_meta%n_iter+1) = beta
 
                 ! Check convergence.
                 write(msg,'(A,I3,2(A,E9.2))') 'GMRES(k)   inner step ', k, ': |res|= ', &
                             & abs(beta), ', tol= ', tol
                 call logger%log_information(msg, module=this_module, procedure='gmres_${type[0]}$${kind}$')
                 if (abs(beta) <= tol) then
+                    gmres_meta%converged = .true.
                     exit arnoldi_fact
                 endif
             enddo arnoldi_fact
@@ -1026,26 +1038,38 @@ contains
 
             ! Recompute residual for sanity check.
             if (trans) then
-                call A%rmatvec(x, v(1))
+                call A%rmatvec(x, v(1)); gmres_meta%n_Ax = gmres_meta%n_Ax + 1
             else
-                call A%matvec(x, v(1))
+                call A%matvec(x, v(1)); gmres_meta%n_Ax = gmres_meta%n_Ax + 1
             endif
             call v(1)%sub(b) ; call v(1)%chsgn()
 
             ! Initialize new starting Krylov vector if needed.
             beta = v(1)%norm() ; call v(1)%scal(one_${type[0]}$${kind}$ / beta)
 
+            ! Save metadata.
+            gmres_meta%n_iter  = gmres_meta%n_iter + 1
+            gmres_meta%n_outer = gmres_meta%n_outer + 1
+            gmres_meta%res(gmres_meta%n_iter) = beta
+
             write(msg,'(A,I3,2(A,E9.2))') 'GMRES(k) outer step   ', i, ': |res|= ', &
                             & abs(beta), ', tol= ', tol
             call logger%log_information(msg, module=this_module, procedure='gmres_${type[0]}$${kind}$')
 
             ! Exit gmres if desired accuracy is reached.
-            if (abs(beta) <= tol) exit gmres_iter
+            if (abs(beta) <= tol) gmres_meta%converged = .true.; exit gmres_iter
 
         enddo gmres_iter
 
         ! Returns the number of iterations.
         info = niter
+        gmres_meta%info = info
+
+        ! Set metadata output
+        select type(meta)
+            type is (gmres_${kind}$_metadata)
+                meta = gmres_meta
+        end select
 
         return
     end subroutine gmres_${type[0]}$${kind}$
@@ -1060,7 +1084,7 @@ contains
     !---------------------------------------------
 
     #:for kind, type in RC_KINDS_TYPES
-    subroutine cg_${type[0]}$${kind}$(A, b, x, info, rtol, atol, preconditioner, options)
+    subroutine cg_${type[0]}$${kind}$(A, b, x, meta, info, rtol, atol, preconditioner, options)
         #:if type[0] == "r"
         class(abstract_sym_linop_${type[0]}$${kind}$), intent(in) :: A
         #:else
@@ -1071,6 +1095,8 @@ contains
         !! Right-hand side vector.
         class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: x
         !! Solution vector.
+        class(abstract_metadata), intent(out) :: meta
+        !! Metadata.
         integer, intent(out) :: info
         !! Information flag.
         real(${kind}$), optional, intent(in) :: rtol
@@ -1089,7 +1115,8 @@ contains
         ! Options.
         integer :: maxiter
         real(${kind}$) :: tol, rtol_, atol_
-        type(cg_${kind}$_opts) :: opts
+        type(cg_${kind}$_opts)     :: opts
+        type(cg_${kind}$_metadata) :: cg_meta
 
         ! Working variables.
         class(abstract_vector_${type[0]}$${kind}$), allocatable :: r, p, Ap
@@ -1115,10 +1142,14 @@ contains
         allocate(p, source=b)  ; call p%zero()
         allocate(Ap, source=b) ; call Ap%zero()
 
+         ! Initialize meta
+        cg_meta = cg_${kind}$_metadata()
+        allocate(cg_meta%res(opts%maxiter+1)); cg_meta%res = 0.0_${kind}$
+
         info = 0
 
         ! Compute initial residual r = b - Ax.
-        if (x%norm() > 0) call A%matvec(x, r)
+        if (x%norm() > 0) call A%matvec(x, r); cg_meta%n_Ax = cg_meta%n_Ax + 1
         call r%sub(b) ; call r%chsgn()
 
         ! Initialize direction vector.
@@ -1126,11 +1157,12 @@ contains
 
         ! Initialize dot product of residual r_dot_r_old = r' * r
         r_dot_r_old = r%dot(r)
+        cg_meta%res(1) = sqrt(abs(r_dot_r_old))
 
         ! Conjugate gradient iteration.
         cg_loop: do i = 1, maxiter
             ! Compute A @ p
-            call A%matvec(p, Ap)
+            call A%matvec(p, Ap); cg_meta%n_Ax = cg_meta%n_Ax + 1
             ! Compute step size.
             alpha = r_dot_r_old / p%dot(Ap)
             ! Update solution x = x + alpha*p
@@ -1145,10 +1177,12 @@ contains
             #:else
             residual = sqrt(r_dot_r_new)
             #:endif
-            ! Current number of iterations performed.
-            info = info + 1
 
-            if (residual < tol) exit cg_loop
+            ! Save metadata.
+            cg_meta%n_iter  = cg_meta%n_iter + 1
+            cg_meta%res(cg_meta%n_iter+1) = residual
+
+            if (residual < tol) cg_meta%converged = .true.; exit cg_loop
 
             ! Compute new direction beta = r_dot_r_new / r_dot_r_old.
             beta = r_dot_r_new / r_dot_r_old
@@ -1160,6 +1194,14 @@ contains
             write(msg,'(A,I3,2(A,E9.2))') 'CG step ', i, ': res= ', residual, ', tol= ', tol
             call logger%log_information(msg, module=this_module, procedure='cg_${type[0]}$${kind}$')
         enddo cg_loop
+
+        info = cg_meta%n_iter
+
+        ! Set metadata output
+        select type(meta)
+            type is (cg_${kind}$_metadata)
+                meta = cg_meta
+        end select
         
         return
     end subroutine cg_${type[0]}$${kind}$

--- a/src/IterativeSolvers.fypp
+++ b/src/IterativeSolvers.fypp
@@ -114,7 +114,7 @@ module lightkrylov_IterativeSolvers
         !!
         !!  `A` : Linear operator derived from `abstract_sym_linop_rsp`, `abstract_sym_linop_rdp`,
         !!        `abstract_hermitian_linop_csp` or `abstract_hermitian_linop_cdp` whose leading
-        !!        eigenpairs need to be computed. It is an `intent(in)` argument.
+        !!        eigenpairs need to be computed. It is an `intent(inout)` argument.
         !!
         !!  `X` : Array of `abstract_vectors` with the same type and kind as `A`. On exit, it
         !!        contains the leading eigenvectors of `A`. Note that the dimension of `X` fixes
@@ -176,7 +176,7 @@ module lightkrylov_IterativeSolvers
         !!
         !!  `A` : Linear operator derived from `abstract_sym_linop_rsp`, `abstract_sym_linop_rdp`,
         !!        `abstract_hermitian_linop_csp` or `abstract_hermitian_linop_cdp` whose leading
-        !!        eigenpairs need to be computed. It is an `intent(in)` argument.
+        !!        eigenpairs need to be computed. It is an `intent(inout)` argument.
         !!
         !!  `X` : Array of `abstract_vectors` with the same type and kind as `A`. On exit, it
         !!        contains the leading eigenvectors of `A`. Note that the dimension of `X` fixes
@@ -244,7 +244,7 @@ module lightkrylov_IterativeSolvers
         !!
         !!  `A` : Linear operator derived from `abstract_sym_linop_rsp`, `abstract_sym_linop_rdp`,
         !!        `abstract_hermitian_linop_csp` or `abstract_hermitian_linop_cdp` whose leading
-        !!        eigenpairs need to be computed. It is an `intent(in)` argument.
+        !!        eigenpairs need to be computed. It is an `intent(inout)` argument.
         !!
         !!  `U` : Array of `abstract_vectors` with the same type and kind as `A`. On exit, it
         !!        contains the left singular vectors of `A`. Note that the dimension of `U` fixes
@@ -300,7 +300,7 @@ module lightkrylov_IterativeSolvers
         !!  ### Arguments
         !!
         !!  `A` : Linear operator derived from one of the `abstract_linop` provided by the
-        !!  `AbstractLinops` module. It is an `intent(in)` argument.
+        !!  `AbstractLinops` module. It is an `intent(inout)` argument.
         !!
         !!  `b` : Right-hand side vector derived from one the `abstract_vector` types provided
         !!  by the `AbstractVectors` module. It needs to have the same type and kind as `A`.
@@ -358,7 +358,7 @@ module lightkrylov_IterativeSolvers
         !!
         !!  `A` : Linear operator derived from one of the `abstract_sym_linop` or
         !!  `abstract_hermitian_linop` types provided by the `AbstractLinops` module. It is an
-        !!  `intent(in)` argument.
+        !!  `intent(inout)` argument.
         !!
         !!  `b` : Right-hand side vector derived from one the `abstract_vector` types provided
         !!  by the `AbstractVectors` module. It needs to have the same type and kind as `A`.
@@ -426,7 +426,7 @@ module lightkrylov_IterativeSolvers
         subroutine abstract_linear_solver_${type[0]}$${kind}$(A, b, x, info, rtol, atol, preconditioner, options, transpose, meta)
             !! Abstract interface to use a user-defined linear solver in `LightKrylov`.
             import abstract_linop_${type[0]}$${kind}$, abstract_vector_${type[0]}$${kind}$, abstract_opts, abstract_metadata, abstract_precond_${type[0]}$${kind}$, ${kind}$
-            class(abstract_linop_${type[0]}$${kind}$), intent(in) :: A
+            class(abstract_linop_${type[0]}$${kind}$), intent(inout) :: A
             !! Linear operator to invert.
             class(abstract_vector_${type[0]}$${kind}$), intent(in) :: b
             !! Right-hand side vector.
@@ -508,7 +508,7 @@ contains
 
     #:for kind, type in RC_KINDS_TYPES
     subroutine eigs_${type[0]}$${kind}$(A, X, eigvals, residuals, info, kdim, select, tolerance, transpose)
-        class(abstract_linop_${type[0]}$${kind}$), intent(in) :: A
+        class(abstract_linop_${type[0]}$${kind}$), intent(inout) :: A
         !! Linear operator whose leading eigenpairs need to be computed.
         class(abstract_vector_${type[0]}$${kind}$), intent(out) :: X(:)
         !! Leading eigenvectors of \(\mathbf{A}\).
@@ -667,9 +667,9 @@ contains
     #:for kind, type in RC_KINDS_TYPES
     subroutine eighs_${type[0]}$${kind}$(A, X, eigvals, residuals, info, kdim, tolerance)
         #:if type[0] == "r"
-        class(abstract_sym_linop_${type[0]}$${kind}$), intent(in) :: A
+        class(abstract_sym_linop_${type[0]}$${kind}$), intent(inout) :: A
         #:else
-        class(abstract_hermitian_linop_${type[0]}$${kind}$), intent(in) :: A
+        class(abstract_hermitian_linop_${type[0]}$${kind}$), intent(inout) :: A
         #:endif
         !! Linear operator whose leading eigenpairs need to be computed.
         class(abstract_vector_${type[0]}$${kind}$), intent(out) :: X(:)
@@ -777,7 +777,7 @@ contains
 
     #:for kind, type in RC_KINDS_TYPES
     subroutine svds_${type[0]}$${kind}$(A, U, S, V, residuals, info, kdim, tolerance)
-        class(abstract_linop_${type[0]}$${kind}$), intent(in) :: A
+        class(abstract_linop_${type[0]}$${kind}$), intent(inout) :: A
         !! Linear operator whose leading singular triplets need to be computed.
         class(abstract_vector_${type[0]}$${kind}$), intent(out) :: U(:)
         !! Leading left singular vectors.
@@ -882,7 +882,7 @@ contains
 
     #:for kind, type in RC_KINDS_TYPES
     subroutine gmres_${type[0]}$${kind}$(A, b, x, info, rtol, atol, preconditioner, options, transpose, meta)
-        class(abstract_linop_${type[0]}$${kind}$), intent(in) :: A
+        class(abstract_linop_${type[0]}$${kind}$), intent(inout) :: A
         !! Linear operator to be inverted.
         class(abstract_vector_${type[0]}$${kind}$), intent(in) :: b
         !! Right-hand side vector.
@@ -966,22 +966,21 @@ contains
 
         ! Initialize meta
         gmres_meta = gmres_${kind}$_metadata()
-        allocate(gmres_meta%res(opts%maxiter*kdim+1)); gmres_meta%res = 0.0_${kind}$
 
         info = 0
 
         ! Initial Krylov vector.
         if (x%norm() > 0) then
             if (trans) then
-                call A%rmatvec(x, V(1)); gmres_meta%n_Ax = gmres_meta%n_Ax + 1
+                call A%apply_rmatvec(x, V(1))
             else
-                call A%matvec(x, V(1)); gmres_meta%n_Ax = gmres_meta%n_Ax + 1
+                call A%apply_matvec(x, V(1))
             endif
         endif
 
         call V(1)%sub(b) ; call V(1)%chsgn()
         beta = V(1)%norm() ; call V(1)%scal(one_${type[0]}$${kind}$/beta)
-        gmres_meta%res(1) = beta
+        allocate(gmres_meta%res(1)); gmres_meta%res(1) = abs(beta)
 
         ! Iterative solver.
         gmres_iter : do i = 1, maxiter
@@ -996,9 +995,9 @@ contains
 
                 ! Matrix-vector product.
                 if (trans) then
-                    call A%rmatvec(wrk, V(k+1)); gmres_meta%n_Ax = gmres_meta%n_Ax + 1
+                    call A%apply_rmatvec(wrk, V(k+1))
                 else
-                    call A%matvec(wrk, V(k+1)); gmres_meta%n_Ax = gmres_meta%n_Ax + 1
+                    call A%apply_matvec(wrk, V(k+1))
                 endif
 
                 ! Double Gram-Schmid orthogonalization
@@ -1020,7 +1019,7 @@ contains
                 ! Save metadata.
                 gmres_meta%n_iter  = gmres_meta%n_iter + 1
                 gmres_meta%n_inner = gmres_meta%n_inner + 1
-                gmres_meta%res(gmres_meta%n_iter+1) = beta
+                gmres_meta%res = [ gmres_meta%res, abs(beta) ]
 
                 ! Check convergence.
                 write(msg,'(A,I3,2(A,E9.2))') 'GMRES(k)   inner step ', k, ': |res|= ', &
@@ -1038,9 +1037,9 @@ contains
 
             ! Recompute residual for sanity check.
             if (trans) then
-                call A%rmatvec(x, v(1)); gmres_meta%n_Ax = gmres_meta%n_Ax + 1
+                call A%apply_rmatvec(x, v(1))
             else
-                call A%matvec(x, v(1)); gmres_meta%n_Ax = gmres_meta%n_Ax + 1
+                call A%apply_matvec(x, v(1))
             endif
             call v(1)%sub(b) ; call v(1)%chsgn()
 
@@ -1050,7 +1049,7 @@ contains
             ! Save metadata.
             gmres_meta%n_iter  = gmres_meta%n_iter + 1
             gmres_meta%n_outer = gmres_meta%n_outer + 1
-            gmres_meta%res(gmres_meta%n_iter) = beta
+            gmres_meta%res = [ gmres_meta%res, abs(beta) ]
 
             write(msg,'(A,I3,2(A,E9.2))') 'GMRES(k) outer step   ', i, ': |res|= ', &
                             & abs(beta), ', tol= ', tol
@@ -1066,6 +1065,8 @@ contains
         ! Returns the number of iterations.
         info = gmres_meta%n_iter
         gmres_meta%info = info
+
+        if (opts%if_print_metadata) call gmres_meta%print()
 
         ! Set metadata output
         if (present(meta)) then
@@ -1090,9 +1091,9 @@ contains
     #:for kind, type in RC_KINDS_TYPES
     subroutine cg_${type[0]}$${kind}$(A, b, x, info, rtol, atol, preconditioner, options, meta)
         #:if type[0] == "r"
-        class(abstract_sym_linop_${type[0]}$${kind}$), intent(in) :: A
+        class(abstract_sym_linop_${type[0]}$${kind}$), intent(inout) :: A
         #:else
-        class(abstract_hermitian_linop_${type[0]}$${kind}$), intent(in) :: A
+        class(abstract_hermitian_linop_${type[0]}$${kind}$), intent(inout) :: A
         #:endif
         !! Linear operator to be inverted.
         class(abstract_vector_${type[0]}$${kind}$), intent(in) :: b
@@ -1148,12 +1149,11 @@ contains
 
          ! Initialize meta
         cg_meta = cg_${kind}$_metadata()
-        allocate(cg_meta%res(opts%maxiter+1)); cg_meta%res = 0.0_${kind}$
 
         info = 0
 
         ! Compute initial residual r = b - Ax.
-        if (x%norm() > 0) call A%matvec(x, r); cg_meta%n_Ax = cg_meta%n_Ax + 1
+        if (x%norm() > 0) call A%apply_matvec(x, r)
         call r%sub(b) ; call r%chsgn()
 
         ! Initialize direction vector.
@@ -1161,12 +1161,12 @@ contains
 
         ! Initialize dot product of residual r_dot_r_old = r' * r
         r_dot_r_old = r%dot(r)
-        cg_meta%res(1) = sqrt(abs(r_dot_r_old))
+        allocate(cg_meta%res(1)); cg_meta%res(1) = sqrt(abs(r_dot_r_old))
 
         ! Conjugate gradient iteration.
         cg_loop: do i = 1, maxiter
             ! Compute A @ p
-            call A%matvec(p, Ap); cg_meta%n_Ax = cg_meta%n_Ax + 1
+            call A%apply_matvec(p, Ap)
             ! Compute step size.
             alpha = r_dot_r_old / p%dot(Ap)
             ! Update solution x = x + alpha*p
@@ -1184,7 +1184,7 @@ contains
 
             ! Save metadata.
             cg_meta%n_iter = cg_meta%n_iter + 1
-            cg_meta%res(cg_meta%n_iter+1) = residual
+            cg_meta%res = [ cg_meta%res, residual ]
 
             if (residual < tol) then
                cg_meta%converged = .true.
@@ -1205,6 +1205,8 @@ contains
         ! Set and copy info flag for completeness
         info = cg_meta%n_iter
         cg_meta%info = info
+
+        if (opts%if_print_metadata) call cg_meta%print()
 
         ! Set metadata output
         if (present(meta)) then

--- a/src/LightKrylov.f90
+++ b/src/LightKrylov.f90
@@ -35,6 +35,12 @@ module LightKrylov
     public :: gmres_dp_opts
     public :: cg_dp_opts
     public :: newton_dp_opts
+    public :: gmres_sp_metadata
+    public :: cg_sp_metadata
+    public :: newton_sp_metadata
+    public :: gmres_dp_metadata
+    public :: cg_dp_metadata
+    public :: newton_dp_metadata
 
     ! AbstractVectors exports.
     public :: abstract_vector

--- a/src/LightKrylov.fypp
+++ b/src/LightKrylov.fypp
@@ -36,6 +36,11 @@ module LightKrylov
     public :: cg_${kind}$_opts
     public :: newton_${kind}$_opts
     #:endfor
+    #:for kind in REAL_KINDS
+    public :: gmres_${kind}$_metadata
+    public :: cg_${kind}$_metadata
+    public :: newton_${kind}$_metadata
+    #:endfor
 
     ! AbstractVectors exports.
     public :: abstract_vector

--- a/src/NewtonKrylov.f90
+++ b/src/NewtonKrylov.f90
@@ -169,9 +169,9 @@ contains
       maxstep_bisection = opts%maxstep_bisection
       allocate(residual, source=X); call residual%zero()
       allocate(increment,source=X); call increment%zero()
-      ! Zero eval counters & instantiate metadata
-      call sys%reset_eval_counter()
+      ! Initialize metadata & reset eval counter
       newton_meta = newton_sp_metadata()
+      call sys%reset_eval_counter('newton%init')
 
       ! Get initial residual.
       call sys%eval(X, residual, target_tol)
@@ -253,7 +253,6 @@ contains
 
       ! Finalize metadata
       newton_meta%info = info
-      newton_meta%eval_counter_all = sys%get_eval_counter()
 
       if (opts%if_print_metadata) call newton_meta%print()
 
@@ -264,6 +263,8 @@ contains
                meta = newton_meta
          end select
       end if
+
+      call sys%reset_eval_counter('newton%post')
 
       return
    end subroutine newton_rsp
@@ -323,9 +324,9 @@ contains
       maxstep_bisection = opts%maxstep_bisection
       allocate(residual, source=X); call residual%zero()
       allocate(increment,source=X); call increment%zero()
-      ! Zero eval counters & instantiate metadata
-      call sys%reset_eval_counter()
+      ! Initialize metadata & reset eval counter
       newton_meta = newton_dp_metadata()
+      call sys%reset_eval_counter('newton%init')
 
       ! Get initial residual.
       call sys%eval(X, residual, target_tol)
@@ -407,7 +408,6 @@ contains
 
       ! Finalize metadata
       newton_meta%info = info
-      newton_meta%eval_counter_all = sys%get_eval_counter()
 
       if (opts%if_print_metadata) call newton_meta%print()
 
@@ -418,6 +418,8 @@ contains
                meta = newton_meta
          end select
       end if
+
+      call sys%reset_eval_counter('newton%post')
 
       return
    end subroutine newton_rdp
@@ -477,9 +479,9 @@ contains
       maxstep_bisection = opts%maxstep_bisection
       allocate(residual, source=X); call residual%zero()
       allocate(increment,source=X); call increment%zero()
-      ! Zero eval counters & instantiate metadata
-      call sys%reset_eval_counter()
+      ! Initialize metadata & reset eval counter
       newton_meta = newton_sp_metadata()
+      call sys%reset_eval_counter('newton%init')
 
       ! Get initial residual.
       call sys%eval(X, residual, target_tol)
@@ -561,7 +563,6 @@ contains
 
       ! Finalize metadata
       newton_meta%info = info
-      newton_meta%eval_counter_all = sys%get_eval_counter()
 
       if (opts%if_print_metadata) call newton_meta%print()
 
@@ -572,6 +573,8 @@ contains
                meta = newton_meta
          end select
       end if
+
+      call sys%reset_eval_counter('newton%post')
 
       return
    end subroutine newton_csp
@@ -631,9 +634,9 @@ contains
       maxstep_bisection = opts%maxstep_bisection
       allocate(residual, source=X); call residual%zero()
       allocate(increment,source=X); call increment%zero()
-      ! Zero eval counters & instantiate metadata
-      call sys%reset_eval_counter()
+      ! Initialize metadata & reset eval counter
       newton_meta = newton_dp_metadata()
+      call sys%reset_eval_counter('newton%init')
 
       ! Get initial residual.
       call sys%eval(X, residual, target_tol)
@@ -715,7 +718,6 @@ contains
 
       ! Finalize metadata
       newton_meta%info = info
-      newton_meta%eval_counter_all = sys%get_eval_counter()
 
       if (opts%if_print_metadata) call newton_meta%print()
 
@@ -726,6 +728,8 @@ contains
                meta = newton_meta
          end select
       end if
+
+      call sys%reset_eval_counter('newton%post')
 
       return
    end subroutine newton_cdp

--- a/src/NewtonKrylov.f90
+++ b/src/NewtonKrylov.f90
@@ -91,7 +91,7 @@ module LightKrylov_NewtonKrylov
          integer,  intent(in)  :: iter
          !! Newton iteration count
          integer,  intent(out)  :: info
-         !! Information flagcharacter(len=128) :: msg
+         !! Information flag
       end subroutine abstract_scheduler_sp
 
       subroutine abstract_scheduler_dp(tol, target_tol, rnorm, iter, info)
@@ -106,7 +106,7 @@ module LightKrylov_NewtonKrylov
          integer,  intent(in)  :: iter
          !! Newton iteration count
          integer,  intent(out)  :: info
-         !! Information flagcharacter(len=128) :: msg
+         !! Information flag
       end subroutine abstract_scheduler_dp
 
 

--- a/src/NewtonKrylov.f90
+++ b/src/NewtonKrylov.f90
@@ -11,7 +11,8 @@ module LightKrylov_NewtonKrylov
    implicit none
    private
 
-   character(len=128), parameter :: this_module = 'LightKrylov_NewtonKrylov'
+   character(len=*), parameter :: this_module      = 'LK_NwtKryl'
+   character(len=*), parameter :: this_module_long = 'LightKrylov_NewtonKrylov'
 
    public :: newton
    public :: constant_atol_sp

--- a/src/NewtonKrylov.f90
+++ b/src/NewtonKrylov.f90
@@ -162,8 +162,9 @@ contains
          tolerance_scheduler => constant_atol_sp
       endif
 
-      ! Initialisation      
-      maxiter           = opts%maxiter
+      ! Initialisation
+      info = 0 
+      maxiter = opts%maxiter
       maxstep_bisection = opts%maxstep_bisection
       allocate(residual, source=X); call residual%zero()
       allocate(increment,source=X); call increment%zero()
@@ -256,10 +257,12 @@ contains
       newton_meta%info = info
 
       ! Set metadata output
-      select type(meta)
-         type is (newton_sp_metadata)
-            meta = newton_meta
-      end select
+      if (present(meta)) then
+         select type(meta)
+            type is (newton_sp_metadata)
+               meta = newton_meta
+         end select
+      end if
 
       return
    end subroutine newton_rsp
@@ -313,8 +316,9 @@ contains
          tolerance_scheduler => constant_atol_dp
       endif
 
-      ! Initialisation      
-      maxiter           = opts%maxiter
+      ! Initialisation
+      info = 0 
+      maxiter = opts%maxiter
       maxstep_bisection = opts%maxstep_bisection
       allocate(residual, source=X); call residual%zero()
       allocate(increment,source=X); call increment%zero()
@@ -407,10 +411,12 @@ contains
       newton_meta%info = info
 
       ! Set metadata output
-      select type(meta)
-         type is (newton_dp_metadata)
-            meta = newton_meta
-      end select
+      if (present(meta)) then
+         select type(meta)
+            type is (newton_dp_metadata)
+               meta = newton_meta
+         end select
+      end if
 
       return
    end subroutine newton_rdp
@@ -464,8 +470,9 @@ contains
          tolerance_scheduler => constant_atol_sp
       endif
 
-      ! Initialisation      
-      maxiter           = opts%maxiter
+      ! Initialisation
+      info = 0 
+      maxiter = opts%maxiter
       maxstep_bisection = opts%maxstep_bisection
       allocate(residual, source=X); call residual%zero()
       allocate(increment,source=X); call increment%zero()
@@ -558,10 +565,12 @@ contains
       newton_meta%info = info
 
       ! Set metadata output
-      select type(meta)
-         type is (newton_sp_metadata)
-            meta = newton_meta
-      end select
+      if (present(meta)) then
+         select type(meta)
+            type is (newton_sp_metadata)
+               meta = newton_meta
+         end select
+      end if
 
       return
    end subroutine newton_csp
@@ -615,8 +624,9 @@ contains
          tolerance_scheduler => constant_atol_dp
       endif
 
-      ! Initialisation      
-      maxiter           = opts%maxiter
+      ! Initialisation
+      info = 0 
+      maxiter = opts%maxiter
       maxstep_bisection = opts%maxstep_bisection
       allocate(residual, source=X); call residual%zero()
       allocate(increment,source=X); call increment%zero()
@@ -709,10 +719,12 @@ contains
       newton_meta%info = info
 
       ! Set metadata output
-      select type(meta)
-         type is (newton_dp_metadata)
-            meta = newton_meta
-      end select
+      if (present(meta)) then
+         select type(meta)
+            type is (newton_dp_metadata)
+               meta = newton_meta
+         end select
+      end if
 
       return
    end subroutine newton_cdp

--- a/src/NewtonKrylov.fypp
+++ b/src/NewtonKrylov.fypp
@@ -80,7 +80,7 @@ module LightKrylov_NewtonKrylov
    end interface
 
    abstract interface
-      #:for kind, type in REAL_KINDS_TYPES
+      #:for kind in REAL_KINDS
       subroutine abstract_scheduler_${kind}$(tol, target_tol, rnorm, iter, info)
          import ${kind}$
          !! Abstract interface to define a tolerance scheduler for the Newton iteration
@@ -93,10 +93,11 @@ module LightKrylov_NewtonKrylov
          integer,  intent(in)  :: iter
          !! Newton iteration count
          integer,  intent(out)  :: info
-         !! Information flag
+         !! Information flagcharacter(len=128) :: msg
       end subroutine abstract_scheduler_${kind}$
 
       #:endfor
+
    end interface
 
 contains
@@ -157,18 +158,16 @@ contains
       maxstep_bisection = opts%maxstep_bisection
       allocate(residual, source=X); call residual%zero()
       allocate(increment,source=X); call increment%zero()
-
+      ! Zero eval counters & instantiate metadata
+      call sys%reset_eval_counter()
       newton_meta = newton_${kind}$_metadata()
-      allocate(newton_meta%res(2*maxiter)); newton_meta%res = 0.0_${kind}$
-      allocate(newton_meta%tol(2*maxiter)); newton_meta%tol = 0.0_${kind}$
 
       ! Get initial residual.
-      call sys%eval(X, residual, target_tol) ; newton_meta%n_eval = newton_meta%n_eval + 1
+      call sys%eval(X, residual, target_tol)
       rnorm = residual%norm()
 
       ! Save metadata.
-      newton_meta%res(1) = rnorm
-      newton_meta%tol(1) = target_tol
+      call newton_meta%record(rnorm, target_tol)
 
       ! Check for lucky convergence.
       if (rnorm < target_tol) then
@@ -205,26 +204,25 @@ contains
          endif
 
          ! Evaluate new residual
-         call sys%eval(X, residual, tol) ; newton_meta%n_eval = newton_meta%n_eval + 1
+         call sys%eval(X, residual, tol)
          rnorm = residual%norm()
 
          ! Save metadata.
          newton_meta%n_iter = newton_meta%n_iter + 1
-         newton_meta%res(newton_meta%n_eval+1) = rnorm
-         newton_meta%tol(newton_meta%n_eval+1) = tol
+         call newton_meta%record(rnorm, tol)
 
          ! Check for convergence.
          if (rnorm < tol) then
             if (tol >= target_tol .and. tol < 100.0_${kind}$*target_tol) then
-               ! the tolerances are not at the target, check the accurate residual                  
-               call sys%eval(X, residual, target_tol) ; newton_meta%n_eval = newton_meta%n_eval + 1
+               ! the tolerances are not at the target, check the accurate residual
+               call sys%eval(X, residual, target_tol)
                rnorm = residual%norm()
-               ! Save metadata.
-               newton_meta%res(newton_meta%n_eval + 1) = rnorm
-               newton_meta%tol(newton_meta%n_eval + 1) = target_tol
+
                if (rnorm < target_tol) then
                   write(msg,'(A,I0,A)') 'Newton iteration converged after ',i,' iterations.'
                   call logger%log_message(msg, module=this_module, procedure='newton_${type[0]}$${kind}$')
+                  ! Save metadata
+                  call newton_meta%record(rnorm, target_tol)
                   newton_meta%converged = .true.
                   exit newton
                else
@@ -242,8 +240,11 @@ contains
          info = -1
       endif
 
-      ! Copy info flag
+      ! Finalize metadata
       newton_meta%info = info
+      newton_meta%eval_counter_all = sys%get_eval_counter()
+
+      if (opts%if_print_metadata) call newton_meta%print()
 
       ! Set metadata output
       if (present(meta)) then
@@ -264,7 +265,7 @@ contains
       !! order to maximally reduce the residual at each iteration.
       class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: X
       !! Current system state to be updated
-      class(abstract_system_${type[0]}$${kind}$), intent(in)    :: sys
+      class(abstract_system_${type[0]}$${kind}$), intent(inout) :: sys
       !! Dynamical system for which the residual is minimized
       class(abstract_vector_${type[0]}$${kind}$), intent(in)    :: increment
       !! Newton step computed from the standard method

--- a/src/NewtonKrylov.fypp
+++ b/src/NewtonKrylov.fypp
@@ -93,7 +93,7 @@ module LightKrylov_NewtonKrylov
          integer,  intent(in)  :: iter
          !! Newton iteration count
          integer,  intent(out)  :: info
-         !! Information flagcharacter(len=128) :: msg
+         !! Information flag
       end subroutine abstract_scheduler_${kind}$
 
       #:endfor

--- a/src/NewtonKrylov.fypp
+++ b/src/NewtonKrylov.fypp
@@ -151,8 +151,9 @@ contains
          tolerance_scheduler => constant_atol_${kind}$
       endif
 
-      ! Initialisation      
-      maxiter           = opts%maxiter
+      ! Initialisation
+      info = 0 
+      maxiter = opts%maxiter
       maxstep_bisection = opts%maxstep_bisection
       allocate(residual, source=X); call residual%zero()
       allocate(increment,source=X); call increment%zero()
@@ -245,10 +246,12 @@ contains
       newton_meta%info = info
 
       ! Set metadata output
-      select type(meta)
-         type is (newton_${kind}$_metadata)
-            meta = newton_meta
-      end select
+      if (present(meta)) then
+         select type(meta)
+            type is (newton_${kind}$_metadata)
+               meta = newton_meta
+         end select
+      end if
 
       return
    end subroutine newton_${type[0]}$${kind}$

--- a/src/NewtonKrylov.fypp
+++ b/src/NewtonKrylov.fypp
@@ -13,7 +13,8 @@ module LightKrylov_NewtonKrylov
    implicit none
    private
 
-   character(len=128), parameter :: this_module = 'LightKrylov_NewtonKrylov'
+   character(len=*), parameter :: this_module      = 'LK_NwtKryl'
+   character(len=*), parameter :: this_module_long = 'LightKrylov_NewtonKrylov'
 
    public :: newton
    #:for kind in REAL_KINDS

--- a/src/NewtonKrylov.fypp
+++ b/src/NewtonKrylov.fypp
@@ -102,7 +102,7 @@ module LightKrylov_NewtonKrylov
 contains
 
    #:for kind, type in RC_KINDS_TYPES
-   subroutine newton_${type[0]}$${kind}$(sys, X, solver, info, tolerance, options, linear_solver_options, preconditioner, scheduler)
+   subroutine newton_${type[0]}$${kind}$(sys, X, solver, info, tolerance, options, linear_solver_options, preconditioner, scheduler, meta)
       class(abstract_system_${type[0]}$${kind}$),                         intent(inout) :: sys
       !! Dynamical system for which we wish to compute a fixed point
       class(abstract_vector_${type[0]}$${kind}$),                         intent(inout) :: X
@@ -122,6 +122,8 @@ contains
       class(abstract_precond_${type[0]}$${kind}$),              optional, intent(in)    :: preconditioner
       !! Preconditioner for the linear solver
       procedure(abstract_scheduler_${kind}$),         optional                :: scheduler
+      class(abstract_metadata),                       optional,   intent(out) :: meta
+      !! Metadata.
 
       !--------------------------------------
       !-----     Internal variables     -----
@@ -130,8 +132,8 @@ contains
       procedure(abstract_scheduler_${kind}$),      pointer :: tolerance_scheduler => null()
       class(abstract_vector_${type[0]}$${kind}$), allocatable        :: residual, increment
       real(${kind}$)           :: rnorm, tol
-      logical            :: converged
       integer            :: i, maxiter, maxstep_bisection
+      type(newton_${kind}$_metadata) :: newton_meta
       character(len=256) :: msg
       
       ! Newton-solver tolerance
@@ -152,17 +154,26 @@ contains
       ! Initialisation      
       maxiter           = opts%maxiter
       maxstep_bisection = opts%maxstep_bisection
-      converged         = .false.
       allocate(residual, source=X); call residual%zero()
       allocate(increment,source=X); call increment%zero()
 
-      call sys%eval(X, residual, target_tol)
+      newton_meta = newton_${kind}$_metadata()
+      allocate(newton_meta%res(2*maxiter)); newton_meta%res = 0.0_${kind}$
+      allocate(newton_meta%tol(2*maxiter)); newton_meta%tol = 0.0_${kind}$
+
+      ! Get initial residual.
+      call sys%eval(X, residual, target_tol) ; newton_meta%n_eval = newton_meta%n_eval + 1
       rnorm = residual%norm()
+
+      ! Save metadata.
+      newton_meta%res(1) = rnorm
+      newton_meta%tol(1) = target_tol
+
       ! Check for lucky convergence.
       if (rnorm < target_tol) then
          write(msg,'(A)') 'Initial guess is a fixed point to tolerance!'
          call logger%log_warning(msg, module=this_module, procedure='newton_${type[0]}$${kind}$')
-         converged = .true.
+         newton_meta%converged = .true.
          return
       end if
 
@@ -193,18 +204,27 @@ contains
          endif
 
          ! Evaluate new residual
-         call sys%eval(X, residual, tol)
+         call sys%eval(X, residual, tol) ; newton_meta%n_eval = newton_meta%n_eval + 1
          rnorm = residual%norm()
+
+         ! Save metadata.
+         newton_meta%n_iter = newton_meta%n_iter + 1
+         newton_meta%res(newton_meta%n_eval+1) = rnorm
+         newton_meta%tol(newton_meta%n_eval+1) = tol
 
          ! Check for convergence.
          if (rnorm < tol) then
             if (tol >= target_tol .and. tol < 100.0_${kind}$*target_tol) then
                ! the tolerances are not at the target, check the accurate residual                  
-               call sys%eval(X, residual, target_tol)
+               call sys%eval(X, residual, target_tol) ; newton_meta%n_eval = newton_meta%n_eval + 1
+               rnorm = residual%norm()
+               ! Save metadata.
+               newton_meta%res(newton_meta%n_eval + 1) = rnorm
+               newton_meta%tol(newton_meta%n_eval + 1) = target_tol
                if (rnorm < target_tol) then
                   write(msg,'(A,I0,A)') 'Newton iteration converged after ',i,' iterations.'
                   call logger%log_message(msg, module=this_module, procedure='newton_${type[0]}$${kind}$')
-                  converged = .true.
+                  newton_meta%converged = .true.
                   exit newton
                else
                   write(msg,'(A)') 'Dynamic tolerance but not target tolerance reached. Continue iteration.'
@@ -215,11 +235,20 @@ contains
 
       enddo newton
 
-      if (.not.converged) then
+      if (.not.newton_meta%converged) then
          write(msg,'(A,I0,A)') 'Newton iteration did not converge within', maxiter, 'steps.'
          call logger%log_warning(msg, module=this_module, procedure='newton_${type[0]}$${kind}$')
          info = -1
       endif
+
+      ! Copy info flag
+      newton_meta%info = info
+
+      ! Set metadata output
+      select type(meta)
+         type is (newton_${kind}$_metadata)
+            meta = newton_meta
+      end select
 
       return
    end subroutine newton_${type[0]}$${kind}$

--- a/src/NewtonKrylov.fypp
+++ b/src/NewtonKrylov.fypp
@@ -158,9 +158,9 @@ contains
       maxstep_bisection = opts%maxstep_bisection
       allocate(residual, source=X); call residual%zero()
       allocate(increment,source=X); call increment%zero()
-      ! Zero eval counters & instantiate metadata
-      call sys%reset_eval_counter()
+      ! Initialize metadata & reset eval counter
       newton_meta = newton_${kind}$_metadata()
+      call sys%reset_eval_counter('newton%init')
 
       ! Get initial residual.
       call sys%eval(X, residual, target_tol)
@@ -242,7 +242,6 @@ contains
 
       ! Finalize metadata
       newton_meta%info = info
-      newton_meta%eval_counter_all = sys%get_eval_counter()
 
       if (opts%if_print_metadata) call newton_meta%print()
 
@@ -253,6 +252,8 @@ contains
                meta = newton_meta
          end select
       end if
+
+      call sys%reset_eval_counter('newton%post')
 
       return
    end subroutine newton_${type[0]}$${kind}$

--- a/src/TestUtils.f90
+++ b/src/TestUtils.f90
@@ -11,7 +11,8 @@ module LightKrylov_TestUtils
     
     private
 
-    character(len=128), parameter, private :: this_module = 'LightKrylov_TestUtils'
+    character(len=*), parameter, private :: this_module      = 'LK_TUtils'
+    character(len=*), parameter, private :: this_module_long = 'LightKrylov_TestUtils'
 
     integer, parameter, public :: test_size = 128
 

--- a/src/TestUtils.f90
+++ b/src/TestUtils.f90
@@ -92,6 +92,13 @@ module LightKrylov_TestUtils
         procedure, pass(self), public :: rmatvec => rmatvec_rsp
     end type
 
+    interface linop_rsp
+        pure module function construct_linop_rsp(data) result(A)
+            real(sp), dimension(test_size, test_size), intent(in) :: data
+            type(linop_rsp) :: A
+        end function
+    end interface
+
     type, extends(abstract_sym_linop_rsp), public :: spd_linop_rsp
         real(sp), dimension(test_size, test_size) :: data = 0.0_sp
     contains
@@ -99,6 +106,19 @@ module LightKrylov_TestUtils
         procedure, pass(self), public :: matvec => sdp_matvec_rsp
         procedure, pass(self), public :: rmatvec => sdp_matvec_rsp
     end type
+    interface spd_linop_rsp
+        pure module function construct_spd_linop_rsp(data) result(A)
+            real(sp), dimension(test_size, test_size), intent(in) :: data
+            type(spd_linop_rsp) :: A
+        end function
+    end interface
+
+    interface hermitian_linop_rsp
+        pure module function construct_hermitian_linop_rsp(data) result(A)
+            real(sp), dimension(test_size, test_size), intent(in) :: data
+            type(linop_rsp) :: A
+        end function
+    end interface
 
     type, extends(abstract_linop_rdp), public :: linop_rdp
         real(dp), dimension(test_size, test_size) :: data = 0.0_dp
@@ -108,6 +128,13 @@ module LightKrylov_TestUtils
         procedure, pass(self), public :: rmatvec => rmatvec_rdp
     end type
 
+    interface linop_rdp
+        pure module function construct_linop_rdp(data) result(A)
+            real(dp), dimension(test_size, test_size), intent(in) :: data
+            type(linop_rdp) :: A
+        end function
+    end interface
+
     type, extends(abstract_sym_linop_rdp), public :: spd_linop_rdp
         real(dp), dimension(test_size, test_size) :: data = 0.0_dp
     contains
@@ -115,6 +142,19 @@ module LightKrylov_TestUtils
         procedure, pass(self), public :: matvec => sdp_matvec_rdp
         procedure, pass(self), public :: rmatvec => sdp_matvec_rdp
     end type
+    interface spd_linop_rdp
+        pure module function construct_spd_linop_rdp(data) result(A)
+            real(dp), dimension(test_size, test_size), intent(in) :: data
+            type(spd_linop_rdp) :: A
+        end function
+    end interface
+
+    interface hermitian_linop_rdp
+        pure module function construct_hermitian_linop_rdp(data) result(A)
+            real(dp), dimension(test_size, test_size), intent(in) :: data
+            type(linop_rdp) :: A
+        end function
+    end interface
 
     type, extends(abstract_linop_csp), public :: linop_csp
         complex(sp), dimension(test_size, test_size) :: data = cmplx(0.0_sp, 0.0_sp, kind=sp)
@@ -123,6 +163,12 @@ module LightKrylov_TestUtils
         procedure, pass(self), public :: matvec  => matvec_csp
         procedure, pass(self), public :: rmatvec => rmatvec_csp
     end type
+    interface linop_csp
+        pure module function construct_linop_csp(data) result(A)
+            complex(sp), dimension(test_size, test_size), intent(in) :: data
+            type(linop_csp) :: A
+        end function
+    end interface
 
     type, extends(abstract_hermitian_linop_csp), public :: hermitian_linop_csp
         complex(sp), dimension(test_size, test_size) :: data = cmplx(0.0_sp, 0.0_sp, kind=sp)
@@ -131,6 +177,12 @@ module LightKrylov_TestUtils
         procedure, pass(self), public :: matvec => hermitian_matvec_csp
         procedure, pass(self), public :: rmatvec => hermitian_matvec_csp
     end type
+    interface hermitian_linop_csp
+        pure module function construct_hermitian_linop_csp(data) result(A)
+            complex(sp), dimension(test_size, test_size), intent(in) :: data
+            type(linop_csp) :: A
+        end function
+    end interface
 
     type, extends(abstract_linop_cdp), public :: linop_cdp
         complex(dp), dimension(test_size, test_size) :: data = cmplx(0.0_dp, 0.0_dp, kind=dp)
@@ -139,6 +191,12 @@ module LightKrylov_TestUtils
         procedure, pass(self), public :: matvec  => matvec_cdp
         procedure, pass(self), public :: rmatvec => rmatvec_cdp
     end type
+    interface linop_cdp
+        pure module function construct_linop_cdp(data) result(A)
+            complex(dp), dimension(test_size, test_size), intent(in) :: data
+            type(linop_cdp) :: A
+        end function
+    end interface
 
     type, extends(abstract_hermitian_linop_cdp), public :: hermitian_linop_cdp
         complex(dp), dimension(test_size, test_size) :: data = cmplx(0.0_dp, 0.0_dp, kind=dp)
@@ -147,6 +205,12 @@ module LightKrylov_TestUtils
         procedure, pass(self), public :: matvec => hermitian_matvec_cdp
         procedure, pass(self), public :: rmatvec => hermitian_matvec_cdp
     end type
+    interface hermitian_linop_cdp
+        pure module function construct_hermitian_linop_cdp(data) result(A)
+            complex(dp), dimension(test_size, test_size), intent(in) :: data
+            type(linop_cdp) :: A
+        end function
+    end interface
 
 
     ! ROESSLER SYSTEM
@@ -267,7 +331,40 @@ module LightKrylov_TestUtils
     end interface
 
 contains
-    
+
+    !--------------------------------
+    !-----     CONSTRUCTORS     -----
+    !--------------------------------
+
+    module procedure construct_linop_rsp
+    A%data = data
+    end procedure
+
+    module procedure construct_spd_linop_rsp
+    A%data = data
+    end procedure
+    module procedure construct_linop_rdp
+    A%data = data
+    end procedure
+
+    module procedure construct_spd_linop_rdp
+    A%data = data
+    end procedure
+    module procedure construct_linop_csp
+    A%data = data
+    end procedure
+
+    module procedure construct_hermitian_linop_csp
+    A%data = data
+    end procedure
+    module procedure construct_linop_cdp
+    A%data = data
+    end procedure
+
+    module procedure construct_hermitian_linop_cdp
+    A%data = data
+    end procedure
+
     !----------------------------------------------------------
     !-----     TYPE-BOUND PROCEDURES FOR TEST VECTORS     -----
     !----------------------------------------------------------

--- a/src/TestUtils.f90
+++ b/src/TestUtils.f90
@@ -172,7 +172,7 @@ module LightKrylov_TestUtils
     type, extends(abstract_system_rsp), public :: roessler_rsp
     contains
        private
-       procedure, pass(self), public :: eval => eval_roessler_rsp
+       procedure, pass(self), public :: response => eval_roessler_rsp
     end type roessler_rsp
 
     type, extends(abstract_jacobian_linop_rsp), public :: jacobian_rsp
@@ -202,7 +202,7 @@ module LightKrylov_TestUtils
     type, extends(abstract_system_rdp), public :: roessler_rdp
     contains
        private
-       procedure, pass(self), public :: eval => eval_roessler_rdp
+       procedure, pass(self), public :: response => eval_roessler_rdp
     end type roessler_rdp
 
     type, extends(abstract_jacobian_linop_rdp), public :: jacobian_rdp
@@ -518,7 +518,7 @@ contains
     !---------------------------------------------------------
 
     subroutine matvec_rsp(self, vec_in, vec_out)
-        class(linop_rsp), intent(in)  :: self
+        class(linop_rsp), intent(inout)  :: self
         class(abstract_vector_rsp)       , intent(in)  :: vec_in
         class(abstract_vector_rsp)       , intent(out) :: vec_out
 
@@ -536,7 +536,7 @@ contains
     end subroutine matvec_rsp
 
     subroutine rmatvec_rsp(self, vec_in, vec_out)
-        class(linop_rsp), intent(in)  :: self
+        class(linop_rsp), intent(inout)  :: self
         class(abstract_vector_rsp)       , intent(in)  :: vec_in
         class(abstract_vector_rsp)       , intent(out) :: vec_out
 
@@ -554,7 +554,7 @@ contains
     end subroutine rmatvec_rsp
 
     subroutine sdp_matvec_rsp(self, vec_in, vec_out)
-        class(spd_linop_rsp), intent(in)  :: self
+        class(spd_linop_rsp), intent(inout)  :: self
         class(abstract_vector_rsp)       , intent(in)  :: vec_in
         class(abstract_vector_rsp)       , intent(out) :: vec_out
 
@@ -572,7 +572,7 @@ contains
     end subroutine sdp_matvec_rsp
 
     subroutine matvec_rdp(self, vec_in, vec_out)
-        class(linop_rdp), intent(in)  :: self
+        class(linop_rdp), intent(inout)  :: self
         class(abstract_vector_rdp)       , intent(in)  :: vec_in
         class(abstract_vector_rdp)       , intent(out) :: vec_out
 
@@ -590,7 +590,7 @@ contains
     end subroutine matvec_rdp
 
     subroutine rmatvec_rdp(self, vec_in, vec_out)
-        class(linop_rdp), intent(in)  :: self
+        class(linop_rdp), intent(inout)  :: self
         class(abstract_vector_rdp)       , intent(in)  :: vec_in
         class(abstract_vector_rdp)       , intent(out) :: vec_out
 
@@ -608,7 +608,7 @@ contains
     end subroutine rmatvec_rdp
 
     subroutine sdp_matvec_rdp(self, vec_in, vec_out)
-        class(spd_linop_rdp), intent(in)  :: self
+        class(spd_linop_rdp), intent(inout)  :: self
         class(abstract_vector_rdp)       , intent(in)  :: vec_in
         class(abstract_vector_rdp)       , intent(out) :: vec_out
 
@@ -626,7 +626,7 @@ contains
     end subroutine sdp_matvec_rdp
 
     subroutine matvec_csp(self, vec_in, vec_out)
-        class(linop_csp), intent(in)  :: self
+        class(linop_csp), intent(inout)  :: self
         class(abstract_vector_csp)       , intent(in)  :: vec_in
         class(abstract_vector_csp)       , intent(out) :: vec_out
 
@@ -644,7 +644,7 @@ contains
     end subroutine matvec_csp
 
     subroutine rmatvec_csp(self, vec_in, vec_out)
-        class(linop_csp), intent(in)  :: self
+        class(linop_csp), intent(inout)  :: self
         class(abstract_vector_csp)       , intent(in)  :: vec_in
         class(abstract_vector_csp)       , intent(out) :: vec_out
 
@@ -662,7 +662,7 @@ contains
     end subroutine rmatvec_csp
 
     subroutine hermitian_matvec_csp(self, vec_in, vec_out)
-        class(hermitian_linop_csp), intent(in)  :: self
+        class(hermitian_linop_csp), intent(inout)  :: self
         class(abstract_vector_csp)       , intent(in)  :: vec_in
         class(abstract_vector_csp)       , intent(out) :: vec_out
 
@@ -680,7 +680,7 @@ contains
     end subroutine hermitian_matvec_csp
 
     subroutine matvec_cdp(self, vec_in, vec_out)
-        class(linop_cdp), intent(in)  :: self
+        class(linop_cdp), intent(inout)  :: self
         class(abstract_vector_cdp)       , intent(in)  :: vec_in
         class(abstract_vector_cdp)       , intent(out) :: vec_out
 
@@ -698,7 +698,7 @@ contains
     end subroutine matvec_cdp
 
     subroutine rmatvec_cdp(self, vec_in, vec_out)
-        class(linop_cdp), intent(in)  :: self
+        class(linop_cdp), intent(inout)  :: self
         class(abstract_vector_cdp)       , intent(in)  :: vec_in
         class(abstract_vector_cdp)       , intent(out) :: vec_out
 
@@ -716,7 +716,7 @@ contains
     end subroutine rmatvec_cdp
 
     subroutine hermitian_matvec_cdp(self, vec_in, vec_out)
-        class(hermitian_linop_cdp), intent(in)  :: self
+        class(hermitian_linop_cdp), intent(inout)  :: self
         class(abstract_vector_cdp)       , intent(in)  :: vec_in
         class(abstract_vector_cdp)       , intent(out) :: vec_out
 
@@ -1276,7 +1276,7 @@ contains
 
 
     subroutine eval_roessler_rsp(self, vec_in, vec_out, atol)
-      class(roessler_rsp),            intent(in)  :: self
+      class(roessler_rsp),            intent(inout)  :: self
       class(abstract_vector_rsp), intent(in)  :: vec_in
       class(abstract_vector_rsp), intent(out) :: vec_out
       real(sp),                    intent(in)  :: atol
@@ -1311,7 +1311,7 @@ contains
     end subroutine get_state_rsp
 
     subroutine lin_roessler_rsp(self, vec_in, vec_out)
-      class(jacobian_rsp),            intent(in)  :: self
+      class(jacobian_rsp),            intent(inout)  :: self
       class(abstract_vector_rsp), intent(in)  :: vec_in
       class(abstract_vector_rsp), intent(out) :: vec_out
 
@@ -1335,7 +1335,7 @@ contains
     end subroutine lin_roessler_rsp
 
     subroutine adj_lin_roessler_rsp(self, vec_in, vec_out)
-      class(jacobian_rsp),            intent(in)  :: self
+      class(jacobian_rsp),            intent(inout)  :: self
       class(abstract_vector_rsp), intent(in)  :: vec_in
       class(abstract_vector_rsp), intent(out) :: vec_out
 
@@ -1377,7 +1377,7 @@ contains
     end subroutine roessler_analytical_fp_rsp
 
     subroutine eval_roessler_rdp(self, vec_in, vec_out, atol)
-      class(roessler_rdp),            intent(in)  :: self
+      class(roessler_rdp),            intent(inout)  :: self
       class(abstract_vector_rdp), intent(in)  :: vec_in
       class(abstract_vector_rdp), intent(out) :: vec_out
       real(dp),                    intent(in)  :: atol
@@ -1412,7 +1412,7 @@ contains
     end subroutine get_state_rdp
 
     subroutine lin_roessler_rdp(self, vec_in, vec_out)
-      class(jacobian_rdp),            intent(in)  :: self
+      class(jacobian_rdp),            intent(inout)  :: self
       class(abstract_vector_rdp), intent(in)  :: vec_in
       class(abstract_vector_rdp), intent(out) :: vec_out
 
@@ -1436,7 +1436,7 @@ contains
     end subroutine lin_roessler_rdp
 
     subroutine adj_lin_roessler_rdp(self, vec_in, vec_out)
-      class(jacobian_rdp),            intent(in)  :: self
+      class(jacobian_rdp),            intent(inout)  :: self
       class(abstract_vector_rdp), intent(in)  :: vec_in
       class(abstract_vector_rdp), intent(out) :: vec_out
 

--- a/src/TestUtils.f90
+++ b/src/TestUtils.f90
@@ -1115,7 +1115,7 @@ contains
       real(sp) :: err
 
       ! internals
-      character*9 :: value_str
+      character(len=9) :: value_str
       character(len=*), parameter :: indent = repeat(" ", 4)
 
       write(value_str, '(E9.2)') err
@@ -1128,7 +1128,7 @@ contains
       real(dp) :: err
 
       ! internals
-      character*9 :: value_str
+      character(len=9) :: value_str
       character(len=*), parameter :: indent = repeat(" ", 4)
 
       write(value_str, '(E9.2)') err

--- a/src/TestUtils.fypp
+++ b/src/TestUtils.fypp
@@ -113,7 +113,7 @@ module LightKrylov_TestUtils
     type, extends(abstract_system_r${kind}$), public :: roessler_r${kind}$
     contains
        private
-       procedure, pass(self), public :: eval => eval_roessler_r${kind}$
+       procedure, pass(self), public :: response => eval_roessler_r${kind}$
     end type roessler_r${kind}$
 
     type, extends(abstract_jacobian_linop_r${kind}$), public :: jacobian_r${kind}$
@@ -238,7 +238,7 @@ contains
 
     #:for kind, type in RC_KINDS_TYPES
     subroutine matvec_${type[0]}$${kind}$(self, vec_in, vec_out)
-        class(linop_${type[0]}$${kind}$), intent(in)  :: self
+        class(linop_${type[0]}$${kind}$), intent(inout)  :: self
         class(abstract_vector_${type[0]}$${kind}$)       , intent(in)  :: vec_in
         class(abstract_vector_${type[0]}$${kind}$)       , intent(out) :: vec_out
 
@@ -256,7 +256,7 @@ contains
     end subroutine matvec_${type[0]}$${kind}$
 
     subroutine rmatvec_${type[0]}$${kind}$(self, vec_in, vec_out)
-        class(linop_${type[0]}$${kind}$), intent(in)  :: self
+        class(linop_${type[0]}$${kind}$), intent(inout)  :: self
         class(abstract_vector_${type[0]}$${kind}$)       , intent(in)  :: vec_in
         class(abstract_vector_${type[0]}$${kind}$)       , intent(out) :: vec_out
 
@@ -279,7 +279,7 @@ contains
 
     #:if type[0] == "r"
     subroutine sdp_matvec_${type[0]}$${kind}$(self, vec_in, vec_out)
-        class(spd_linop_${type[0]}$${kind}$), intent(in)  :: self
+        class(spd_linop_${type[0]}$${kind}$), intent(inout)  :: self
         class(abstract_vector_${type[0]}$${kind}$)       , intent(in)  :: vec_in
         class(abstract_vector_${type[0]}$${kind}$)       , intent(out) :: vec_out
 
@@ -297,7 +297,7 @@ contains
     end subroutine sdp_matvec_${type[0]}$${kind}$
     #:else
     subroutine hermitian_matvec_${type[0]}$${kind}$(self, vec_in, vec_out)
-        class(hermitian_linop_${type[0]}$${kind}$), intent(in)  :: self
+        class(hermitian_linop_${type[0]}$${kind}$), intent(inout)  :: self
         class(abstract_vector_${type[0]}$${kind}$)       , intent(in)  :: vec_in
         class(abstract_vector_${type[0]}$${kind}$)       , intent(out) :: vec_out
 
@@ -540,7 +540,7 @@ contains
 
     #:for kind in REAL_KINDS
     subroutine eval_roessler_r${kind}$(self, vec_in, vec_out, atol)
-      class(roessler_r${kind}$),            intent(in)  :: self
+      class(roessler_r${kind}$),            intent(inout)  :: self
       class(abstract_vector_r${kind}$), intent(in)  :: vec_in
       class(abstract_vector_r${kind}$), intent(out) :: vec_out
       real(${kind}$),                    intent(in)  :: atol
@@ -575,7 +575,7 @@ contains
     end subroutine get_state_r${kind}$
 
     subroutine lin_roessler_r${kind}$(self, vec_in, vec_out)
-      class(jacobian_r${kind}$),            intent(in)  :: self
+      class(jacobian_r${kind}$),            intent(inout)  :: self
       class(abstract_vector_r${kind}$), intent(in)  :: vec_in
       class(abstract_vector_r${kind}$), intent(out) :: vec_out
 
@@ -599,7 +599,7 @@ contains
     end subroutine lin_roessler_r${kind}$
 
     subroutine adj_lin_roessler_r${kind}$(self, vec_in, vec_out)
-      class(jacobian_r${kind}$),            intent(in)  :: self
+      class(jacobian_r${kind}$),            intent(inout)  :: self
       class(abstract_vector_r${kind}$), intent(in)  :: vec_in
       class(abstract_vector_r${kind}$), intent(out) :: vec_out
 

--- a/src/TestUtils.fypp
+++ b/src/TestUtils.fypp
@@ -62,6 +62,13 @@ module LightKrylov_TestUtils
         procedure, pass(self), public :: rmatvec => rmatvec_${type[0]}$${kind}$
     end type
 
+    interface linop_${type[0]}$${kind}$
+        pure module function construct_linop_${type[0]}$${kind}$(data) result(A)
+            ${type}$, dimension(test_size, test_size), intent(in) :: data
+            type(linop_${type[0]}$${kind}$) :: A
+        end function
+    end interface
+
     type, extends(abstract_sym_linop_${type[0]}$${kind}$), public :: spd_linop_${type[0]}$${kind}$
         ${type}$, dimension(test_size, test_size) :: data = 0.0_${kind}$
     contains
@@ -69,6 +76,13 @@ module LightKrylov_TestUtils
         procedure, pass(self), public :: matvec => sdp_matvec_${type[0]}$${kind}$
         procedure, pass(self), public :: rmatvec => sdp_matvec_${type[0]}$${kind}$
     end type
+    interface spd_linop_${type[0]}$${kind}$
+        pure module function construct_spd_linop_${type[0]}$${kind}$(data) result(A)
+            ${type}$, dimension(test_size, test_size), intent(in) :: data
+            type(spd_linop_${type[0]}$${kind}$) :: A
+        end function
+    end interface
+
     #:else
     type, extends(abstract_linop_${type[0]}$${kind}$), public :: linop_${type[0]}$${kind}$
         ${type}$, dimension(test_size, test_size) :: data = cmplx(0.0_${kind}$, 0.0_${kind}$, kind=${kind}$)
@@ -77,6 +91,12 @@ module LightKrylov_TestUtils
         procedure, pass(self), public :: matvec  => matvec_${type[0]}$${kind}$
         procedure, pass(self), public :: rmatvec => rmatvec_${type[0]}$${kind}$
     end type
+    interface linop_${type[0]}$${kind}$
+        pure module function construct_linop_${type[0]}$${kind}$(data) result(A)
+            ${type}$, dimension(test_size, test_size), intent(in) :: data
+            type(linop_${type[0]}$${kind}$) :: A
+        end function
+    end interface
 
     type, extends(abstract_hermitian_linop_${type[0]}$${kind}$), public :: hermitian_linop_${type[0]}$${kind}$
         ${type}$, dimension(test_size, test_size) :: data = cmplx(0.0_${kind}$, 0.0_${kind}$, kind=${kind}$)
@@ -86,6 +106,12 @@ module LightKrylov_TestUtils
         procedure, pass(self), public :: rmatvec => hermitian_matvec_${type[0]}$${kind}$
     end type
     #:endif
+    interface hermitian_linop_${type[0]}$${kind}$
+        pure module function construct_hermitian_linop_${type[0]}$${kind}$(data) result(A)
+            ${type}$, dimension(test_size, test_size), intent(in) :: data
+            type(linop_${type[0]}$${kind}$) :: A
+        end function
+    end interface
 
     #:endfor
 
@@ -160,7 +186,27 @@ module LightKrylov_TestUtils
     end interface
 
 contains
-    
+
+    !--------------------------------
+    !-----     CONSTRUCTORS     -----
+    !--------------------------------
+
+    #:for kind, type in RC_KINDS_TYPES
+    module procedure construct_linop_${type[0]}$${kind}$
+    A%data = data
+    end procedure
+
+    #:if type[0] == "r"
+    module procedure construct_spd_linop_${type[0]}$${kind}$
+    A%data = data
+    end procedure
+    #:else
+    module procedure construct_hermitian_linop_${type[0]}$${kind}$
+    A%data = data
+    end procedure
+    #:endif
+    #:endfor
+
     !----------------------------------------------------------
     !-----     TYPE-BOUND PROCEDURES FOR TEST VECTORS     -----
     !----------------------------------------------------------

--- a/src/TestUtils.fypp
+++ b/src/TestUtils.fypp
@@ -13,7 +13,8 @@ module LightKrylov_TestUtils
     
     private
 
-    character(len=128), parameter, private :: this_module = 'LightKrylov_TestUtils'
+    character(len=*), parameter, private :: this_module      = 'LK_TUtils'
+    character(len=*), parameter, private :: this_module_long = 'LightKrylov_TestUtils'
 
     integer, parameter, public :: test_size = 128
 

--- a/src/TestUtils.fypp
+++ b/src/TestUtils.fypp
@@ -455,7 +455,7 @@ contains
       real(${kind}$) :: err
 
       ! internals
-      character*9 :: value_str
+      character(len=9) :: value_str
       character(len=*), parameter :: indent = repeat(" ", 4)
 
       write(value_str, '(E9.2)') err

--- a/src/Utils.f90
+++ b/src/Utils.f90
@@ -297,74 +297,102 @@ module lightkrylov_utils
 
     type, extends(abstract_metadata), public :: gmres_sp_metadata
         !! GMRES metadata.
-        integer :: n_iter
+        integer :: n_iter = 0
         !! Iteration counter
-        integer :: n_Ax
+        integer :: n_Ax = 0
         !! Matrix-vector product counter
-        integer :: n_inner
+        integer :: n_inner = 0
         !! Number of inner iterations
-        integer :: n_outer
+        integer :: n_outer = 0
         !! Number of outer iterations
         real(sp), dimension(:), allocatable :: res
         !! Residual history
+        logical :: converged = .false.
+        !! Convergence flag
+        integer :: info = 0
+        !! Copy of the information flag for completeness
     end type
 
     type, extends(abstract_metadata), public :: cg_sp_metadata
         !! Conjugate gradient metadata.
-        integer :: n_iter
+        integer :: n_iter = 0
         !! Iteration counter
-        integer :: n_Ax
+        integer :: n_Ax = 0
         !! Matrix-vector product counter
         real(sp), dimension(:), allocatable :: res
         !! Residual history
+        logical :: converged = .false.
+        !! Convergence flag
+        integer :: info = 0
+        !! Copy of the information flag for completeness
     end type
 
     type, extends(abstract_metadata), public :: newton_sp_metadata
         !! Metadata for Newton-Krylov fixed-point iteration.
-        integer :: n_iter
+        integer :: n_iter = 0
         !! Iteration counter
-        integer :: n_Ax
+        integer :: n_Ax = 0
         !! Matrix-vector product counter
-        integer :: n_eval
+        integer :: n_eval = 0
         !! System evaluation counter
         real(sp), dimension(:), allocatable :: res
         !! Residual history
+        real(sp), dimension(:), allocatable :: tol
+        !! Tolerance history
+        logical :: converged = .false.
+        !! Convergence flag
+        integer :: info = 0
+        !! Copy of the information flag for completeness
     end type
     
     type, extends(abstract_metadata), public :: gmres_dp_metadata
         !! GMRES metadata.
-        integer :: n_iter
+        integer :: n_iter = 0
         !! Iteration counter
-        integer :: n_Ax
+        integer :: n_Ax = 0
         !! Matrix-vector product counter
-        integer :: n_inner
+        integer :: n_inner = 0
         !! Number of inner iterations
-        integer :: n_outer
+        integer :: n_outer = 0
         !! Number of outer iterations
         real(dp), dimension(:), allocatable :: res
         !! Residual history
+        logical :: converged = .false.
+        !! Convergence flag
+        integer :: info = 0
+        !! Copy of the information flag for completeness
     end type
 
     type, extends(abstract_metadata), public :: cg_dp_metadata
         !! Conjugate gradient metadata.
-        integer :: n_iter
+        integer :: n_iter = 0
         !! Iteration counter
-        integer :: n_Ax
+        integer :: n_Ax = 0
         !! Matrix-vector product counter
         real(dp), dimension(:), allocatable :: res
         !! Residual history
+        logical :: converged = .false.
+        !! Convergence flag
+        integer :: info = 0
+        !! Copy of the information flag for completeness
     end type
 
     type, extends(abstract_metadata), public :: newton_dp_metadata
         !! Metadata for Newton-Krylov fixed-point iteration.
-        integer :: n_iter
+        integer :: n_iter = 0
         !! Iteration counter
-        integer :: n_Ax
+        integer :: n_Ax = 0
         !! Matrix-vector product counter
-        integer :: n_eval
+        integer :: n_eval = 0
         !! System evaluation counter
         real(dp), dimension(:), allocatable :: res
         !! Residual history
+        real(dp), dimension(:), allocatable :: tol
+        !! Tolerance history
+        logical :: converged = .false.
+        !! Convergence flag
+        integer :: info = 0
+        !! Copy of the information flag for completeness
     end type
     
 

--- a/src/Utils.f90
+++ b/src/Utils.f90
@@ -32,7 +32,8 @@ module lightkrylov_utils
     implicit none
     private
 
-    character(len=128), parameter :: this_module = 'LightKrylov_Utils'
+    character(len=*), parameter :: this_module      = 'LK_Utils'
+    character(len=*), parameter :: this_module_long = 'LightKrylov_Utils'
 
     public :: assert_shape, norml, log2
     ! Compute AX = XD for general dense matrices.
@@ -287,6 +288,83 @@ module lightkrylov_utils
         integer :: maxstep_bisection = 5
         !! Maximum number of bisections (evaluations of F) for step selection (default = 5)
         !! Ignored if ifbisect = .false.
+    end type
+    
+
+    type, abstract, public :: abstract_metadata
+        !! Abstract type container for solver metadata from with all others are extended.
+    end type
+
+    type, extends(abstract_metadata), public :: gmres_sp_metadata
+        !! GMRES metadata.
+        integer :: n_iter
+        !! Iteration counter
+        integer :: n_Ax
+        !! Matrix-vector product counter
+        integer :: n_inner
+        !! Number of inner iterations
+        integer :: n_outer
+        !! Number of outer iterations
+        real(sp), dimension(:), allocatable :: res
+        !! Residual history
+    end type
+
+    type, extends(abstract_metadata), public :: cg_sp_metadata
+        !! Conjugate gradient metadata.
+        integer :: n_iter
+        !! Iteration counter
+        integer :: n_Ax
+        !! Matrix-vector product counter
+        real(sp), dimension(:), allocatable :: res
+        !! Residual history
+    end type
+
+    type, extends(abstract_metadata), public :: newton_sp_metadata
+        !! Metadata for Newton-Krylov fixed-point iteration.
+        integer :: n_iter
+        !! Iteration counter
+        integer :: n_Ax
+        !! Matrix-vector product counter
+        integer :: n_eval
+        !! System evaluation counter
+        real(sp), dimension(:), allocatable :: res
+        !! Residual history
+    end type
+    
+    type, extends(abstract_metadata), public :: gmres_dp_metadata
+        !! GMRES metadata.
+        integer :: n_iter
+        !! Iteration counter
+        integer :: n_Ax
+        !! Matrix-vector product counter
+        integer :: n_inner
+        !! Number of inner iterations
+        integer :: n_outer
+        !! Number of outer iterations
+        real(dp), dimension(:), allocatable :: res
+        !! Residual history
+    end type
+
+    type, extends(abstract_metadata), public :: cg_dp_metadata
+        !! Conjugate gradient metadata.
+        integer :: n_iter
+        !! Iteration counter
+        integer :: n_Ax
+        !! Matrix-vector product counter
+        real(dp), dimension(:), allocatable :: res
+        !! Residual history
+    end type
+
+    type, extends(abstract_metadata), public :: newton_dp_metadata
+        !! Metadata for Newton-Krylov fixed-point iteration.
+        integer :: n_iter
+        !! Iteration counter
+        integer :: n_Ax
+        !! Matrix-vector product counter
+        integer :: n_eval
+        !! System evaluation counter
+        real(dp), dimension(:), allocatable :: res
+        !! Residual history
     end type
     
 

--- a/src/Utils.f90
+++ b/src/Utils.f90
@@ -368,9 +368,6 @@ module lightkrylov_utils
         integer :: eval_counter_record = 0
         !! System response evaluation counter:
         !! N.B.: For each of these evals the current residual and tolerance are recorded.
-        integer :: eval_counter_all = 0
-        !! System response evaluation counter, including additional evals for convergence checks and step bisection.
-        !! N.B.: For the additional system evaluations, the residual and tolerance are NOT recorded.
         real(sp), dimension(:), allocatable :: res
         !! Residual history
         real(sp), dimension(:), allocatable :: tol
@@ -426,9 +423,6 @@ module lightkrylov_utils
         integer :: eval_counter_record = 0
         !! System response evaluation counter:
         !! N.B.: For each of these evals the current residual and tolerance are recorded.
-        integer :: eval_counter_all = 0
-        !! System response evaluation counter, including additional evals for convergence checks and step bisection.
-        !! N.B.: For the additional system evaluations, the residual and tolerance are NOT recorded.
         real(dp), dimension(:), allocatable :: res
         !! Residual history
         real(dp), dimension(:), allocatable :: tol
@@ -568,23 +562,20 @@ contains
 
         write(msg,'(A30,I20)') padr('Iterations: ', 30), self%n_iter
         call logger%log_message(msg, module=this_module, procedure='newton_metadata')
-        write(msg,'(A30,I20)') padr('System evaluations: ', 30), self%eval_counter_all
-        call logger%log_message(msg, module=this_module, procedure='newton_metadata')
         if (ifverbose) then
             write(msg,'(14X,A15,2X,A15)') 'Residual', 'Tolerance'
             call logger%log_message(msg, module=this_module, procedure='newton_metadata')
             write(msg,'(A14,E15.8,2X,E15.8)') '   INIT:', self%res(1), self%tol(1)
             call logger%log_message(msg, module=this_module, procedure='newton_metadata')
-            do i = 2, self%eval_counter_record - 1
+            do i = 2, size(self%res) - 1
                write(msg,'(A,I4,A,E15.8,2X,E15.8)') '   Step ', i-1, ': ', self%res(i), self%tol(i)
                call logger%log_message(msg, module=this_module, procedure='newton_metadata')
             end do
-            i = self%eval_counter_record
+            i = size(self%res)
             write(msg,'(A14,E15.8,2X,E15.8)') '   FINAL:', self%res(i), self%tol(i)
             call logger%log_message(msg, module=this_module, procedure='newton_metadata')
         else
-            i = self%eval_counter_record
-            write(msg,'(A30,E20.8)') padr('Residual: ', 30), self%res(i)
+            write(msg,'(A30,E20.8)') padr('Residual: ', 30), self%res(size(self%res))
             call logger%log_message(msg, module=this_module, procedure='newton_metadata')
         end if
         if (self%converged) then
@@ -600,7 +591,6 @@ contains
         class(newton_sp_metadata), intent(inout) :: self
         self%n_iter = 0
         self%eval_counter_record = 0
-        self%eval_counter_all = 0
         self%converged = .false.
         self%info = 0
         if (allocated(self%res)) deallocate(self%res)
@@ -748,23 +738,20 @@ contains
 
         write(msg,'(A30,I20)') padr('Iterations: ', 30), self%n_iter
         call logger%log_message(msg, module=this_module, procedure='newton_metadata')
-        write(msg,'(A30,I20)') padr('System evaluations: ', 30), self%eval_counter_all
-        call logger%log_message(msg, module=this_module, procedure='newton_metadata')
         if (ifverbose) then
             write(msg,'(14X,A15,2X,A15)') 'Residual', 'Tolerance'
             call logger%log_message(msg, module=this_module, procedure='newton_metadata')
             write(msg,'(A14,E15.8,2X,E15.8)') '   INIT:', self%res(1), self%tol(1)
             call logger%log_message(msg, module=this_module, procedure='newton_metadata')
-            do i = 2, self%eval_counter_record - 1
+            do i = 2, size(self%res) - 1
                write(msg,'(A,I4,A,E15.8,2X,E15.8)') '   Step ', i-1, ': ', self%res(i), self%tol(i)
                call logger%log_message(msg, module=this_module, procedure='newton_metadata')
             end do
-            i = self%eval_counter_record
+            i = size(self%res)
             write(msg,'(A14,E15.8,2X,E15.8)') '   FINAL:', self%res(i), self%tol(i)
             call logger%log_message(msg, module=this_module, procedure='newton_metadata')
         else
-            i = self%eval_counter_record
-            write(msg,'(A30,E20.8)') padr('Residual: ', 30), self%res(i)
+            write(msg,'(A30,E20.8)') padr('Residual: ', 30), self%res(size(self%res))
             call logger%log_message(msg, module=this_module, procedure='newton_metadata')
         end if
         if (self%converged) then
@@ -780,7 +767,6 @@ contains
         class(newton_dp_metadata), intent(inout) :: self
         self%n_iter = 0
         self%eval_counter_record = 0
-        self%eval_counter_all = 0
         self%converged = .false.
         self%info = 0
         if (allocated(self%res)) deallocate(self%res)

--- a/src/Utils.f90
+++ b/src/Utils.f90
@@ -17,6 +17,7 @@ module lightkrylov_utils
     !--------------------------------------------
     use iso_fortran_env, only: output_unit
     use stdlib_optval, only: optval
+    use stdlib_strings, only: padr
     use stdlib_linalg, only: is_hermitian, is_symmetric, diag, svd, eigh
     ! Eigenvalue problem.
     use stdlib_linalg_lapack, only: geev
@@ -463,7 +464,7 @@ contains
         ifreset   = optval(reset_counters, .false.)
         ifverbose = optval(verbose, .false.)
   
-        write(msg,'(A30,I6,"  (",I6,"/",I3,")")') adjustl('Iterations   (inner/outer): '), &
+        write(msg,'(A30,I6,"  (",I6,"/",I3,")")') padr('Iterations   (inner/outer): ', 30), &
                   & self%n_iter, self%n_inner, self%n_outer
         call logger%log_message(msg, module=this_module, procedure='gmres_metadata')
         if (ifverbose) then
@@ -476,9 +477,9 @@ contains
                call logger%log_message(msg, module=this_module, procedure='gmres_metadata')
             end do
         else
-            write(msg,'(A30,I20)') adjustl('Number of records: '), size(self%res)
+            write(msg,'(A30,I20)') padr('Number of records: ', 30), size(self%res)
             call logger%log_message(msg, module=this_module, procedure='gmres_metadata')
-            write(msg,'(A30,E20.8)') adjustl('Residual: '), self%res(size(self%res))
+            write(msg,'(A30,E20.8)') padr('Residual: ', 30), self%res(size(self%res))
             call logger%log_message(msg, module=this_module, procedure='gmres_metadata')
         end if
         if (self%converged) then
@@ -515,7 +516,7 @@ contains
         ifreset   = optval(reset_counters, .false.)
         ifverbose = optval(verbose, .false.)
 
-        write(msg,'(A30,I20)') adjustl('Iterations: '), self%n_iter
+        write(msg,'(A30,I20)') padr('Iterations: ', 30), self%n_iter
         call logger%log_message(msg, module=this_module, procedure='cg_metadata')
         if (ifverbose) then
             write(msg,'(14X,A15)') 'Residual'
@@ -528,9 +529,9 @@ contains
                call logger%log_message(msg, module=this_module, procedure='cg_metadata')
             end do
         else
-            write(msg,'(A30,I20)') adjustl('Number of records: '), size(self%res)
+            write(msg,'(A30,I20)') padr('Number of records: ', 30), size(self%res)
             call logger%log_message(msg, module=this_module, procedure='cg_metadata')
-            write(msg,'(A30,E20.8)') adjustl('Residual: '), self%res(size(self%res))
+            write(msg,'(A30,E20.8)') padr('Residual: ', 30), self%res(size(self%res))
             call logger%log_message(msg, module=this_module, procedure='cg_metadata')
         end if
         if (self%converged) then
@@ -565,9 +566,9 @@ contains
         ifreset   = optval(reset_counters, .false.)
         ifverbose = optval(verbose, .false.)
 
-        write(msg,'(A30,I20)') adjustl('Iterations: '), self%n_iter
+        write(msg,'(A30,I20)') padr('Iterations: ', 30), self%n_iter
         call logger%log_message(msg, module=this_module, procedure='newton_metadata')
-        write(msg,'(A30,I20)') adjustl('System evaluations: '), self%eval_counter_all
+        write(msg,'(A30,I20)') padr('System evaluations: ', 30), self%eval_counter_all
         call logger%log_message(msg, module=this_module, procedure='newton_metadata')
         if (ifverbose) then
             write(msg,'(14X,A15,2X,A15)') 'Residual', 'Tolerance'
@@ -583,7 +584,7 @@ contains
             call logger%log_message(msg, module=this_module, procedure='newton_metadata')
         else
             i = self%eval_counter_record
-            write(msg,'(A30,E20.8)') adjustl('Residual: '), self%res(i)
+            write(msg,'(A30,E20.8)') padr('Residual: ', 30), self%res(i)
             call logger%log_message(msg, module=this_module, procedure='newton_metadata')
         end if
         if (self%converged) then
@@ -643,7 +644,7 @@ contains
         ifreset   = optval(reset_counters, .false.)
         ifverbose = optval(verbose, .false.)
   
-        write(msg,'(A30,I6,"  (",I6,"/",I3,")")') adjustl('Iterations   (inner/outer): '), &
+        write(msg,'(A30,I6,"  (",I6,"/",I3,")")') padr('Iterations   (inner/outer): ', 30), &
                   & self%n_iter, self%n_inner, self%n_outer
         call logger%log_message(msg, module=this_module, procedure='gmres_metadata')
         if (ifverbose) then
@@ -656,9 +657,9 @@ contains
                call logger%log_message(msg, module=this_module, procedure='gmres_metadata')
             end do
         else
-            write(msg,'(A30,I20)') adjustl('Number of records: '), size(self%res)
+            write(msg,'(A30,I20)') padr('Number of records: ', 30), size(self%res)
             call logger%log_message(msg, module=this_module, procedure='gmres_metadata')
-            write(msg,'(A30,E20.8)') adjustl('Residual: '), self%res(size(self%res))
+            write(msg,'(A30,E20.8)') padr('Residual: ', 30), self%res(size(self%res))
             call logger%log_message(msg, module=this_module, procedure='gmres_metadata')
         end if
         if (self%converged) then
@@ -695,7 +696,7 @@ contains
         ifreset   = optval(reset_counters, .false.)
         ifverbose = optval(verbose, .false.)
 
-        write(msg,'(A30,I20)') adjustl('Iterations: '), self%n_iter
+        write(msg,'(A30,I20)') padr('Iterations: ', 30), self%n_iter
         call logger%log_message(msg, module=this_module, procedure='cg_metadata')
         if (ifverbose) then
             write(msg,'(14X,A15)') 'Residual'
@@ -708,9 +709,9 @@ contains
                call logger%log_message(msg, module=this_module, procedure='cg_metadata')
             end do
         else
-            write(msg,'(A30,I20)') adjustl('Number of records: '), size(self%res)
+            write(msg,'(A30,I20)') padr('Number of records: ', 30), size(self%res)
             call logger%log_message(msg, module=this_module, procedure='cg_metadata')
-            write(msg,'(A30,E20.8)') adjustl('Residual: '), self%res(size(self%res))
+            write(msg,'(A30,E20.8)') padr('Residual: ', 30), self%res(size(self%res))
             call logger%log_message(msg, module=this_module, procedure='cg_metadata')
         end if
         if (self%converged) then
@@ -745,9 +746,9 @@ contains
         ifreset   = optval(reset_counters, .false.)
         ifverbose = optval(verbose, .false.)
 
-        write(msg,'(A30,I20)') adjustl('Iterations: '), self%n_iter
+        write(msg,'(A30,I20)') padr('Iterations: ', 30), self%n_iter
         call logger%log_message(msg, module=this_module, procedure='newton_metadata')
-        write(msg,'(A30,I20)') adjustl('System evaluations: '), self%eval_counter_all
+        write(msg,'(A30,I20)') padr('System evaluations: ', 30), self%eval_counter_all
         call logger%log_message(msg, module=this_module, procedure='newton_metadata')
         if (ifverbose) then
             write(msg,'(14X,A15,2X,A15)') 'Residual', 'Tolerance'
@@ -763,7 +764,7 @@ contains
             call logger%log_message(msg, module=this_module, procedure='newton_metadata')
         else
             i = self%eval_counter_record
-            write(msg,'(A30,E20.8)') adjustl('Residual: '), self%res(i)
+            write(msg,'(A30,E20.8)') padr('Residual: ', 30), self%res(i)
             call logger%log_message(msg, module=this_module, procedure='newton_metadata')
         end if
         if (self%converged) then

--- a/src/Utils.fypp
+++ b/src/Utils.fypp
@@ -34,7 +34,8 @@ module lightkrylov_utils
     implicit none
     private
 
-    character(len=128), parameter :: this_module = 'LightKrylov_Utils'
+    character(len=*), parameter :: this_module      = 'LK_Utils'
+    character(len=*), parameter :: this_module_long = 'LightKrylov_Utils'
 
     public :: assert_shape, norml, log2
     ! Compute AX = XD for general dense matrices.
@@ -256,6 +257,49 @@ module lightkrylov_utils
         integer :: maxstep_bisection = 5
         !! Maximum number of bisections (evaluations of F) for step selection (default = 5)
         !! Ignored if ifbisect = .false.
+    end type
+    
+    #:endfor
+
+    type, abstract, public :: abstract_metadata
+        !! Abstract type container for solver metadata from with all others are extended.
+    end type
+
+    #:for kind in REAL_KINDS
+    type, extends(abstract_metadata), public :: gmres_${kind}$_metadata
+        !! GMRES metadata.
+        integer :: n_iter
+        !! Iteration counter
+        integer :: n_Ax
+        !! Matrix-vector product counter
+        integer :: n_inner
+        !! Number of inner iterations
+        integer :: n_outer
+        !! Number of outer iterations
+        real(${kind}$), dimension(:), allocatable :: res
+        !! Residual history
+    end type
+
+    type, extends(abstract_metadata), public :: cg_${kind}$_metadata
+        !! Conjugate gradient metadata.
+        integer :: n_iter
+        !! Iteration counter
+        integer :: n_Ax
+        !! Matrix-vector product counter
+        real(${kind}$), dimension(:), allocatable :: res
+        !! Residual history
+    end type
+
+    type, extends(abstract_metadata), public :: newton_${kind}$_metadata
+        !! Metadata for Newton-Krylov fixed-point iteration.
+        integer :: n_iter
+        !! Iteration counter
+        integer :: n_Ax
+        !! Matrix-vector product counter
+        integer :: n_eval
+        !! System evaluation counter
+        real(${kind}$), dimension(:), allocatable :: res
+        !! Residual history
     end type
     
     #:endfor

--- a/src/Utils.fypp
+++ b/src/Utils.fypp
@@ -268,38 +268,52 @@ module lightkrylov_utils
     #:for kind in REAL_KINDS
     type, extends(abstract_metadata), public :: gmres_${kind}$_metadata
         !! GMRES metadata.
-        integer :: n_iter
+        integer :: n_iter = 0
         !! Iteration counter
-        integer :: n_Ax
+        integer :: n_Ax = 0
         !! Matrix-vector product counter
-        integer :: n_inner
+        integer :: n_inner = 0
         !! Number of inner iterations
-        integer :: n_outer
+        integer :: n_outer = 0
         !! Number of outer iterations
         real(${kind}$), dimension(:), allocatable :: res
         !! Residual history
+        logical :: converged = .false.
+        !! Convergence flag
+        integer :: info = 0
+        !! Copy of the information flag for completeness
     end type
 
     type, extends(abstract_metadata), public :: cg_${kind}$_metadata
         !! Conjugate gradient metadata.
-        integer :: n_iter
+        integer :: n_iter = 0
         !! Iteration counter
-        integer :: n_Ax
+        integer :: n_Ax = 0
         !! Matrix-vector product counter
         real(${kind}$), dimension(:), allocatable :: res
         !! Residual history
+        logical :: converged = .false.
+        !! Convergence flag
+        integer :: info = 0
+        !! Copy of the information flag for completeness
     end type
 
     type, extends(abstract_metadata), public :: newton_${kind}$_metadata
         !! Metadata for Newton-Krylov fixed-point iteration.
-        integer :: n_iter
+        integer :: n_iter = 0
         !! Iteration counter
-        integer :: n_Ax
+        integer :: n_Ax = 0
         !! Matrix-vector product counter
-        integer :: n_eval
+        integer :: n_eval = 0
         !! System evaluation counter
         real(${kind}$), dimension(:), allocatable :: res
         !! Residual history
+        real(${kind}$), dimension(:), allocatable :: tol
+        !! Tolerance history
+        logical :: converged = .false.
+        !! Convergence flag
+        integer :: info = 0
+        !! Copy of the information flag for completeness
     end type
     
     #:endfor

--- a/src/Utils.fypp
+++ b/src/Utils.fypp
@@ -19,6 +19,7 @@ module lightkrylov_utils
     !--------------------------------------------
     use iso_fortran_env, only: output_unit
     use stdlib_optval, only: optval
+    use stdlib_strings, only: padr
     use stdlib_linalg, only: is_hermitian, is_symmetric, diag, svd, eigh
     ! Eigenvalue problem.
     use stdlib_linalg_lapack, only: geev
@@ -372,7 +373,7 @@ contains
         ifreset   = optval(reset_counters, .false.)
         ifverbose = optval(verbose, .false.)
   
-        write(msg,'(A30,I6,"  (",I6,"/",I3,")")') adjustl('Iterations   (inner/outer): '), &
+        write(msg,'(A30,I6,"  (",I6,"/",I3,")")') padr('Iterations   (inner/outer): ', 30), &
                   & self%n_iter, self%n_inner, self%n_outer
         call logger%log_message(msg, module=this_module, procedure='gmres_metadata')
         if (ifverbose) then
@@ -385,9 +386,9 @@ contains
                call logger%log_message(msg, module=this_module, procedure='gmres_metadata')
             end do
         else
-            write(msg,'(A30,I20)') adjustl('Number of records: '), size(self%res)
+            write(msg,'(A30,I20)') padr('Number of records: ', 30), size(self%res)
             call logger%log_message(msg, module=this_module, procedure='gmres_metadata')
-            write(msg,'(A30,E20.8)') adjustl('Residual: '), self%res(size(self%res))
+            write(msg,'(A30,E20.8)') padr('Residual: ', 30), self%res(size(self%res))
             call logger%log_message(msg, module=this_module, procedure='gmres_metadata')
         end if
         if (self%converged) then
@@ -424,7 +425,7 @@ contains
         ifreset   = optval(reset_counters, .false.)
         ifverbose = optval(verbose, .false.)
 
-        write(msg,'(A30,I20)') adjustl('Iterations: '), self%n_iter
+        write(msg,'(A30,I20)') padr('Iterations: ', 30), self%n_iter
         call logger%log_message(msg, module=this_module, procedure='cg_metadata')
         if (ifverbose) then
             write(msg,'(14X,A15)') 'Residual'
@@ -437,9 +438,9 @@ contains
                call logger%log_message(msg, module=this_module, procedure='cg_metadata')
             end do
         else
-            write(msg,'(A30,I20)') adjustl('Number of records: '), size(self%res)
+            write(msg,'(A30,I20)') padr('Number of records: ', 30), size(self%res)
             call logger%log_message(msg, module=this_module, procedure='cg_metadata')
-            write(msg,'(A30,E20.8)') adjustl('Residual: '), self%res(size(self%res))
+            write(msg,'(A30,E20.8)') padr('Residual: ', 30), self%res(size(self%res))
             call logger%log_message(msg, module=this_module, procedure='cg_metadata')
         end if
         if (self%converged) then
@@ -474,9 +475,9 @@ contains
         ifreset   = optval(reset_counters, .false.)
         ifverbose = optval(verbose, .false.)
 
-        write(msg,'(A30,I20)') adjustl('Iterations: '), self%n_iter
+        write(msg,'(A30,I20)') padr('Iterations: ', 30), self%n_iter
         call logger%log_message(msg, module=this_module, procedure='newton_metadata')
-        write(msg,'(A30,I20)') adjustl('System evaluations: '), self%eval_counter_all
+        write(msg,'(A30,I20)') padr('System evaluations: ', 30), self%eval_counter_all
         call logger%log_message(msg, module=this_module, procedure='newton_metadata')
         if (ifverbose) then
             write(msg,'(14X,A15,2X,A15)') 'Residual', 'Tolerance'
@@ -492,7 +493,7 @@ contains
             call logger%log_message(msg, module=this_module, procedure='newton_metadata')
         else
             i = self%eval_counter_record
-            write(msg,'(A30,E20.8)') adjustl('Residual: '), self%res(i)
+            write(msg,'(A30,E20.8)') padr('Residual: ', 30), self%res(i)
             call logger%log_message(msg, module=this_module, procedure='newton_metadata')
         end if
         if (self%converged) then

--- a/src/Utils.fypp
+++ b/src/Utils.fypp
@@ -18,6 +18,7 @@ module lightkrylov_utils
     !-----     Standard Fortran Library     -----
     !--------------------------------------------
     use iso_fortran_env, only: output_unit
+    use stdlib_optval, only: optval
     use stdlib_linalg, only: is_hermitian, is_symmetric, diag, svd, eigh
     ! Eigenvalue problem.
     use stdlib_linalg_lapack, only: geev
@@ -240,12 +241,16 @@ module lightkrylov_utils
         !! Dimension of the Krylov subspace (default: 30).
         integer :: maxiter = 10
         !! Maximum number of `gmres` restarts (default: 10).
+        logical :: if_print_metadata = .false.
+        !! Print interation metadata on exit (default = .false.)
     end type
 
     type, extends(abstract_opts), public :: cg_${kind}$_opts
         !! Conjugate gradient options.
         integer :: maxiter = 100
         !! Maximum number of `cg` iterations (default: 100).
+        logical :: if_print_metadata = .false.
+        !! Print interation metadata on exit (default = .false.)
     end type
 
     type, extends(abstract_opts), public :: newton_${kind}$_opts
@@ -257,21 +262,39 @@ module lightkrylov_utils
         integer :: maxstep_bisection = 5
         !! Maximum number of bisections (evaluations of F) for step selection (default = 5)
         !! Ignored if ifbisect = .false.
+        logical :: if_print_metadata = .false.
+        !! Print interation metadata on exit (default = .false.)
     end type
     
     #:endfor
 
     type, abstract, public :: abstract_metadata
         !! Abstract type container for solver metadata from with all others are extended.
+    contains
+        procedure(abstract_print_metadata), pass(self), deferred, public :: print
+        procedure(abstract_reset_metadata), pass(self), deferred, public :: reset
     end type
+
+    abstract interface
+        subroutine abstract_print_metadata(self, reset_counters, verbose)
+            import abstract_metadata
+            class(abstract_metadata), intent(inout) :: self
+            logical, optional, intent(in) :: reset_counters
+            !! Reset all counters to zero after printing?
+            logical, optional, intent(in) :: verbose
+            !! Print the residual full residual history?
+        end subroutine abstract_print_metadata
+        subroutine abstract_reset_metadata(self)
+            import abstract_metadata
+            class(abstract_metadata), intent(inout) :: self
+        end subroutine abstract_reset_metadata
+    end interface
 
     #:for kind in REAL_KINDS
     type, extends(abstract_metadata), public :: gmres_${kind}$_metadata
         !! GMRES metadata.
         integer :: n_iter = 0
         !! Iteration counter
-        integer :: n_Ax = 0
-        !! Matrix-vector product counter
         integer :: n_inner = 0
         !! Number of inner iterations
         integer :: n_outer = 0
@@ -282,30 +305,36 @@ module lightkrylov_utils
         !! Convergence flag
         integer :: info = 0
         !! Copy of the information flag for completeness
+    contains
+        procedure, pass(self), public :: print => print_gmres_${kind}$
+        procedure, pass(self), public :: reset => reset_gmres_${kind}$
     end type
 
     type, extends(abstract_metadata), public :: cg_${kind}$_metadata
         !! Conjugate gradient metadata.
         integer :: n_iter = 0
         !! Iteration counter
-        integer :: n_Ax = 0
-        !! Matrix-vector product counter
         real(${kind}$), dimension(:), allocatable :: res
         !! Residual history
         logical :: converged = .false.
         !! Convergence flag
         integer :: info = 0
         !! Copy of the information flag for completeness
+    contains
+        procedure, pass(self), public :: print => print_cg_${kind}$
+        procedure, pass(self), public :: reset => reset_cg_${kind}$
     end type
 
     type, extends(abstract_metadata), public :: newton_${kind}$_metadata
         !! Metadata for Newton-Krylov fixed-point iteration.
         integer :: n_iter = 0
         !! Iteration counter
-        integer :: n_Ax = 0
-        !! Matrix-vector product counter
-        integer :: n_eval = 0
-        !! System evaluation counter
+        integer :: eval_counter_record = 0
+        !! System response evaluation counter:
+        !! N.B.: For each of these evals the current residual and tolerance are recorded.
+        integer :: eval_counter_all = 0
+        !! System response evaluation counter, including additional evals for convergence checks and step bisection.
+        !! N.B.: For the additional system evaluations, the residual and tolerance are NOT recorded.
         real(${kind}$), dimension(:), allocatable :: res
         !! Residual history
         real(${kind}$), dimension(:), allocatable :: tol
@@ -314,11 +343,202 @@ module lightkrylov_utils
         !! Convergence flag
         integer :: info = 0
         !! Copy of the information flag for completeness
+    contains
+        procedure, pass(self), public :: print => print_newton_${kind}$
+        procedure, pass(self), public :: reset => reset_newton_${kind}$
+        procedure, pass(self), public :: record => record_data_${kind}$
     end type
-    
+   
     #:endfor
 
 contains
+
+    !------------------------------------------------------
+    !-----     TYPE BOUND PROCEDURES FOR METADATA     -----
+    !------------------------------------------------------
+
+    #:for kind in REAL_KINDS
+    subroutine print_gmres_${kind}$(self, reset_counters, verbose)
+        class(gmres_${kind}$_metadata), intent(inout) :: self
+        logical, optional, intent(in) :: reset_counters
+        !! Reset all counters to zero after printing?
+        logical, optional, intent(in) :: verbose
+        !! Print the residual full residual history?
+        ! internals
+        integer :: i
+        logical :: ifreset, ifverbose
+        character(len=128) :: msg
+
+        ifreset   = optval(reset_counters, .false.)
+        ifverbose = optval(verbose, .false.)
+  
+        write(msg,'(A30,I6,"  (",I6,"/",I3,")")') adjustl('Iterations   (inner/outer): '), &
+                  & self%n_iter, self%n_inner, self%n_outer
+        call logger%log_message(msg, module=this_module, procedure='gmres_metadata')
+        if (ifverbose) then
+            write(msg,'(14X,A15)') 'Residual'
+            call logger%log_message(msg, module=this_module, procedure='gmres_metadata')
+            write(msg,'(A14,E15.8)') '   INIT:', self%res(1)
+            call logger%log_message(msg, module=this_module, procedure='gmres_metadata')
+            do i = 1, self%n_iter
+               write(msg,'(A,I3,A,E20.8)') '   Step ', i, ': ', self%res(i)
+               call logger%log_message(msg, module=this_module, procedure='gmres_metadata')
+            end do
+        else
+            write(msg,'(A30,I20)') adjustl('Number of records: '), size(self%res)
+            call logger%log_message(msg, module=this_module, procedure='gmres_metadata')
+            write(msg,'(A30,E20.8)') adjustl('Residual: '), self%res(size(self%res))
+            call logger%log_message(msg, module=this_module, procedure='gmres_metadata')
+        end if
+        if (self%converged) then
+            call logger%log_message('Status: CONVERGED', module=this_module, procedure='gmres_metadata')
+        else
+            call logger%log_message('Status: NOT CONVERGED', module=this_module, procedure='gmres_metadata')
+        end if
+        if (ifreset) call self%reset()
+        return
+    end subroutine print_gmres_${kind}$
+
+    subroutine reset_gmres_${kind}$(self)
+        class(gmres_${kind}$_metadata), intent(inout) :: self
+        self%n_iter = 0
+        self%n_inner = 0
+        self%n_outer = 0
+        self%converged = .false.
+        self%info = 0
+        if (allocated(self%res)) deallocate(self%res)
+        return
+    end subroutine reset_gmres_${kind}$
+
+    subroutine print_cg_${kind}$(self, reset_counters, verbose)
+        class(cg_${kind}$_metadata), intent(inout) :: self
+        logical, optional, intent(in) :: reset_counters
+        !! Reset all counters to zero after printing?
+        logical, optional, intent(in) :: verbose
+        !! Print the residual full residual history?
+        ! internals
+        integer :: i
+        logical :: ifreset, ifverbose
+        character(len=128) :: msg
+
+        ifreset   = optval(reset_counters, .false.)
+        ifverbose = optval(verbose, .false.)
+
+        write(msg,'(A30,I20)') adjustl('Iterations: '), self%n_iter
+        call logger%log_message(msg, module=this_module, procedure='cg_metadata')
+        if (ifverbose) then
+            write(msg,'(14X,A15)') 'Residual'
+            call logger%log_message(msg, module=this_module, procedure='cg_metadata')
+            call logger%log_message('Residual history:', module=this_module, procedure='cg_metadata')
+            write(msg,'(A14,E15.8)') '   INIT:', self%res(1)
+            call logger%log_message(msg, module=this_module, procedure='cg_metadata')
+            do i = 2, self%n_iter+1
+               write(msg,'(A,I4,A,E15.8)') '   Step ', i-1, ': ', self%res(i)
+               call logger%log_message(msg, module=this_module, procedure='cg_metadata')
+            end do
+        else
+            write(msg,'(A30,I20)') adjustl('Number of records: '), size(self%res)
+            call logger%log_message(msg, module=this_module, procedure='cg_metadata')
+            write(msg,'(A30,E20.8)') adjustl('Residual: '), self%res(size(self%res))
+            call logger%log_message(msg, module=this_module, procedure='cg_metadata')
+        end if
+        if (self%converged) then
+            call logger%log_message('Status: CONVERGED', module=this_module, procedure='cg_metadata')
+        else
+            call logger%log_message('Status: NOT CONVERGED', module=this_module, procedure='cg_metadata')
+        end if
+        if (ifreset) call self%reset()
+        return
+    end subroutine print_cg_${kind}$
+
+    subroutine reset_cg_${kind}$(self)
+        class(cg_${kind}$_metadata), intent(inout) :: self
+        self%n_iter = 0
+        self%converged = .false.
+        self%info = 0
+        if (allocated(self%res)) deallocate(self%res)
+        return
+    end subroutine reset_cg_${kind}$
+
+    subroutine print_newton_${kind}$(self, reset_counters, verbose)
+        class(newton_${kind}$_metadata), intent(inout) :: self
+        logical, optional, intent(in) :: reset_counters
+        !! Reset all counters to zero after printing?
+        logical, optional, intent(in) :: verbose
+        !! Print the residual full residual history?
+        ! internals
+        integer :: i
+        logical :: ifreset, ifverbose
+        character(len=128) :: msg
+
+        ifreset   = optval(reset_counters, .false.)
+        ifverbose = optval(verbose, .false.)
+
+        write(msg,'(A30,I20)') adjustl('Iterations: '), self%n_iter
+        call logger%log_message(msg, module=this_module, procedure='newton_metadata')
+        write(msg,'(A30,I20)') adjustl('System evaluations: '), self%eval_counter_all
+        call logger%log_message(msg, module=this_module, procedure='newton_metadata')
+        if (ifverbose) then
+            write(msg,'(14X,A15,2X,A15)') 'Residual', 'Tolerance'
+            call logger%log_message(msg, module=this_module, procedure='newton_metadata')
+            write(msg,'(A14,E15.8,2X,E15.8)') '   INIT:', self%res(1), self%tol(1)
+            call logger%log_message(msg, module=this_module, procedure='newton_metadata')
+            do i = 2, self%eval_counter_record - 1
+               write(msg,'(A,I4,A,E15.8,2X,E15.8)') '   Step ', i-1, ': ', self%res(i), self%tol(i)
+               call logger%log_message(msg, module=this_module, procedure='newton_metadata')
+            end do
+            i = self%eval_counter_record
+            write(msg,'(A14,E15.8,2X,E15.8)') '   FINAL:', self%res(i), self%tol(i)
+            call logger%log_message(msg, module=this_module, procedure='newton_metadata')
+        else
+            i = self%eval_counter_record
+            write(msg,'(A30,E20.8)') adjustl('Residual: '), self%res(i)
+            call logger%log_message(msg, module=this_module, procedure='newton_metadata')
+        end if
+        if (self%converged) then
+            call logger%log_message('Status: CONVERGED', module=this_module, procedure='newton_metadata')
+        else
+            call logger%log_message('Status: NOT CONVERGED', module=this_module, procedure='newton_metadata')
+        end if
+        if (ifreset) call self%reset()
+        return
+    end subroutine print_newton_${kind}$
+
+    subroutine reset_newton_${kind}$(self)
+        class(newton_${kind}$_metadata), intent(inout) :: self
+        self%n_iter = 0
+        self%eval_counter_record = 0
+        self%eval_counter_all = 0
+        self%converged = .false.
+        self%info = 0
+        if (allocated(self%res)) deallocate(self%res)
+        if (allocated(self%tol)) deallocate(self%tol)
+        return
+    end subroutine reset_newton_${kind}$
+
+    subroutine record_data_${kind}$(self, res, tol)
+        class(newton_${kind}$_metadata), intent(inout) :: self
+        real(${kind}$) :: res
+        !! Residual of the current evaluation
+        real(${kind}$) :: tol
+        !! Tolerance of the current evaluation
+        if (.not.allocated(self%res)) then
+            allocate(self%res(1))
+            self%res(1) = res
+        else
+            self%res = [ self%res, res ]
+        end if
+        if (.not.allocated(self%tol)) then
+            allocate(self%tol(1))
+            self%tol(1) = tol
+        else
+            self%tol = [ self%tol, tol ]
+        end if
+        self%eval_counter_record = self%eval_counter_record + 1
+        return
+    end subroutine record_data_${kind}$
+
+    #:endfor
 
     !-------------------------------------
     !-----     VARIOUS UTILITIES     -----

--- a/src/Utils.fypp
+++ b/src/Utils.fypp
@@ -333,9 +333,6 @@ module lightkrylov_utils
         integer :: eval_counter_record = 0
         !! System response evaluation counter:
         !! N.B.: For each of these evals the current residual and tolerance are recorded.
-        integer :: eval_counter_all = 0
-        !! System response evaluation counter, including additional evals for convergence checks and step bisection.
-        !! N.B.: For the additional system evaluations, the residual and tolerance are NOT recorded.
         real(${kind}$), dimension(:), allocatable :: res
         !! Residual history
         real(${kind}$), dimension(:), allocatable :: tol
@@ -477,23 +474,20 @@ contains
 
         write(msg,'(A30,I20)') padr('Iterations: ', 30), self%n_iter
         call logger%log_message(msg, module=this_module, procedure='newton_metadata')
-        write(msg,'(A30,I20)') padr('System evaluations: ', 30), self%eval_counter_all
-        call logger%log_message(msg, module=this_module, procedure='newton_metadata')
         if (ifverbose) then
             write(msg,'(14X,A15,2X,A15)') 'Residual', 'Tolerance'
             call logger%log_message(msg, module=this_module, procedure='newton_metadata')
             write(msg,'(A14,E15.8,2X,E15.8)') '   INIT:', self%res(1), self%tol(1)
             call logger%log_message(msg, module=this_module, procedure='newton_metadata')
-            do i = 2, self%eval_counter_record - 1
+            do i = 2, size(self%res) - 1
                write(msg,'(A,I4,A,E15.8,2X,E15.8)') '   Step ', i-1, ': ', self%res(i), self%tol(i)
                call logger%log_message(msg, module=this_module, procedure='newton_metadata')
             end do
-            i = self%eval_counter_record
+            i = size(self%res)
             write(msg,'(A14,E15.8,2X,E15.8)') '   FINAL:', self%res(i), self%tol(i)
             call logger%log_message(msg, module=this_module, procedure='newton_metadata')
         else
-            i = self%eval_counter_record
-            write(msg,'(A30,E20.8)') padr('Residual: ', 30), self%res(i)
+            write(msg,'(A30,E20.8)') padr('Residual: ', 30), self%res(size(self%res))
             call logger%log_message(msg, module=this_module, procedure='newton_metadata')
         end if
         if (self%converged) then
@@ -509,7 +503,6 @@ contains
         class(newton_${kind}$_metadata), intent(inout) :: self
         self%n_iter = 0
         self%eval_counter_record = 0
-        self%eval_counter_all = 0
         self%converged = .false.
         self%info = 0
         if (allocated(self%res)) deallocate(self%res)

--- a/test/TestExpmlib.f90
+++ b/test/TestExpmlib.f90
@@ -18,7 +18,8 @@ module TestExpmlib
 
     private
 
-    character(len=128), parameter, private :: this_module = 'LightKrylov_TestExpmLib'
+    character(len=*), parameter, private :: this_module      = 'LK_TExpmLib'
+    character(len=*), parameter, private :: this_module_long = 'LightKrylov_TestExpmLib'
 
     public :: collect_expm_rsp_testsuite
     public :: collect_expm_rdp_testsuite

--- a/test/TestExpmlib.f90
+++ b/test/TestExpmlib.f90
@@ -115,7 +115,7 @@ contains
 
         ! Krylov exponential.
         call kexpm(Xkryl, A, Q, tau, rtol_sp, info, kdim=nkmax)
-        call check_info(info, 'kexpm', module=this_module, procedure='test_kexptA_rsp')
+        call check_info(info, 'kexpm', module=this_module_long, procedure='test_kexptA_rsp')
 
         ! Check result.
         call Xkryl%sub(Xref) ; err = Xkryl%norm()
@@ -178,12 +178,12 @@ contains
         ! Compute Krylov matrix exponential using sequential arnoldi method for each input column
         do i = 1,p
             call kexpm(C(i), A, B(i), tau, tol, info, kdim=nkmax)
-            call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_rsp, 1')
+            call check_info(info, 'kexpm', module=this_module_long, procedure='test_block_kexptA_rsp, 1')
         end do
         
         ! Compute Krylov matrix exponential using block-arnoldi method
         call kexpm(Cblk, A, B, tau, tol, info, kdim=nkmax)
-        call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_rsp, 2')
+        call check_info(info, 'kexpm', module=this_module_long, procedure='test_block_kexptA_rsp, 2')
     
         do i = 1, p
             write(output_unit, *) C(i)%norm(), Cblk(i)%norm()
@@ -293,7 +293,7 @@ contains
 
         ! Krylov exponential.
         call kexpm(Xkryl, A, Q, tau, rtol_dp, info, kdim=nkmax)
-        call check_info(info, 'kexpm', module=this_module, procedure='test_kexptA_rdp')
+        call check_info(info, 'kexpm', module=this_module_long, procedure='test_kexptA_rdp')
 
         ! Check result.
         call Xkryl%sub(Xref) ; err = Xkryl%norm()
@@ -356,12 +356,12 @@ contains
         ! Compute Krylov matrix exponential using sequential arnoldi method for each input column
         do i = 1,p
             call kexpm(C(i), A, B(i), tau, tol, info, kdim=nkmax)
-            call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_rdp, 1')
+            call check_info(info, 'kexpm', module=this_module_long, procedure='test_block_kexptA_rdp, 1')
         end do
         
         ! Compute Krylov matrix exponential using block-arnoldi method
         call kexpm(Cblk, A, B, tau, tol, info, kdim=nkmax)
-        call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_rdp, 2')
+        call check_info(info, 'kexpm', module=this_module_long, procedure='test_block_kexptA_rdp, 2')
     
         do i = 1, p
             write(output_unit, *) C(i)%norm(), Cblk(i)%norm()
@@ -471,7 +471,7 @@ contains
 
         ! Krylov exponential.
         call kexpm(Xkryl, A, Q, tau, rtol_sp, info, kdim=nkmax)
-        call check_info(info, 'kexpm', module=this_module, procedure='test_kexptA_csp')
+        call check_info(info, 'kexpm', module=this_module_long, procedure='test_kexptA_csp')
 
         ! Check result.
         call Xkryl%sub(Xref) ; err = Xkryl%norm()
@@ -534,12 +534,12 @@ contains
         ! Compute Krylov matrix exponential using sequential arnoldi method for each input column
         do i = 1,p
             call kexpm(C(i), A, B(i), tau, tol, info, kdim=nkmax)
-            call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_csp, 1')
+            call check_info(info, 'kexpm', module=this_module_long, procedure='test_block_kexptA_csp, 1')
         end do
         
         ! Compute Krylov matrix exponential using block-arnoldi method
         call kexpm(Cblk, A, B, tau, tol, info, kdim=nkmax)
-        call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_csp, 2')
+        call check_info(info, 'kexpm', module=this_module_long, procedure='test_block_kexptA_csp, 2')
     
         do i = 1, p
             write(output_unit, *) C(i)%norm(), Cblk(i)%norm()
@@ -649,7 +649,7 @@ contains
 
         ! Krylov exponential.
         call kexpm(Xkryl, A, Q, tau, rtol_dp, info, kdim=nkmax)
-        call check_info(info, 'kexpm', module=this_module, procedure='test_kexptA_cdp')
+        call check_info(info, 'kexpm', module=this_module_long, procedure='test_kexptA_cdp')
 
         ! Check result.
         call Xkryl%sub(Xref) ; err = Xkryl%norm()
@@ -712,12 +712,12 @@ contains
         ! Compute Krylov matrix exponential using sequential arnoldi method for each input column
         do i = 1,p
             call kexpm(C(i), A, B(i), tau, tol, info, kdim=nkmax)
-            call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_cdp, 1')
+            call check_info(info, 'kexpm', module=this_module_long, procedure='test_block_kexptA_cdp, 1')
         end do
         
         ! Compute Krylov matrix exponential using block-arnoldi method
         call kexpm(Cblk, A, B, tau, tol, info, kdim=nkmax)
-        call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_cdp, 2')
+        call check_info(info, 'kexpm', module=this_module_long, procedure='test_block_kexptA_cdp, 2')
     
         do i = 1, p
             write(output_unit, *) C(i)%norm(), Cblk(i)%norm()
@@ -793,7 +793,7 @@ contains
      
        ! compute matrix square root
        call sqrtm(A, sqrtmA, info)
-       call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_def_rsp')
+       call check_info(info, 'sqrtm', module=this_module_long, procedure='test_dense_sqrtm_pos_def_rsp')
     
        err = maxval(matmul(sqrtmA, sqrtmA) - A)
        call get_err_str(msg, "max err: ", err)
@@ -833,7 +833,7 @@ contains
     
        ! compute matrix square root
        call sqrtm(A, sqrtmA, info)
-       call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_semi_def_rsp')
+       call check_info(info, 'sqrtm', module=this_module_long, procedure='test_dense_sqrtm_pos_semi_def_rsp')
     
        err = maxval(matmul(sqrtmA, sqrtmA) - A)
        call get_err_str(msg, "max err: ", err)
@@ -883,7 +883,7 @@ contains
      
        ! compute matrix square root
        call sqrtm(A, sqrtmA, info)
-       call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_def_rdp')
+       call check_info(info, 'sqrtm', module=this_module_long, procedure='test_dense_sqrtm_pos_def_rdp')
     
        err = maxval(matmul(sqrtmA, sqrtmA) - A)
        call get_err_str(msg, "max err: ", err)
@@ -923,7 +923,7 @@ contains
     
        ! compute matrix square root
        call sqrtm(A, sqrtmA, info)
-       call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_semi_def_rdp')
+       call check_info(info, 'sqrtm', module=this_module_long, procedure='test_dense_sqrtm_pos_semi_def_rdp')
     
        err = maxval(matmul(sqrtmA, sqrtmA) - A)
        call get_err_str(msg, "max err: ", err)
@@ -974,7 +974,7 @@ contains
      
        ! compute matrix square root
        call sqrtm(A, sqrtmA, info)
-       call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_def_csp')
+       call check_info(info, 'sqrtm', module=this_module_long, procedure='test_dense_sqrtm_pos_def_csp')
     
        err =  maxval(abs(matmul(sqrtmA, sqrtmA) - A))
        call get_err_str(msg, "max err: ", err)
@@ -1015,7 +1015,7 @@ contains
     
        ! compute matrix square root
        call sqrtm(A, sqrtmA, info)
-       call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_semi_def_csp')
+       call check_info(info, 'sqrtm', module=this_module_long, procedure='test_dense_sqrtm_pos_semi_def_csp')
     
        err = maxval(abs(matmul(sqrtmA, sqrtmA) - A))
        call get_err_str(msg, "max err: ", err)
@@ -1066,7 +1066,7 @@ contains
      
        ! compute matrix square root
        call sqrtm(A, sqrtmA, info)
-       call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_def_cdp')
+       call check_info(info, 'sqrtm', module=this_module_long, procedure='test_dense_sqrtm_pos_def_cdp')
     
        err =  maxval(abs(matmul(sqrtmA, sqrtmA) - A))
        call get_err_str(msg, "max err: ", err)
@@ -1107,7 +1107,7 @@ contains
     
        ! compute matrix square root
        call sqrtm(A, sqrtmA, info)
-       call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_semi_def_cdp')
+       call check_info(info, 'sqrtm', module=this_module_long, procedure='test_dense_sqrtm_pos_semi_def_cdp')
     
        err = maxval(abs(matmul(sqrtmA, sqrtmA) - A))
        call get_err_str(msg, "max err: ", err)

--- a/test/TestExpmlib.fypp
+++ b/test/TestExpmlib.fypp
@@ -116,7 +116,7 @@ contains
 
         ! Krylov exponential.
         call kexpm(Xkryl, A, Q, tau, rtol_${kind}$, info, kdim=nkmax)
-        call check_info(info, 'kexpm', module=this_module, procedure='test_kexptA_${type[0]}$${kind}$')
+        call check_info(info, 'kexpm', module=this_module_long, procedure='test_kexptA_${type[0]}$${kind}$')
 
         ! Check result.
         call Xkryl%sub(Xref) ; err = Xkryl%norm()
@@ -179,12 +179,12 @@ contains
         ! Compute Krylov matrix exponential using sequential arnoldi method for each input column
         do i = 1,p
             call kexpm(C(i), A, B(i), tau, tol, info, kdim=nkmax)
-            call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_${type[0]}$${kind}$, 1')
+            call check_info(info, 'kexpm', module=this_module_long, procedure='test_block_kexptA_${type[0]}$${kind}$, 1')
         end do
         
         ! Compute Krylov matrix exponential using block-arnoldi method
         call kexpm(Cblk, A, B, tau, tol, info, kdim=nkmax)
-        call check_info(info, 'kexpm', module=this_module, procedure='test_block_kexptA_${type[0]}$${kind}$, 2')
+        call check_info(info, 'kexpm', module=this_module_long, procedure='test_block_kexptA_${type[0]}$${kind}$, 2')
     
         do i = 1, p
             write(output_unit, *) C(i)%norm(), Cblk(i)%norm()
@@ -275,7 +275,7 @@ contains
      
        ! compute matrix square root
        call sqrtm(A, sqrtmA, info)
-       call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_def_${type[0]}$${kind}$')
+       call check_info(info, 'sqrtm', module=this_module_long, procedure='test_dense_sqrtm_pos_def_${type[0]}$${kind}$')
     
        #:if type[0] == "r"
        err = maxval(matmul(sqrtmA, sqrtmA) - A)
@@ -334,7 +334,7 @@ contains
     
        ! compute matrix square root
        call sqrtm(A, sqrtmA, info)
-       call check_info(info, 'sqrtm', module=this_module, procedure='test_dense_sqrtm_pos_semi_def_${type[0]}$${kind}$')
+       call check_info(info, 'sqrtm', module=this_module_long, procedure='test_dense_sqrtm_pos_semi_def_${type[0]}$${kind}$')
     
        #:if type[0] == "r"
        err = maxval(matmul(sqrtmA, sqrtmA) - A)

--- a/test/TestExpmlib.fypp
+++ b/test/TestExpmlib.fypp
@@ -20,7 +20,8 @@ module TestExpmlib
 
     private
 
-    character(len=128), parameter, private :: this_module = 'LightKrylov_TestExpmLib'
+    character(len=*), parameter, private :: this_module      = 'LK_TExpmLib'
+    character(len=*), parameter, private :: this_module_long = 'LightKrylov_TestExpmLib'
 
     #:for kind, type in RC_KINDS_TYPES
     public :: collect_expm_${type[0]}$${kind}$_testsuite

--- a/test/TestIterativeSolvers.f90
+++ b/test/TestIterativeSolvers.f90
@@ -118,7 +118,7 @@ contains
         !allocate(AX(nev))
         !allocate(eigvec_residuals(test_size, nev))
         !do i = 1, nev
-        !    call A%matvec(X(i), AX(i))
+        !    call A%apply_matvec(X(i), AX(i))
         !    eigvec_residuals(:, i) = AX(i)%data - eigvals(i)*X(i)%data
         !end do
         !err = norm2(abs(eigvec_residuals))
@@ -191,7 +191,7 @@ contains
 !        allocate(AX(test_size))
 !        allocate(eigvec_residuals(test_size, test_size)); eigvec_residuals = zero_csp
 !        do i = 1, test_size
-!            call A%matvec(X(i), AX(i))
+!            call A%apply_matvec(X(i), AX(i))
 !            eigvec_residuals(:, i) = AX(i)%data - eigvals(i)*X(i)%data
 !        end do
 !        err = norm2(abs(eigvec_residuals))
@@ -267,7 +267,7 @@ contains
         allocate(AX(test_size))
         allocate(eigvec_residuals(test_size, test_size)); eigvec_residuals = zero_csp
         do i = 1, test_size
-            call A%matvec(X(i), AX(i))
+            call A%apply_matvec(X(i), AX(i))
             eigvec_residuals(:, i) = AX(i)%data - evals(i)*X(i)%data
         end do
         err = norm2(abs(eigvec_residuals))
@@ -361,7 +361,7 @@ contains
         !allocate(AX(nev))
         !allocate(eigvec_residuals(test_size, nev))
         !do i = 1, nev
-        !    call A%matvec(X(i), AX(i))
+        !    call A%apply_matvec(X(i), AX(i))
         !    eigvec_residuals(:, i) = AX(i)%data - eigvals(i)*X(i)%data
         !end do
         !err = norm2(abs(eigvec_residuals))
@@ -434,7 +434,7 @@ contains
 !        allocate(AX(test_size))
 !        allocate(eigvec_residuals(test_size, test_size)); eigvec_residuals = zero_cdp
 !        do i = 1, test_size
-!            call A%matvec(X(i), AX(i))
+!            call A%apply_matvec(X(i), AX(i))
 !            eigvec_residuals(:, i) = AX(i)%data - eigvals(i)*X(i)%data
 !        end do
 !        err = norm2(abs(eigvec_residuals))
@@ -510,7 +510,7 @@ contains
         allocate(AX(test_size))
         allocate(eigvec_residuals(test_size, test_size)); eigvec_residuals = zero_cdp
         do i = 1, test_size
-            call A%matvec(X(i), AX(i))
+            call A%apply_matvec(X(i), AX(i))
             eigvec_residuals(:, i) = AX(i)%data - evals(i)*X(i)%data
         end do
         err = norm2(abs(eigvec_residuals))
@@ -954,7 +954,7 @@ contains
         x = vector_rsp() ; call x%zero()
 
         ! GMRES solver.
-        opts = gmres_sp_opts(kdim=test_size)
+        opts = gmres_sp_opts(kdim=test_size, if_print_metadata=.true.)
         call gmres(A, b, x, info, rtol=rtol_sp, atol=atol_sp, options=opts, meta=meta)
         call check_info(info, 'gmres', module=this_module_long, procedure='test_gmres_rsp')
 
@@ -990,7 +990,7 @@ contains
         x = vector_rsp() ; call x%zero()
 
         ! GMRES solver.
-        opts = gmres_sp_opts(kdim=test_size)
+        opts = gmres_sp_opts(kdim=test_size, if_print_metadata=.true.)
         call gmres(A, b, x, info, rtol=rtol_sp, atol=atol_sp, options=opts, meta=meta)
         call check_info(info, 'gmres', module=this_module_long, procedure='test_gmres_spd_rsp')
 
@@ -1035,7 +1035,7 @@ contains
         x = vector_rdp() ; call x%zero()
 
         ! GMRES solver.
-        opts = gmres_dp_opts(kdim=test_size)
+        opts = gmres_dp_opts(kdim=test_size, if_print_metadata=.true.)
         call gmres(A, b, x, info, rtol=rtol_dp, atol=atol_dp, options=opts, meta=meta)
         call check_info(info, 'gmres', module=this_module_long, procedure='test_gmres_rdp')
 
@@ -1071,7 +1071,7 @@ contains
         x = vector_rdp() ; call x%zero()
 
         ! GMRES solver.
-        opts = gmres_dp_opts(kdim=test_size)
+        opts = gmres_dp_opts(kdim=test_size, if_print_metadata=.true.)
         call gmres(A, b, x, info, rtol=rtol_dp, atol=atol_dp, options=opts, meta=meta)
         call check_info(info, 'gmres', module=this_module_long, procedure='test_gmres_spd_rdp')
 
@@ -1116,7 +1116,7 @@ contains
         x = vector_csp() ; call x%zero()
 
         ! GMRES solver.
-        opts = gmres_sp_opts(kdim=test_size)
+        opts = gmres_sp_opts(kdim=test_size, if_print_metadata=.true.)
         call gmres(A, b, x, info, rtol=rtol_sp, atol=atol_sp, options=opts, meta=meta)
         call check_info(info, 'gmres', module=this_module_long, procedure='test_gmres_csp')
 
@@ -1152,7 +1152,7 @@ contains
         x = vector_csp() ; call x%zero()
 
         ! GMRES solver.
-        opts = gmres_sp_opts(kdim=test_size)
+        opts = gmres_sp_opts(kdim=test_size, if_print_metadata=.true.)
         call gmres(A, b, x, info, rtol=rtol_sp, atol=atol_sp, options=opts, meta=meta)
         call check_info(info, 'gmres', module=this_module_long, procedure='test_gmres_spd_csp')
 
@@ -1197,7 +1197,7 @@ contains
         x = vector_cdp() ; call x%zero()
 
         ! GMRES solver.
-        opts = gmres_dp_opts(kdim=test_size)
+        opts = gmres_dp_opts(kdim=test_size, if_print_metadata=.true.)
         call gmres(A, b, x, info, rtol=rtol_dp, atol=atol_dp, options=opts, meta=meta)
         call check_info(info, 'gmres', module=this_module_long, procedure='test_gmres_cdp')
 
@@ -1233,7 +1233,7 @@ contains
         x = vector_cdp() ; call x%zero()
 
         ! GMRES solver.
-        opts = gmres_dp_opts(kdim=test_size)
+        opts = gmres_dp_opts(kdim=test_size, if_print_metadata=.true.)
         call gmres(A, b, x, info, rtol=rtol_dp, atol=atol_dp, options=opts, meta=meta)
         call check_info(info, 'gmres', module=this_module_long, procedure='test_gmres_spd_cdp')
 
@@ -1282,7 +1282,7 @@ contains
         x = vector_rsp() ; call x%zero()
 
         ! CG solver.
-        opts = cg_sp_opts(maxiter=2*test_size)
+        opts = cg_sp_opts(maxiter=2*test_size, if_print_metadata=.true.)
         call cg(A, b, x, info, rtol=rtol_sp, atol=atol_sp, options=opts, meta=meta)
         call check_info(info, 'cg', module=this_module_long, procedure='test_cg_rsp')
 
@@ -1326,7 +1326,7 @@ contains
         x = vector_rdp() ; call x%zero()
 
         ! CG solver.
-        opts = cg_dp_opts(maxiter=2*test_size)
+        opts = cg_dp_opts(maxiter=2*test_size, if_print_metadata=.true.)
         call cg(A, b, x, info, rtol=rtol_dp, atol=atol_dp, options=opts, meta=meta)
         call check_info(info, 'cg', module=this_module_long, procedure='test_cg_rdp')
 
@@ -1370,7 +1370,7 @@ contains
         x = vector_csp() ; call x%zero()
 
         ! CG solver.
-        opts = cg_sp_opts(maxiter=2*test_size)
+        opts = cg_sp_opts(maxiter=2*test_size, if_print_metadata=.true.)
         call cg(A, b, x, info, rtol=rtol_sp, atol=atol_sp, options=opts, meta=meta)
         call check_info(info, 'cg', module=this_module_long, procedure='test_cg_csp')
 
@@ -1414,7 +1414,7 @@ contains
         x = vector_cdp() ; call x%zero()
 
         ! CG solver.
-        opts = cg_dp_opts(maxiter=2*test_size)
+        opts = cg_dp_opts(maxiter=2*test_size, if_print_metadata=.true.)
         call cg(A, b, x, info, rtol=rtol_dp, atol=atol_dp, options=opts, meta=meta)
         call check_info(info, 'cg', module=this_module_long, procedure='test_cg_cdp')
 

--- a/test/TestIterativeSolvers.f90
+++ b/test/TestIterativeSolvers.f90
@@ -940,6 +940,8 @@ contains
         type(vector_rsp), allocatable :: x ! Solution vector.
         ! GMRES options.
         type(gmres_sp_opts) :: opts
+        ! GMRES metadata.
+        type(gmres_sp_metadata) :: meta
         ! Information flag.
         integer :: info
         ! Misc
@@ -953,7 +955,7 @@ contains
 
         ! GMRES solver.
         opts = gmres_sp_opts(kdim=test_size)
-        call gmres(A, b, x, info, rtol=rtol_sp, atol=atol_sp, options=opts)
+        call gmres(A, b, x, info, rtol=rtol_sp, atol=atol_sp, options=opts, meta=meta)
         call check_info(info, 'gmres', module=this_module, procedure='test_gmres_rsp')
 
         ! Check convergence.
@@ -974,6 +976,8 @@ contains
         type(vector_rsp), allocatable :: x ! Solution vector.
         ! GMRES options.
         type(gmres_sp_opts) :: opts
+        ! GMRES metadata.
+        type(gmres_sp_metadata) :: meta
         ! Information flag.
         integer :: info
         ! Misc
@@ -987,7 +991,7 @@ contains
 
         ! GMRES solver.
         opts = gmres_sp_opts(kdim=test_size)
-        call gmres(A, b, x, info, rtol=rtol_sp, atol=atol_sp, options=opts)
+        call gmres(A, b, x, info, rtol=rtol_sp, atol=atol_sp, options=opts, meta=meta)
         call check_info(info, 'gmres', module=this_module, procedure='test_gmres_spd_rsp')
 
         ! Check convergence.
@@ -1017,6 +1021,8 @@ contains
         type(vector_rdp), allocatable :: x ! Solution vector.
         ! GMRES options.
         type(gmres_dp_opts) :: opts
+        ! GMRES metadata.
+        type(gmres_dp_metadata) :: meta
         ! Information flag.
         integer :: info
         ! Misc
@@ -1030,7 +1036,7 @@ contains
 
         ! GMRES solver.
         opts = gmres_dp_opts(kdim=test_size)
-        call gmres(A, b, x, info, rtol=rtol_dp, atol=atol_dp, options=opts)
+        call gmres(A, b, x, info, rtol=rtol_dp, atol=atol_dp, options=opts, meta=meta)
         call check_info(info, 'gmres', module=this_module, procedure='test_gmres_rdp')
 
         ! Check convergence.
@@ -1051,6 +1057,8 @@ contains
         type(vector_rdp), allocatable :: x ! Solution vector.
         ! GMRES options.
         type(gmres_dp_opts) :: opts
+        ! GMRES metadata.
+        type(gmres_dp_metadata) :: meta
         ! Information flag.
         integer :: info
         ! Misc
@@ -1064,7 +1072,7 @@ contains
 
         ! GMRES solver.
         opts = gmres_dp_opts(kdim=test_size)
-        call gmres(A, b, x, info, rtol=rtol_dp, atol=atol_dp, options=opts)
+        call gmres(A, b, x, info, rtol=rtol_dp, atol=atol_dp, options=opts, meta=meta)
         call check_info(info, 'gmres', module=this_module, procedure='test_gmres_spd_rdp')
 
         ! Check convergence.
@@ -1094,6 +1102,8 @@ contains
         type(vector_csp), allocatable :: x ! Solution vector.
         ! GMRES options.
         type(gmres_sp_opts) :: opts
+        ! GMRES metadata.
+        type(gmres_sp_metadata) :: meta
         ! Information flag.
         integer :: info
         ! Misc
@@ -1107,7 +1117,7 @@ contains
 
         ! GMRES solver.
         opts = gmres_sp_opts(kdim=test_size)
-        call gmres(A, b, x, info, rtol=rtol_sp, atol=atol_sp, options=opts)
+        call gmres(A, b, x, info, rtol=rtol_sp, atol=atol_sp, options=opts, meta=meta)
         call check_info(info, 'gmres', module=this_module, procedure='test_gmres_csp')
 
         ! Check convergence.
@@ -1128,6 +1138,8 @@ contains
         type(vector_csp), allocatable :: x ! Solution vector.
         ! GMRES options.
         type(gmres_sp_opts) :: opts
+        ! GMRES metadata.
+        type(gmres_sp_metadata) :: meta
         ! Information flag.
         integer :: info
         ! Misc
@@ -1141,7 +1153,7 @@ contains
 
         ! GMRES solver.
         opts = gmres_sp_opts(kdim=test_size)
-        call gmres(A, b, x, info, rtol=rtol_sp, atol=atol_sp, options=opts)
+        call gmres(A, b, x, info, rtol=rtol_sp, atol=atol_sp, options=opts, meta=meta)
         call check_info(info, 'gmres', module=this_module, procedure='test_gmres_spd_csp')
 
         ! Check convergence.
@@ -1171,6 +1183,8 @@ contains
         type(vector_cdp), allocatable :: x ! Solution vector.
         ! GMRES options.
         type(gmres_dp_opts) :: opts
+        ! GMRES metadata.
+        type(gmres_dp_metadata) :: meta
         ! Information flag.
         integer :: info
         ! Misc
@@ -1184,7 +1198,7 @@ contains
 
         ! GMRES solver.
         opts = gmres_dp_opts(kdim=test_size)
-        call gmres(A, b, x, info, rtol=rtol_dp, atol=atol_dp, options=opts)
+        call gmres(A, b, x, info, rtol=rtol_dp, atol=atol_dp, options=opts, meta=meta)
         call check_info(info, 'gmres', module=this_module, procedure='test_gmres_cdp')
 
         ! Check convergence.
@@ -1205,6 +1219,8 @@ contains
         type(vector_cdp), allocatable :: x ! Solution vector.
         ! GMRES options.
         type(gmres_dp_opts) :: opts
+        ! GMRES metadata.
+        type(gmres_dp_metadata) :: meta
         ! Information flag.
         integer :: info
         ! Misc
@@ -1218,7 +1234,7 @@ contains
 
         ! GMRES solver.
         opts = gmres_dp_opts(kdim=test_size)
-        call gmres(A, b, x, info, rtol=rtol_dp, atol=atol_dp, options=opts)
+        call gmres(A, b, x, info, rtol=rtol_dp, atol=atol_dp, options=opts, meta=meta)
         call check_info(info, 'gmres', module=this_module, procedure='test_gmres_spd_cdp')
 
         ! Check convergence.
@@ -1250,7 +1266,10 @@ contains
         type(spd_linop_rsp), allocatable :: A
         type(vector_rsp), allocatable :: b
         type(vector_rsp), allocatable :: x
+        ! CG options.
         type(cg_sp_opts) :: opts
+        ! CG metadata.
+        type(cg_sp_metadata) :: meta
         ! Information flag
         integer :: info
         ! Misc
@@ -1264,7 +1283,7 @@ contains
 
         ! CG solver.
         opts = cg_sp_opts(maxiter=2*test_size)
-        call cg(A, b, x, info, rtol=rtol_sp, atol=atol_sp, options=opts)
+        call cg(A, b, x, info, rtol=rtol_sp, atol=atol_sp, options=opts, meta=meta)
         call check_info(info, 'cg', module=this_module, procedure='test_cg_rsp')
 
         ! Check convergence.
@@ -1291,7 +1310,10 @@ contains
         type(spd_linop_rdp), allocatable :: A
         type(vector_rdp), allocatable :: b
         type(vector_rdp), allocatable :: x
+        ! CG options.
         type(cg_dp_opts) :: opts
+        ! CG metadata.
+        type(cg_dp_metadata) :: meta
         ! Information flag
         integer :: info
         ! Misc
@@ -1305,7 +1327,7 @@ contains
 
         ! CG solver.
         opts = cg_dp_opts(maxiter=2*test_size)
-        call cg(A, b, x, info, rtol=rtol_dp, atol=atol_dp, options=opts)
+        call cg(A, b, x, info, rtol=rtol_dp, atol=atol_dp, options=opts, meta=meta)
         call check_info(info, 'cg', module=this_module, procedure='test_cg_rdp')
 
         ! Check convergence.
@@ -1332,7 +1354,10 @@ contains
         type(hermitian_linop_csp), allocatable :: A
         type(vector_csp), allocatable :: b
         type(vector_csp), allocatable :: x
+        ! CG options.
         type(cg_sp_opts) :: opts
+        ! CG metadata.
+        type(cg_sp_metadata) :: meta
         ! Information flag
         integer :: info
         ! Misc
@@ -1346,7 +1371,7 @@ contains
 
         ! CG solver.
         opts = cg_sp_opts(maxiter=2*test_size)
-        call cg(A, b, x, info, rtol=rtol_sp, atol=atol_sp, options=opts)
+        call cg(A, b, x, info, rtol=rtol_sp, atol=atol_sp, options=opts, meta=meta)
         call check_info(info, 'cg', module=this_module, procedure='test_cg_csp')
 
         ! Check convergence.
@@ -1373,7 +1398,10 @@ contains
         type(hermitian_linop_cdp), allocatable :: A
         type(vector_cdp), allocatable :: b
         type(vector_cdp), allocatable :: x
+        ! CG options.
         type(cg_dp_opts) :: opts
+        ! CG metadata.
+        type(cg_dp_metadata) :: meta
         ! Information flag
         integer :: info
         ! Misc
@@ -1387,7 +1415,7 @@ contains
 
         ! CG solver.
         opts = cg_dp_opts(maxiter=2*test_size)
-        call cg(A, b, x, info, rtol=rtol_dp, atol=atol_dp, options=opts)
+        call cg(A, b, x, info, rtol=rtol_dp, atol=atol_dp, options=opts, meta=meta)
         call check_info(info, 'cg', module=this_module, procedure='test_cg_cdp')
 
         ! Check convergence.

--- a/test/TestIterativeSolvers.f90
+++ b/test/TestIterativeSolvers.f90
@@ -99,7 +99,7 @@ contains
 
         ! Compute spectral decomposition.
         call eigs(A, X, eigvals, residuals, info, tolerance=atol_sp)
-        call check_info(info, 'eigs', module=this_module, procedure='test_ks_evp_rsp')
+        call check_info(info, 'eigs', module=this_module_long, procedure='test_ks_evp_rsp')
 
         ! Analytical eigenvalues.
         true_eigvals = zero_csp; k = 1
@@ -172,7 +172,7 @@ contains
 
         ! Compute spectral decomposition.
         call eigs(A, X, eigvals, residuals, info, tolerance=atol_sp)
-        call check_info(info, 'eigs', module=this_module, procedure='test_evp_rsp')
+        call check_info(info, 'eigs', module=this_module_long, procedure='test_evp_rsp')
 
         ! Analytical eigenvalues.
         true_eigvals = zero_csp; k = 1
@@ -249,7 +249,7 @@ contains
 
         ! Spectral decomposition.
         call eighs(A, X, evals, residuals, info, kdim=test_size, tolerance=atol_sp)
-        call check_info(info, 'eighs', module=this_module, procedure='test_sym_evp_rsp')
+        call check_info(info, 'eighs', module=this_module_long, procedure='test_sym_evp_rsp')
 
         ! Analytical eigenvalues.
         true_evals = 0.0_sp
@@ -342,7 +342,7 @@ contains
 
         ! Compute spectral decomposition.
         call eigs(A, X, eigvals, residuals, info, tolerance=atol_dp)
-        call check_info(info, 'eigs', module=this_module, procedure='test_ks_evp_rdp')
+        call check_info(info, 'eigs', module=this_module_long, procedure='test_ks_evp_rdp')
 
         ! Analytical eigenvalues.
         true_eigvals = zero_cdp; k = 1
@@ -415,7 +415,7 @@ contains
 
         ! Compute spectral decomposition.
         call eigs(A, X, eigvals, residuals, info, tolerance=atol_dp)
-        call check_info(info, 'eigs', module=this_module, procedure='test_evp_rdp')
+        call check_info(info, 'eigs', module=this_module_long, procedure='test_evp_rdp')
 
         ! Analytical eigenvalues.
         true_eigvals = zero_cdp; k = 1
@@ -492,7 +492,7 @@ contains
 
         ! Spectral decomposition.
         call eighs(A, X, evals, residuals, info, kdim=test_size, tolerance=atol_dp)
-        call check_info(info, 'eighs', module=this_module, procedure='test_sym_evp_rdp')
+        call check_info(info, 'eighs', module=this_module_long, procedure='test_sym_evp_rdp')
 
         ! Analytical eigenvalues.
         true_evals = 0.0_dp
@@ -711,7 +711,7 @@ contains
 
         ! Compute spectral decomposition.
         call svds(A, U, S, V, residuals, info, tolerance=atol_sp)
-        call check_info(info, 'svds', module=this_module, procedure='test_svd_rsp')
+        call check_info(info, 'svds', module=this_module_long, procedure='test_svd_rsp')
 
         ! Check correctness of full factorization.
         allocate(Udata(test_size, test_size)) ; call get_data(Udata, U)
@@ -805,7 +805,7 @@ contains
 
         ! Compute spectral decomposition.
         call svds(A, U, S, V, residuals, info, tolerance=atol_dp)
-        call check_info(info, 'svds', module=this_module, procedure='test_svd_rdp')
+        call check_info(info, 'svds', module=this_module_long, procedure='test_svd_rdp')
 
         ! Check correctness of full factorization.
         allocate(Udata(test_size, test_size)) ; call get_data(Udata, U)
@@ -956,7 +956,7 @@ contains
         ! GMRES solver.
         opts = gmres_sp_opts(kdim=test_size)
         call gmres(A, b, x, info, rtol=rtol_sp, atol=atol_sp, options=opts, meta=meta)
-        call check_info(info, 'gmres', module=this_module, procedure='test_gmres_rsp')
+        call check_info(info, 'gmres', module=this_module_long, procedure='test_gmres_rsp')
 
         ! Check convergence.
         err = norm2(abs(matmul(A%data, x%data) - b%data))
@@ -992,7 +992,7 @@ contains
         ! GMRES solver.
         opts = gmres_sp_opts(kdim=test_size)
         call gmres(A, b, x, info, rtol=rtol_sp, atol=atol_sp, options=opts, meta=meta)
-        call check_info(info, 'gmres', module=this_module, procedure='test_gmres_spd_rsp')
+        call check_info(info, 'gmres', module=this_module_long, procedure='test_gmres_spd_rsp')
 
         ! Check convergence.
         err = norm2(abs(matmul(A%data, x%data) - b%data))
@@ -1037,7 +1037,7 @@ contains
         ! GMRES solver.
         opts = gmres_dp_opts(kdim=test_size)
         call gmres(A, b, x, info, rtol=rtol_dp, atol=atol_dp, options=opts, meta=meta)
-        call check_info(info, 'gmres', module=this_module, procedure='test_gmres_rdp')
+        call check_info(info, 'gmres', module=this_module_long, procedure='test_gmres_rdp')
 
         ! Check convergence.
         err = norm2(abs(matmul(A%data, x%data) - b%data))
@@ -1073,7 +1073,7 @@ contains
         ! GMRES solver.
         opts = gmres_dp_opts(kdim=test_size)
         call gmres(A, b, x, info, rtol=rtol_dp, atol=atol_dp, options=opts, meta=meta)
-        call check_info(info, 'gmres', module=this_module, procedure='test_gmres_spd_rdp')
+        call check_info(info, 'gmres', module=this_module_long, procedure='test_gmres_spd_rdp')
 
         ! Check convergence.
         err = norm2(abs(matmul(A%data, x%data) - b%data))
@@ -1118,7 +1118,7 @@ contains
         ! GMRES solver.
         opts = gmres_sp_opts(kdim=test_size)
         call gmres(A, b, x, info, rtol=rtol_sp, atol=atol_sp, options=opts, meta=meta)
-        call check_info(info, 'gmres', module=this_module, procedure='test_gmres_csp')
+        call check_info(info, 'gmres', module=this_module_long, procedure='test_gmres_csp')
 
         ! Check convergence.
         err = norm2(abs(matmul(A%data, x%data) - b%data))
@@ -1154,7 +1154,7 @@ contains
         ! GMRES solver.
         opts = gmres_sp_opts(kdim=test_size)
         call gmres(A, b, x, info, rtol=rtol_sp, atol=atol_sp, options=opts, meta=meta)
-        call check_info(info, 'gmres', module=this_module, procedure='test_gmres_spd_csp')
+        call check_info(info, 'gmres', module=this_module_long, procedure='test_gmres_spd_csp')
 
         ! Check convergence.
         err = norm2(abs(matmul(A%data, x%data) - b%data))
@@ -1199,7 +1199,7 @@ contains
         ! GMRES solver.
         opts = gmres_dp_opts(kdim=test_size)
         call gmres(A, b, x, info, rtol=rtol_dp, atol=atol_dp, options=opts, meta=meta)
-        call check_info(info, 'gmres', module=this_module, procedure='test_gmres_cdp')
+        call check_info(info, 'gmres', module=this_module_long, procedure='test_gmres_cdp')
 
         ! Check convergence.
         err = norm2(abs(matmul(A%data, x%data) - b%data))
@@ -1235,7 +1235,7 @@ contains
         ! GMRES solver.
         opts = gmres_dp_opts(kdim=test_size)
         call gmres(A, b, x, info, rtol=rtol_dp, atol=atol_dp, options=opts, meta=meta)
-        call check_info(info, 'gmres', module=this_module, procedure='test_gmres_spd_cdp')
+        call check_info(info, 'gmres', module=this_module_long, procedure='test_gmres_spd_cdp')
 
         ! Check convergence.
         err = norm2(abs(matmul(A%data, x%data) - b%data))
@@ -1284,7 +1284,7 @@ contains
         ! CG solver.
         opts = cg_sp_opts(maxiter=2*test_size)
         call cg(A, b, x, info, rtol=rtol_sp, atol=atol_sp, options=opts, meta=meta)
-        call check_info(info, 'cg', module=this_module, procedure='test_cg_rsp')
+        call check_info(info, 'cg', module=this_module_long, procedure='test_cg_rsp')
 
         ! Check convergence.
         err = norm2(abs(matmul(A%data, x%data) - b%data))
@@ -1328,7 +1328,7 @@ contains
         ! CG solver.
         opts = cg_dp_opts(maxiter=2*test_size)
         call cg(A, b, x, info, rtol=rtol_dp, atol=atol_dp, options=opts, meta=meta)
-        call check_info(info, 'cg', module=this_module, procedure='test_cg_rdp')
+        call check_info(info, 'cg', module=this_module_long, procedure='test_cg_rdp')
 
         ! Check convergence.
         err = norm2(abs(matmul(A%data, x%data) - b%data))
@@ -1372,7 +1372,7 @@ contains
         ! CG solver.
         opts = cg_sp_opts(maxiter=2*test_size)
         call cg(A, b, x, info, rtol=rtol_sp, atol=atol_sp, options=opts, meta=meta)
-        call check_info(info, 'cg', module=this_module, procedure='test_cg_csp')
+        call check_info(info, 'cg', module=this_module_long, procedure='test_cg_csp')
 
         ! Check convergence.
         err = norm2(abs(matmul(A%data, x%data) - b%data))
@@ -1416,7 +1416,7 @@ contains
         ! CG solver.
         opts = cg_dp_opts(maxiter=2*test_size)
         call cg(A, b, x, info, rtol=rtol_dp, atol=atol_dp, options=opts, meta=meta)
-        call check_info(info, 'cg', module=this_module, procedure='test_cg_cdp')
+        call check_info(info, 'cg', module=this_module_long, procedure='test_cg_cdp')
 
         ! Check convergence.
         err = norm2(abs(matmul(A%data, x%data) - b%data))

--- a/test/TestIterativeSolvers.f90
+++ b/test/TestIterativeSolvers.f90
@@ -19,7 +19,8 @@ module TestIterativeSolvers
     
     private
 
-    character(len=128), parameter, private :: this_module = 'LightKrylov_TestIterativeSolvers'
+    character(len=*), parameter, private :: this_module      = 'LK_TSolvers'
+    character(len=*), parameter, private :: this_module_long = 'LightKrylov_TestIterativeSolvers'
 
     public :: collect_eig_rsp_testsuite
     public :: collect_svd_rsp_testsuite

--- a/test/TestIterativeSolvers.fypp
+++ b/test/TestIterativeSolvers.fypp
@@ -95,7 +95,7 @@ contains
 
         ! Compute spectral decomposition.
         call eigs(A, X, eigvals, residuals, info, tolerance=atol_${kind}$)
-        call check_info(info, 'eigs', module=this_module, procedure='test_ks_evp_${type[0]}$${kind}$')
+        call check_info(info, 'eigs', module=this_module_long, procedure='test_ks_evp_${type[0]}$${kind}$')
 
         ! Analytical eigenvalues.
         true_eigvals = zero_c${kind}$; k = 1
@@ -170,7 +170,7 @@ contains
 
         ! Compute spectral decomposition.
         call eigs(A, X, eigvals, residuals, info, tolerance=atol_${kind}$)
-        call check_info(info, 'eigs', module=this_module, procedure='test_evp_${type[0]}$${kind}$')
+        call check_info(info, 'eigs', module=this_module_long, procedure='test_evp_${type[0]}$${kind}$')
 
         ! Analytical eigenvalues.
         true_eigvals = zero_c${kind}$; k = 1
@@ -249,7 +249,7 @@ contains
 
         ! Spectral decomposition.
         call eighs(A, X, evals, residuals, info, kdim=test_size, tolerance=atol_${kind}$)
-        call check_info(info, 'eighs', module=this_module, procedure='test_sym_evp_${type[0]}$${kind}$')
+        call check_info(info, 'eighs', module=this_module_long, procedure='test_sym_evp_${type[0]}$${kind}$')
 
         ! Analytical eigenvalues.
         true_evals = 0.0_${kind}$
@@ -348,7 +348,7 @@ contains
 
         ! Compute spectral decomposition.
         call svds(A, U, S, V, residuals, info, tolerance=atol_${kind}$)
-        call check_info(info, 'svds', module=this_module, procedure='test_svd_${type[0]}$${kind}$')
+        call check_info(info, 'svds', module=this_module_long, procedure='test_svd_${type[0]}$${kind}$')
 
         ! Check correctness of full factorization.
         allocate(Udata(test_size, test_size)) ; call get_data(Udata, U)
@@ -434,7 +434,7 @@ contains
         ! GMRES solver.
         opts = gmres_${kind}$_opts(kdim=test_size)
         call gmres(A, b, x, info, rtol=rtol_${kind}$, atol=atol_${kind}$, options=opts, meta=meta)
-        call check_info(info, 'gmres', module=this_module, procedure='test_gmres_${type[0]}$${kind}$')
+        call check_info(info, 'gmres', module=this_module_long, procedure='test_gmres_${type[0]}$${kind}$')
 
         ! Check convergence.
         err = norm2(abs(matmul(A%data, x%data) - b%data))
@@ -478,7 +478,7 @@ contains
         ! GMRES solver.
         opts = gmres_${kind}$_opts(kdim=test_size)
         call gmres(A, b, x, info, rtol=rtol_${kind}$, atol=atol_${kind}$, options=opts, meta=meta)
-        call check_info(info, 'gmres', module=this_module, procedure='test_gmres_spd_${type[0]}$${kind}$')
+        call check_info(info, 'gmres', module=this_module_long, procedure='test_gmres_spd_${type[0]}$${kind}$')
 
         ! Check convergence.
         err = norm2(abs(matmul(A%data, x%data) - b%data))
@@ -537,7 +537,7 @@ contains
         ! CG solver.
         opts = cg_${kind}$_opts(maxiter=2*test_size)
         call cg(A, b, x, info, rtol=rtol_${kind}$, atol=atol_${kind}$, options=opts, meta=meta)
-        call check_info(info, 'cg', module=this_module, procedure='test_cg_${type[0]}$${kind}$')
+        call check_info(info, 'cg', module=this_module_long, procedure='test_cg_${type[0]}$${kind}$')
 
         ! Check convergence.
         err = norm2(abs(matmul(A%data, x%data) - b%data))

--- a/test/TestIterativeSolvers.fypp
+++ b/test/TestIterativeSolvers.fypp
@@ -21,7 +21,8 @@ module TestIterativeSolvers
     
     private
 
-    character(len=128), parameter, private :: this_module = 'LightKrylov_TestIterativeSolvers'
+    character(len=*), parameter, private :: this_module      = 'LK_TSolvers'
+    character(len=*), parameter, private :: this_module_long = 'LightKrylov_TestIterativeSolvers'
 
     #:for kind, type in RC_KINDS_TYPES
     public :: collect_eig_${type[0]}$${kind}$_testsuite

--- a/test/TestIterativeSolvers.fypp
+++ b/test/TestIterativeSolvers.fypp
@@ -114,7 +114,7 @@ contains
         !allocate(AX(nev))
         !allocate(eigvec_residuals(test_size, nev))
         !do i = 1, nev
-        !    call A%matvec(X(i), AX(i))
+        !    call A%apply_matvec(X(i), AX(i))
         !    eigvec_residuals(:, i) = AX(i)%data - eigvals(i)*X(i)%data
         !end do
         !err = norm2(abs(eigvec_residuals))
@@ -189,7 +189,7 @@ contains
 !        allocate(AX(test_size))
 !        allocate(eigvec_residuals(test_size, test_size)); eigvec_residuals = zero_c${kind}$
 !        do i = 1, test_size
-!            call A%matvec(X(i), AX(i))
+!            call A%apply_matvec(X(i), AX(i))
 !            eigvec_residuals(:, i) = AX(i)%data - eigvals(i)*X(i)%data
 !        end do
 !        err = norm2(abs(eigvec_residuals))
@@ -267,7 +267,7 @@ contains
         allocate(AX(test_size))
         allocate(eigvec_residuals(test_size, test_size)); eigvec_residuals = zero_c${kind}$
         do i = 1, test_size
-            call A%matvec(X(i), AX(i))
+            call A%apply_matvec(X(i), AX(i))
             eigvec_residuals(:, i) = AX(i)%data - evals(i)*X(i)%data
         end do
         err = norm2(abs(eigvec_residuals))
@@ -432,7 +432,7 @@ contains
         x = vector_${type[0]}$${kind}$() ; call x%zero()
 
         ! GMRES solver.
-        opts = gmres_${kind}$_opts(kdim=test_size)
+        opts = gmres_${kind}$_opts(kdim=test_size, if_print_metadata=.true.)
         call gmres(A, b, x, info, rtol=rtol_${kind}$, atol=atol_${kind}$, options=opts, meta=meta)
         call check_info(info, 'gmres', module=this_module_long, procedure='test_gmres_${type[0]}$${kind}$')
 
@@ -476,7 +476,7 @@ contains
         x = vector_${type[0]}$${kind}$() ; call x%zero()
 
         ! GMRES solver.
-        opts = gmres_${kind}$_opts(kdim=test_size)
+        opts = gmres_${kind}$_opts(kdim=test_size, if_print_metadata=.true.)
         call gmres(A, b, x, info, rtol=rtol_${kind}$, atol=atol_${kind}$, options=opts, meta=meta)
         call check_info(info, 'gmres', module=this_module_long, procedure='test_gmres_spd_${type[0]}$${kind}$')
 
@@ -535,7 +535,7 @@ contains
         x = vector_${type[0]}$${kind}$() ; call x%zero()
 
         ! CG solver.
-        opts = cg_${kind}$_opts(maxiter=2*test_size)
+        opts = cg_${kind}$_opts(maxiter=2*test_size, if_print_metadata=.true.)
         call cg(A, b, x, info, rtol=rtol_${kind}$, atol=atol_${kind}$, options=opts, meta=meta)
         call check_info(info, 'cg', module=this_module_long, procedure='test_cg_${type[0]}$${kind}$')
 

--- a/test/TestIterativeSolvers.fypp
+++ b/test/TestIterativeSolvers.fypp
@@ -418,6 +418,8 @@ contains
         type(vector_${type[0]}$${kind}$), allocatable :: x ! Solution vector.
         ! GMRES options.
         type(gmres_${kind}$_opts) :: opts
+        ! GMRES metadata.
+        type(gmres_${kind}$_metadata) :: meta
         ! Information flag.
         integer :: info
         ! Misc
@@ -431,7 +433,7 @@ contains
 
         ! GMRES solver.
         opts = gmres_${kind}$_opts(kdim=test_size)
-        call gmres(A, b, x, info, rtol=rtol_${kind}$, atol=atol_${kind}$, options=opts)
+        call gmres(A, b, x, info, rtol=rtol_${kind}$, atol=atol_${kind}$, options=opts, meta=meta)
         call check_info(info, 'gmres', module=this_module, procedure='test_gmres_${type[0]}$${kind}$')
 
         ! Check convergence.
@@ -456,6 +458,8 @@ contains
         type(vector_${type[0]}$${kind}$), allocatable :: x ! Solution vector.
         ! GMRES options.
         type(gmres_${kind}$_opts) :: opts
+        ! GMRES metadata.
+        type(gmres_${kind}$_metadata) :: meta
         ! Information flag.
         integer :: info
         ! Misc
@@ -473,7 +477,7 @@ contains
 
         ! GMRES solver.
         opts = gmres_${kind}$_opts(kdim=test_size)
-        call gmres(A, b, x, info, rtol=rtol_${kind}$, atol=atol_${kind}$, options=opts)
+        call gmres(A, b, x, info, rtol=rtol_${kind}$, atol=atol_${kind}$, options=opts, meta=meta)
         call check_info(info, 'gmres', module=this_module, procedure='test_gmres_spd_${type[0]}$${kind}$')
 
         ! Check convergence.
@@ -511,7 +515,10 @@ contains
         #:endif
         type(vector_${type[0]}$${kind}$), allocatable :: b
         type(vector_${type[0]}$${kind}$), allocatable :: x
+        ! CG options.
         type(cg_${kind}$_opts) :: opts
+        ! CG metadata.
+        type(cg_${kind}$_metadata) :: meta
         ! Information flag
         integer :: info
         ! Misc
@@ -529,7 +536,7 @@ contains
 
         ! CG solver.
         opts = cg_${kind}$_opts(maxiter=2*test_size)
-        call cg(A, b, x, info, rtol=rtol_${kind}$, atol=atol_${kind}$, options=opts)
+        call cg(A, b, x, info, rtol=rtol_${kind}$, atol=atol_${kind}$, options=opts, meta=meta)
         call check_info(info, 'cg', module=this_module, procedure='test_cg_${type[0]}$${kind}$')
 
         ! Check convergence.

--- a/test/TestKrylov.f90
+++ b/test/TestKrylov.f90
@@ -18,7 +18,8 @@ module TestKrylov
     
     private
 
-    character(len=128), parameter, private :: this_module = 'LightKrylov_TestKrylov'
+    character(len=*), parameter, private :: this_module      = 'LK_TBKrylov'
+    character(len=*), parameter, private :: this_module_long = 'LightKrylov_TestKrylov'
 
     public :: collect_qr_rsp_testsuite
     public :: collect_arnoldi_rsp_testsuite

--- a/test/TestKrylov.f90
+++ b/test/TestKrylov.f90
@@ -82,7 +82,7 @@ contains
 
         ! In-place QR factorization.
         call qr(A, R, info, tol=atol_sp)
-        call check_info(info, 'qr', module=this_module, procedure='test_qr_factorization_rsp')
+        call check_info(info, 'qr', module=this_module_long, procedure='test_qr_factorization_rsp')
 
         ! Get data.
         allocate(Qdata(test_size, kdim)) ; call get_data(Qdata, A)
@@ -156,7 +156,7 @@ contains
 
         ! In-place QR factorization.
         call qr(A, R, perm, info, tol=atol_sp)
-        call check_info(info, 'qr_pivot', module=this_module, procedure='test_pivoting_qr_exact_rank_deficiency_rsp')
+        call check_info(info, 'qr_pivot', module=this_module_long, procedure='test_pivoting_qr_exact_rank_deficiency_rsp')
 
         ! Extract data
         allocate(Qdata(test_size, kdim)) ; call get_data(Qdata, A)
@@ -217,7 +217,7 @@ contains
 
         ! In-place QR factorization.
         call qr(A, R, info, tol=atol_dp)
-        call check_info(info, 'qr', module=this_module, procedure='test_qr_factorization_rdp')
+        call check_info(info, 'qr', module=this_module_long, procedure='test_qr_factorization_rdp')
 
         ! Get data.
         allocate(Qdata(test_size, kdim)) ; call get_data(Qdata, A)
@@ -291,7 +291,7 @@ contains
 
         ! In-place QR factorization.
         call qr(A, R, perm, info, tol=atol_dp)
-        call check_info(info, 'qr_pivot', module=this_module, procedure='test_pivoting_qr_exact_rank_deficiency_rdp')
+        call check_info(info, 'qr_pivot', module=this_module_long, procedure='test_pivoting_qr_exact_rank_deficiency_rdp')
 
         ! Extract data
         allocate(Qdata(test_size, kdim)) ; call get_data(Qdata, A)
@@ -352,7 +352,7 @@ contains
 
         ! In-place QR factorization.
         call qr(A, R, info, tol=atol_sp)
-        call check_info(info, 'qr', module=this_module, procedure='test_qr_factorization_csp')
+        call check_info(info, 'qr', module=this_module_long, procedure='test_qr_factorization_csp')
 
         ! Get data.
         allocate(Qdata(test_size, kdim)) ; call get_data(Qdata, A)
@@ -426,7 +426,7 @@ contains
 
         ! In-place QR factorization.
         call qr(A, R, perm, info, tol=atol_sp)
-        call check_info(info, 'qr_pivot', module=this_module, procedure='test_pivoting_qr_exact_rank_deficiency_csp')
+        call check_info(info, 'qr_pivot', module=this_module_long, procedure='test_pivoting_qr_exact_rank_deficiency_csp')
 
         ! Extract data
         allocate(Qdata(test_size, kdim)) ; call get_data(Qdata, A)
@@ -487,7 +487,7 @@ contains
 
         ! In-place QR factorization.
         call qr(A, R, info, tol=atol_dp)
-        call check_info(info, 'qr', module=this_module, procedure='test_qr_factorization_cdp')
+        call check_info(info, 'qr', module=this_module_long, procedure='test_qr_factorization_cdp')
 
         ! Get data.
         allocate(Qdata(test_size, kdim)) ; call get_data(Qdata, A)
@@ -561,7 +561,7 @@ contains
 
         ! In-place QR factorization.
         call qr(A, R, perm, info, tol=atol_dp)
-        call check_info(info, 'qr_pivot', module=this_module, procedure='test_pivoting_qr_exact_rank_deficiency_cdp')
+        call check_info(info, 'qr_pivot', module=this_module_long, procedure='test_pivoting_qr_exact_rank_deficiency_cdp')
 
         ! Extract data
         allocate(Qdata(test_size, kdim)) ; call get_data(Qdata, A)
@@ -629,7 +629,7 @@ contains
         allocate(H(kdim+1, kdim)) ; H = zero_rsp
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, tol=atol_sp)
-        call check_info(info, 'arnoldi', module=this_module, procedure='test_arnoldi_factorization_rsp')
+        call check_info(info, 'arnoldi', module=this_module_long, procedure='test_arnoldi_factorization_rsp')
 
         ! Check correctness of full factorization.
         allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
@@ -684,7 +684,7 @@ contains
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, blksize=p, tol=atol_sp)
-        call check_info(info, 'arnoldi', module=this_module, procedure='test_block_arnoldi_factorization_rsp')
+        call check_info(info, 'arnoldi', module=this_module_long, procedure='test_block_arnoldi_factorization_rsp')
 
         ! Check correctness of full factorization.
         allocate(Xdata(test_size, p*(kdim+1))) ; call get_data(Xdata, X)
@@ -737,7 +737,7 @@ contains
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, tol=atol_sp)
-        call check_info(info, 'arnoldi', module=this_module, procedure='test_krylov_schur_rsp')
+        call check_info(info, 'arnoldi', module=this_module_long, procedure='test_krylov_schur_rsp')
 
         ! Krylov-Schur condensation.
         call krylov_schur(n, X, H, select_eigs)
@@ -797,7 +797,7 @@ contains
         allocate(H(kdim+1, kdim)) ; H = zero_rdp
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, tol=atol_dp)
-        call check_info(info, 'arnoldi', module=this_module, procedure='test_arnoldi_factorization_rdp')
+        call check_info(info, 'arnoldi', module=this_module_long, procedure='test_arnoldi_factorization_rdp')
 
         ! Check correctness of full factorization.
         allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
@@ -852,7 +852,7 @@ contains
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, blksize=p, tol=atol_dp)
-        call check_info(info, 'arnoldi', module=this_module, procedure='test_block_arnoldi_factorization_rdp')
+        call check_info(info, 'arnoldi', module=this_module_long, procedure='test_block_arnoldi_factorization_rdp')
 
         ! Check correctness of full factorization.
         allocate(Xdata(test_size, p*(kdim+1))) ; call get_data(Xdata, X)
@@ -905,7 +905,7 @@ contains
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, tol=atol_dp)
-        call check_info(info, 'arnoldi', module=this_module, procedure='test_krylov_schur_rdp')
+        call check_info(info, 'arnoldi', module=this_module_long, procedure='test_krylov_schur_rdp')
 
         ! Krylov-Schur condensation.
         call krylov_schur(n, X, H, select_eigs)
@@ -965,7 +965,7 @@ contains
         allocate(H(kdim+1, kdim)) ; H = zero_csp
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, tol=atol_sp)
-        call check_info(info, 'arnoldi', module=this_module, procedure='test_arnoldi_factorization_csp')
+        call check_info(info, 'arnoldi', module=this_module_long, procedure='test_arnoldi_factorization_csp')
 
         ! Check correctness of full factorization.
         allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
@@ -1020,7 +1020,7 @@ contains
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, blksize=p, tol=atol_sp)
-        call check_info(info, 'arnoldi', module=this_module, procedure='test_block_arnoldi_factorization_csp')
+        call check_info(info, 'arnoldi', module=this_module_long, procedure='test_block_arnoldi_factorization_csp')
 
         ! Check correctness of full factorization.
         allocate(Xdata(test_size, p*(kdim+1))) ; call get_data(Xdata, X)
@@ -1073,7 +1073,7 @@ contains
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, tol=atol_sp)
-        call check_info(info, 'arnoldi', module=this_module, procedure='test_krylov_schur_csp')
+        call check_info(info, 'arnoldi', module=this_module_long, procedure='test_krylov_schur_csp')
 
         ! Krylov-Schur condensation.
         call krylov_schur(n, X, H, select_eigs)
@@ -1133,7 +1133,7 @@ contains
         allocate(H(kdim+1, kdim)) ; H = zero_cdp
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, tol=atol_dp)
-        call check_info(info, 'arnoldi', module=this_module, procedure='test_arnoldi_factorization_cdp')
+        call check_info(info, 'arnoldi', module=this_module_long, procedure='test_arnoldi_factorization_cdp')
 
         ! Check correctness of full factorization.
         allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
@@ -1188,7 +1188,7 @@ contains
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, blksize=p, tol=atol_dp)
-        call check_info(info, 'arnoldi', module=this_module, procedure='test_block_arnoldi_factorization_cdp')
+        call check_info(info, 'arnoldi', module=this_module_long, procedure='test_block_arnoldi_factorization_cdp')
 
         ! Check correctness of full factorization.
         allocate(Xdata(test_size, p*(kdim+1))) ; call get_data(Xdata, X)
@@ -1241,7 +1241,7 @@ contains
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, tol=atol_dp)
-        call check_info(info, 'arnoldi', module=this_module, procedure='test_krylov_schur_cdp')
+        call check_info(info, 'arnoldi', module=this_module_long, procedure='test_krylov_schur_cdp')
 
         ! Krylov-Schur condensation.
         call krylov_schur(n, X, H, select_eigs)
@@ -1309,7 +1309,7 @@ contains
 
         ! Lanczos bidiagonalization.
         call bidiagonalization(A, U, V, B, info, tol=atol_sp)
-        call check_info(info, 'bidiagonalization', module=this_module, &
+        call check_info(info, 'bidiagonalization', module=this_module_long, &
                         & procedure='test_lanczos_bidiag_factorization_rsp')
 
         ! Check correctness.
@@ -1386,7 +1386,7 @@ contains
 
         ! Lanczos bidiagonalization.
         call bidiagonalization(A, U, V, B, info, tol=atol_dp)
-        call check_info(info, 'bidiagonalization', module=this_module, &
+        call check_info(info, 'bidiagonalization', module=this_module_long, &
                         & procedure='test_lanczos_bidiag_factorization_rdp')
 
         ! Check correctness.
@@ -1463,7 +1463,7 @@ contains
 
         ! Lanczos bidiagonalization.
         call bidiagonalization(A, U, V, B, info, tol=atol_sp)
-        call check_info(info, 'bidiagonalization', module=this_module, &
+        call check_info(info, 'bidiagonalization', module=this_module_long, &
                         & procedure='test_lanczos_bidiag_factorization_csp')
 
         ! Check correctness.
@@ -1540,7 +1540,7 @@ contains
 
         ! Lanczos bidiagonalization.
         call bidiagonalization(A, U, V, B, info, tol=atol_dp)
-        call check_info(info, 'bidiagonalization', module=this_module, &
+        call check_info(info, 'bidiagonalization', module=this_module_long, &
                         & procedure='test_lanczos_bidiag_factorization_cdp')
 
         ! Check correctness.
@@ -1626,7 +1626,7 @@ contains
 
         ! Lanczos factorization.
         call lanczos(A, X, T, info, tol=atol_sp)
-        call check_info(info, 'lanczos', module=this_module, & 
+        call check_info(info, 'lanczos', module=this_module_long, & 
                         & procedure='test_lanczos_tridiag_factorization_rsp')
 
         ! Check correctness.
@@ -1696,7 +1696,7 @@ contains
 
         ! Lanczos factorization.
         call lanczos(A, X, T, info, tol=atol_dp)
-        call check_info(info, 'lanczos', module=this_module, & 
+        call check_info(info, 'lanczos', module=this_module_long, & 
                         & procedure='test_lanczos_tridiag_factorization_rdp')
 
         ! Check correctness.
@@ -1766,7 +1766,7 @@ contains
 
         ! Lanczos factorization.
         call lanczos(A, X, T, info, tol=atol_sp)
-        call check_info(info, 'lanczos', module=this_module, & 
+        call check_info(info, 'lanczos', module=this_module_long, & 
                         & procedure='test_lanczos_tridiag_factorization_csp')
 
         ! Check correctness.
@@ -1836,7 +1836,7 @@ contains
 
         ! Lanczos factorization.
         call lanczos(A, X, T, info, tol=atol_dp)
-        call check_info(info, 'lanczos', module=this_module, & 
+        call check_info(info, 'lanczos', module=this_module_long, & 
                         & procedure='test_lanczos_tridiag_factorization_cdp')
 
         ! Check correctness.

--- a/test/TestKrylov.fypp
+++ b/test/TestKrylov.fypp
@@ -20,7 +20,8 @@ module TestKrylov
     
     private
 
-    character(len=128), parameter, private :: this_module = 'LightKrylov_TestKrylov'
+    character(len=*), parameter, private :: this_module      = 'LK_TBKrylov'
+    character(len=*), parameter, private :: this_module_long = 'LightKrylov_TestKrylov'
 
     #:for kind, type in RC_KINDS_TYPES
     public :: collect_qr_${type[0]}$${kind}$_testsuite

--- a/test/TestKrylov.fypp
+++ b/test/TestKrylov.fypp
@@ -72,7 +72,7 @@ contains
 
         ! In-place QR factorization.
         call qr(A, R, info, tol=atol_${kind}$)
-        call check_info(info, 'qr', module=this_module, procedure='test_qr_factorization_${type[0]}$${kind}$')
+        call check_info(info, 'qr', module=this_module_long, procedure='test_qr_factorization_${type[0]}$${kind}$')
 
         ! Get data.
         allocate(Qdata(test_size, kdim)) ; call get_data(Qdata, A)
@@ -146,7 +146,7 @@ contains
 
         ! In-place QR factorization.
         call qr(A, R, perm, info, tol=atol_${kind}$)
-        call check_info(info, 'qr_pivot', module=this_module, procedure='test_pivoting_qr_exact_rank_deficiency_${type[0]}$${kind}$')
+        call check_info(info, 'qr_pivot', module=this_module_long, procedure='test_pivoting_qr_exact_rank_deficiency_${type[0]}$${kind}$')
 
         ! Extract data
         allocate(Qdata(test_size, kdim)) ; call get_data(Qdata, A)
@@ -216,7 +216,7 @@ contains
         allocate(H(kdim+1, kdim)) ; H = zero_${type[0]}$${kind}$
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, tol=atol_${kind}$)
-        call check_info(info, 'arnoldi', module=this_module, procedure='test_arnoldi_factorization_${type[0]}$${kind}$')
+        call check_info(info, 'arnoldi', module=this_module_long, procedure='test_arnoldi_factorization_${type[0]}$${kind}$')
 
         ! Check correctness of full factorization.
         allocate(Xdata(test_size, kdim+1)) ; call get_data(Xdata, X)
@@ -271,7 +271,7 @@ contains
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, blksize=p, tol=atol_${kind}$)
-        call check_info(info, 'arnoldi', module=this_module, procedure='test_block_arnoldi_factorization_${type[0]}$${kind}$')
+        call check_info(info, 'arnoldi', module=this_module_long, procedure='test_block_arnoldi_factorization_${type[0]}$${kind}$')
 
         ! Check correctness of full factorization.
         allocate(Xdata(test_size, p*(kdim+1))) ; call get_data(Xdata, X)
@@ -324,7 +324,7 @@ contains
 
         ! Arnoldi factorization.
         call arnoldi(A, X, H, info, tol=atol_${kind}$)
-        call check_info(info, 'arnoldi', module=this_module, procedure='test_krylov_schur_${type[0]}$${kind}$')
+        call check_info(info, 'arnoldi', module=this_module_long, procedure='test_krylov_schur_${type[0]}$${kind}$')
 
         ! Krylov-Schur condensation.
         call krylov_schur(n, X, H, select_eigs)
@@ -394,7 +394,7 @@ contains
 
         ! Lanczos bidiagonalization.
         call bidiagonalization(A, U, V, B, info, tol=atol_${kind}$)
-        call check_info(info, 'bidiagonalization', module=this_module, &
+        call check_info(info, 'bidiagonalization', module=this_module_long, &
                         & procedure='test_lanczos_bidiag_factorization_${type[0]}$${kind}$')
 
         ! Check correctness.
@@ -490,7 +490,7 @@ contains
 
         ! Lanczos factorization.
         call lanczos(A, X, T, info, tol=atol_${kind}$)
-        call check_info(info, 'lanczos', module=this_module, & 
+        call check_info(info, 'lanczos', module=this_module_long, & 
                         & procedure='test_lanczos_tridiag_factorization_${type[0]}$${kind}$')
 
         ! Check correctness.

--- a/test/TestLinops.f90
+++ b/test/TestLinops.f90
@@ -57,7 +57,7 @@ contains
         call random_number(A%data)
 
         ! Compute matrix-vector product.
-        call A%matvec(x, y)
+        call A%apply_matvec(x, y)
 
         ! Check result.
         call check(error, norm2(y%data - matmul(A%data, x%data)) < rtol_sp)
@@ -83,7 +83,7 @@ contains
         call random_number(A%data)
 
         ! Compute matrix-vector product.
-        call A%rmatvec(x, y)
+        call A%apply_rmatvec(x, y)
 
         ! Check result.
         call check(error, norm2(y%data - matmul(transpose(A%data), x%data)) < rtol_sp)
@@ -116,7 +116,7 @@ contains
         y = vector_rsp() ; call y%zero()
 
         ! Compute adjoint matrix-vector product
-        call B%matvec(x, y)
+        call B%apply_matvec(x, y)
 
         ! Check result.
         alpha = norm2(y%data - matmul(transpose(A%data), x%data))
@@ -152,7 +152,7 @@ contains
         y = vector_rsp() ; call y%zero()
 
         ! Compute adjoint matrix-vector product
-        call B%rmatvec(x, y)
+        call B%apply_rmatvec(x, y)
 
         ! Check result.
         alpha = norm2(y%data - matmul(A%data, x%data))
@@ -191,7 +191,7 @@ contains
         call random_number(A%data)
 
         ! Compute matrix-vector product.
-        call A%matvec(x, y)
+        call A%apply_matvec(x, y)
 
         ! Check result.
         call check(error, norm2(y%data - matmul(A%data, x%data)) < rtol_dp)
@@ -217,7 +217,7 @@ contains
         call random_number(A%data)
 
         ! Compute matrix-vector product.
-        call A%rmatvec(x, y)
+        call A%apply_rmatvec(x, y)
 
         ! Check result.
         call check(error, norm2(y%data - matmul(transpose(A%data), x%data)) < rtol_dp)
@@ -250,7 +250,7 @@ contains
         y = vector_rdp() ; call y%zero()
 
         ! Compute adjoint matrix-vector product
-        call B%matvec(x, y)
+        call B%apply_matvec(x, y)
 
         ! Check result.
         alpha = norm2(y%data - matmul(transpose(A%data), x%data))
@@ -286,7 +286,7 @@ contains
         y = vector_rdp() ; call y%zero()
 
         ! Compute adjoint matrix-vector product
-        call B%rmatvec(x, y)
+        call B%apply_rmatvec(x, y)
 
         ! Check result.
         alpha = norm2(y%data - matmul(A%data, x%data))
@@ -327,7 +327,7 @@ contains
         call random_number(Adata) ; A%data%re = Adata(:, :, 1) ; A%data%im = Adata(:, :, 2)
 
         ! Compute matrix-vector product.
-        call A%matvec(x, y)
+        call A%apply_matvec(x, y)
 
         ! Check result.
         call check(error, norm2(abs(y%data - matmul(A%data, x%data))) < rtol_sp)
@@ -355,7 +355,7 @@ contains
         call random_number(Adata) ; A%data%re = Adata(:, :, 1) ; A%data%im = Adata(:, :, 2)
 
         ! Compute matrix-vector product.
-        call A%rmatvec(x, y)
+        call A%apply_rmatvec(x, y)
 
         ! Check result.
         call check(error, norm2(abs(y%data - matmul(transpose(conjg(A%data)), x%data))) < rtol_sp)
@@ -390,7 +390,7 @@ contains
         y = vector_csp() ; call y%zero()
 
         ! Compute adjoint matrix-vector product
-        call B%matvec(x, y)
+        call B%apply_matvec(x, y)
 
         ! Check result.
         alpha = norm2(abs(y%data - matmul(transpose(conjg(A%data)), x%data)))
@@ -428,7 +428,7 @@ contains
         y = vector_csp() ; call y%zero()
 
         ! Compute adjoint matrix-vector product
-        call B%rmatvec(x, y)
+        call B%apply_rmatvec(x, y)
 
         ! Check result.
         alpha = norm2(abs(y%data - matmul(A%data, x%data)))
@@ -469,7 +469,7 @@ contains
         call random_number(Adata) ; A%data%re = Adata(:, :, 1) ; A%data%im = Adata(:, :, 2)
 
         ! Compute matrix-vector product.
-        call A%matvec(x, y)
+        call A%apply_matvec(x, y)
 
         ! Check result.
         call check(error, norm2(abs(y%data - matmul(A%data, x%data))) < rtol_dp)
@@ -497,7 +497,7 @@ contains
         call random_number(Adata) ; A%data%re = Adata(:, :, 1) ; A%data%im = Adata(:, :, 2)
 
         ! Compute matrix-vector product.
-        call A%rmatvec(x, y)
+        call A%apply_rmatvec(x, y)
 
         ! Check result.
         call check(error, norm2(abs(y%data - matmul(transpose(conjg(A%data)), x%data))) < rtol_dp)
@@ -532,7 +532,7 @@ contains
         y = vector_cdp() ; call y%zero()
 
         ! Compute adjoint matrix-vector product
-        call B%matvec(x, y)
+        call B%apply_matvec(x, y)
 
         ! Check result.
         alpha = norm2(abs(y%data - matmul(transpose(conjg(A%data)), x%data)))
@@ -570,7 +570,7 @@ contains
         y = vector_cdp() ; call y%zero()
 
         ! Compute adjoint matrix-vector product
-        call B%rmatvec(x, y)
+        call B%apply_rmatvec(x, y)
 
         ! Check result.
         alpha = norm2(abs(y%data - matmul(A%data, x%data)))

--- a/test/TestLinops.f90
+++ b/test/TestLinops.f90
@@ -14,7 +14,8 @@ module TestLinops
     
     private
 
-    character(len=128), parameter, private :: this_module = 'LightKrylov_TestLinops'
+    character(len=*), parameter, private :: this_module      = 'LK_TLinops'
+    character(len=*), parameter, private :: this_module_long = 'LightKrylov_TestLinops'
 
     public :: collect_linop_rsp_testsuite
     public :: collect_linop_rdp_testsuite

--- a/test/TestLinops.fypp
+++ b/test/TestLinops.fypp
@@ -67,7 +67,7 @@ contains
         #:endif
 
         ! Compute matrix-vector product.
-        call A%matvec(x, y)
+        call A%apply_matvec(x, y)
 
         ! Check result.
         #:if type[0] == "c"
@@ -106,7 +106,7 @@ contains
         #:endif
 
         ! Compute matrix-vector product.
-        call A%rmatvec(x, y)
+        call A%apply_rmatvec(x, y)
 
         ! Check result.
         #:if type[0] == "c"
@@ -152,7 +152,7 @@ contains
         y = vector_${type[0]}$${kind}$() ; call y%zero()
 
         ! Compute adjoint matrix-vector product
-        call B%matvec(x, y)
+        call B%apply_matvec(x, y)
 
         ! Check result.
         #:if type[0] == "c"
@@ -202,7 +202,7 @@ contains
         y = vector_${type[0]}$${kind}$() ; call y%zero()
 
         ! Compute adjoint matrix-vector product
-        call B%rmatvec(x, y)
+        call B%apply_rmatvec(x, y)
 
         ! Check result.
         #:if type[0] == "c"

--- a/test/TestLinops.fypp
+++ b/test/TestLinops.fypp
@@ -16,7 +16,8 @@ module TestLinops
     
     private
 
-    character(len=128), parameter, private :: this_module = 'LightKrylov_TestLinops'
+    character(len=*), parameter, private :: this_module      = 'LK_TLinops'
+    character(len=*), parameter, private :: this_module_long = 'LightKrylov_TestLinops'
 
     #:for kind, type in RC_KINDS_TYPES
     public :: collect_linop_${type[0]}$${kind}$_testsuite

--- a/test/TestNewtonKrylov.f90
+++ b/test/TestNewtonKrylov.f90
@@ -17,7 +17,8 @@ module TestNewtonKrylov
     
     private
 
-    character(len=128), parameter, private :: this_module = 'LightKrylov_TestNewtonKrylov'
+    character(len=*), parameter, private :: this_module      = 'LK_TNwtKryl'
+    character(len=*), parameter, private :: this_module_long = 'LightKrylov_TestNewtonKrylov'
 
     public :: collect_newton_rsp_testsuite
     public :: collect_newton_rdp_testsuite

--- a/test/TestNewtonKrylov.f90
+++ b/test/TestNewtonKrylov.f90
@@ -57,7 +57,7 @@ contains
        allocate(X, fp1, fp2);
 
        ! Newton opts
-       opts = newton_sp_opts(maxiter=10, ifbisect=.false.) 
+       opts = newton_sp_opts(maxiter=10, ifbisect=.false., if_print_metadata=.true.) 
 
        ! Allocate and set Roessler system and Jacobian
        sys = roessler_rsp()
@@ -68,7 +68,7 @@ contains
        X%x = zero_rsp
        X%y = zero_rsp
        X%z = zero_rsp
-       call newton(sys, X, gmres_rsp, info, tolerance=atol_sp, options=opts)
+       call newton(sys, X, gmres_rsp, info, tolerance=10*atol_sp, options=opts)
        call X%sub(fp1)
 
        ! check fixed point 1
@@ -82,7 +82,7 @@ contains
        X%x = 10.0_sp
        X%y = -5.0_sp
        X%z = 20.0_sp
-       call newton(sys, X, gmres_rsp, info, tolerance=atol_sp, options=opts)
+       call newton(sys, X, gmres_rsp, info, tolerance=10*atol_sp, options=opts)
        call X%sub(fp2)
 
        ! check fixed point 2
@@ -97,7 +97,7 @@ contains
        X%y = zero_rsp
        X%z = zero_rsp
        opts%ifbisect = .true.
-       call newton(sys, X, gmres_rsp, info, tolerance=atol_sp, options=opts)
+       call newton(sys, X, gmres_rsp, info, tolerance=10*atol_sp, options=opts)
        call X%sub(fp1)
 
        ! check fixed point 1 with bisection (if necessary)
@@ -136,7 +136,7 @@ contains
        allocate(X, fp1, fp2);
 
        ! Newton opts
-       opts = newton_dp_opts(maxiter=10, ifbisect=.false.) 
+       opts = newton_dp_opts(maxiter=10, ifbisect=.false., if_print_metadata=.true.) 
 
        ! Allocate and set Roessler system and Jacobian
        sys = roessler_rdp()
@@ -147,7 +147,7 @@ contains
        X%x = zero_rdp
        X%y = zero_rdp
        X%z = zero_rdp
-       call newton(sys, X, gmres_rdp, info, tolerance=atol_dp, options=opts)
+       call newton(sys, X, gmres_rdp, info, tolerance=10*atol_dp, options=opts)
        call X%sub(fp1)
 
        ! check fixed point 1
@@ -161,7 +161,7 @@ contains
        X%x = 10.0_dp
        X%y = -5.0_dp
        X%z = 20.0_dp
-       call newton(sys, X, gmres_rdp, info, tolerance=atol_dp, options=opts)
+       call newton(sys, X, gmres_rdp, info, tolerance=10*atol_dp, options=opts)
        call X%sub(fp2)
 
        ! check fixed point 2
@@ -176,7 +176,7 @@ contains
        X%y = zero_rdp
        X%z = zero_rdp
        opts%ifbisect = .true.
-       call newton(sys, X, gmres_rdp, info, tolerance=atol_dp, options=opts)
+       call newton(sys, X, gmres_rdp, info, tolerance=10*atol_dp, options=opts)
        call X%sub(fp1)
 
        ! check fixed point 1 with bisection (if necessary)

--- a/test/TestNewtonKrylov.fypp
+++ b/test/TestNewtonKrylov.fypp
@@ -19,7 +19,8 @@ module TestNewtonKrylov
     
     private
 
-    character(len=128), parameter, private :: this_module = 'LightKrylov_TestNewtonKrylov'
+    character(len=*), parameter, private :: this_module      = 'LK_TNwtKryl'
+    character(len=*), parameter, private :: this_module_long = 'LightKrylov_TestNewtonKrylov'
 
     #:for kind in REAL_KINDS
     public :: collect_newton_r${kind}$_testsuite

--- a/test/TestNewtonKrylov.fypp
+++ b/test/TestNewtonKrylov.fypp
@@ -61,7 +61,7 @@ contains
        allocate(X, fp1, fp2);
 
        ! Newton opts
-       opts = newton_${kind}$_opts(maxiter=10, ifbisect=.false.) 
+       opts = newton_${kind}$_opts(maxiter=10, ifbisect=.false., if_print_metadata=.true.) 
 
        ! Allocate and set Roessler system and Jacobian
        sys = roessler_r${kind}$()
@@ -72,7 +72,7 @@ contains
        X%x = zero_r${kind}$
        X%y = zero_r${kind}$
        X%z = zero_r${kind}$
-       call newton(sys, X, gmres_r${kind}$, info, tolerance=atol_${kind}$, options=opts)
+       call newton(sys, X, gmres_r${kind}$, info, tolerance=10*atol_${kind}$, options=opts)
        call X%sub(fp1)
 
        ! check fixed point 1
@@ -86,7 +86,7 @@ contains
        X%x = 10.0_${kind}$
        X%y = -5.0_${kind}$
        X%z = 20.0_${kind}$
-       call newton(sys, X, gmres_r${kind}$, info, tolerance=atol_${kind}$, options=opts)
+       call newton(sys, X, gmres_r${kind}$, info, tolerance=10*atol_${kind}$, options=opts)
        call X%sub(fp2)
 
        ! check fixed point 2
@@ -101,7 +101,7 @@ contains
        X%y = zero_r${kind}$
        X%z = zero_r${kind}$
        opts%ifbisect = .true.
-       call newton(sys, X, gmres_r${kind}$, info, tolerance=atol_${kind}$, options=opts)
+       call newton(sys, X, gmres_r${kind}$, info, tolerance=10*atol_${kind}$, options=opts)
        call X%sub(fp1)
 
        ! check fixed point 1 with bisection (if necessary)

--- a/test/TestVectors.f90
+++ b/test/TestVectors.f90
@@ -15,7 +15,8 @@ module TestVectors
     
     private
 
-    character(len=128), parameter, private :: this_module = 'LightKrylov_TestVectors'
+    character(len=*), parameter, private :: this_module      = 'LK_TVectors'
+    character(len=*), parameter, private :: this_module_long = 'LightKrylov_TestVectors'
 
     public :: collect_vector_rsp_testsuite
     public :: collect_vector_rdp_testsuite

--- a/test/TestVectors.fypp
+++ b/test/TestVectors.fypp
@@ -17,7 +17,8 @@ module TestVectors
     
     private
 
-    character(len=128), parameter, private :: this_module = 'LightKrylov_TestVectors'
+    character(len=*), parameter, private :: this_module      = 'LK_TVectors'
+    character(len=*), parameter, private :: this_module_long = 'LightKrylov_TestVectors'
 
     #:for kind, type in RC_KINDS_TYPES
     public :: collect_vector_${type[0]}$${kind}$_testsuite


### PR DESCRIPTION
Main updates:

- Added `k_exptA_*` exports needed to define as default routine.
- Shortened module names to make logging output more readable. In tests, the default long name is used.
- Added abstract type 'abstract_metadata' and deployed to `cg`, `gmres` and `newton` solvers.
- Added `matvec`/`rmatvec` counters as private components to `abstract_linop` and corresponding `eval` counters to `abstract_system` types. 
*Note that these changes require the argument `self` in the type-bound procedures `matvec` and `rmatvec` as well as `eval` (renamed `response`) to be `intent(inout)`, which leads to changes throughout the toolbox.*
- Added utility functions and logic associated with counters. In particular, the wrappers `apply_matvec` and `apply_rmatvec` are used throughout to call `matvec` and `rmatvec` and increment the counter. The corresponding routines in `abstract_system` are `eval` that calls `response` and increments the counter.