### PR TITLE
Logger + Timer updates

### DIFF
--- a/example/ginzburg_landau/main.f90
+++ b/example/ginzburg_landau/main.f90
@@ -3,6 +3,7 @@ program demo
    use LightKrylov, only: wp => dp
    use LightKrylov
    use LightKrylov_Logger
+   use LightKrylov_Timing, only: timer => global_lightkrylov_timer
    use Ginzburg_Landau
    implicit none
 
@@ -45,6 +46,9 @@ program demo
    !> Set up logging
    call logger_setup()
 
+   !> Set up timing
+   call timer%initialize()
+
    !> Initialize physical parameters.
    call initialize_parameters()
 
@@ -79,5 +83,10 @@ program demo
 
    !> Save eigenvectors to disk.
    call save_npy("example/ginzburg_landau/eigenvectors.npy", eigenvectors)
+
+   ! Print timing info for exponential propagator
+   call A%print_timer_info()
+   ! Finalize timing
+   call timer%finalize()
 
 end program demo

--- a/example/ginzburg_landau/main.f90
+++ b/example/ginzburg_landau/main.f90
@@ -85,7 +85,7 @@ program demo
    call save_npy("example/ginzburg_landau/eigenvectors.npy", eigenvectors)
 
    ! Print timing info for exponential propagator
-   call A%print_timer_info()
+   call A%finalize_timer()
    ! Finalize timing
    call timer%finalize()
 

--- a/example/roessler/main.f90
+++ b/example/roessler/main.f90
@@ -42,6 +42,7 @@ program demo
    real(wp), dimension(r, r)       :: Lr
    ! IO
    character(len=20)    :: data_fmt, header_fmt
+   !integer, allocatable :: logunits(:)
 
    write (header_fmt, *) '(22X,*(A,2X))'
    write (data_fmt, *) '(A22,*(1X,F15.6))'
@@ -49,23 +50,42 @@ program demo
    ! Set up logging
    call logger_setup()
    call logger%configure(level=error_level, time_stamp=.false.)
-
-   call initialize_timers()
-   call global_timer%enumerate_timers()
-   call global_timer%start('gmres_rdp')
-   print '(A,*(I0,1X))', 'print', ( i, i = 1, 1000) 
-   call global_timer%stop('gmres_rdp')
-   !call global_timer%stop('gmres_test')
-   call global_timer%remove_timer('gmres_rdp')
-   call global_timer%enumerate_timers()
-   print *, timeit()
-   if (timeit()) call global_timer%start('svds_rsp')
-   print '(A,*(I0,1X))', 'print', ( i, i = 1, 1000)
-   if (timeit()) call global_timer%stop('svds_rsp')
-   call global_timer%enumerate_timers()
-   call finalize_timers()
-
-   STOP 8
+   !call logger%configuration(log_units=logunits)
+   !do i = 1, size(logunits)
+   !   print *, 'unit', logunits(i)
+   !end do
+   !call logger%remove_log_unit(logunits(1))
+   !call logger%configuration(log_units=logunits)
+   !do i = 1, size(logunits)
+   !   print *, 'unit', logunits(i)
+   !end do
+   !STOP 678
+!
+   !print *, time_lightkrylov()
+   !call global_timer%initialize()
+   !call global_timer%add_timer('my_test_timer')
+   !call global_timer%start('my_test_timer')
+   !print *, time_lightkrylov()
+   !call global_timer%enumerate()
+   !call global_timer%stop('my_test_timer')
+   !call global_timer%start('my_test_timer')
+   !if (time_lightkrylov()) call global_timer%start('svds_rsp')
+   !call global_timer%start('gmres_rdp')
+   !print '(A,*(I0,1X))', 'print ', ( i, i = 1, 1000) 
+   !call global_timer%stop('gmres_rdp')
+   !i = global_timer%get_timer_id('gmres_rdp')
+   !print *, 'ID', i
+   !!call global_timer%stop('gmres_test')
+   !call global_timer%remove_timer('gmres_rdp')
+   !call global_timer%enumerate()
+   !print *, time_lightkrylov()
+   !print '(A,*(I0,1X))', 'print ', ( i, i = 1, 1000)
+   !if (time_lightkrylov()) call global_timer%stop('svds_rsp')
+   !call global_timer%stop('my_test_timer')
+   !call global_timer%enumerate()
+   !call global_timer%finalize()
+!
+!   STOP 8
 
    ! Initialize baseflow and perturbation state vectors
    call bf%zero(); call dx%zero(); call residual%zero()

--- a/example/roessler/main.f90
+++ b/example/roessler/main.f90
@@ -10,8 +10,9 @@ program demo
    use LightKrylov
    use LightKrylov, only: wp => dp
    use LightKrylov_Logger
-   use lightkrylov_IterativeSolvers, only: gmres_rdp
+   use LightKrylov_Timer
    use LightKrylov_Utils
+   use lightkrylov_IterativeSolvers, only: gmres_rdp
    ! Roessler system
    use Roessler
    use Roessler_OTD
@@ -48,6 +49,23 @@ program demo
    ! Set up logging
    call logger_setup()
    call logger%configure(level=error_level, time_stamp=.false.)
+
+   call initialize_timers()
+   call global_timer%enumerate_timers()
+   call global_timer%start('gmres_rdp')
+   print '(A,*(I0,1X))', 'print', ( i, i = 1, 1000) 
+   call global_timer%stop('gmres_rdp')
+   !call global_timer%stop('gmres_test')
+   call global_timer%remove_timer('gmres_rdp')
+   call global_timer%enumerate_timers()
+   print *, timeit()
+   if (timeit()) call global_timer%start('svds_rsp')
+   print '(A,*(I0,1X))', 'print', ( i, i = 1, 1000)
+   if (timeit()) call global_timer%stop('svds_rsp')
+   call global_timer%enumerate_timers()
+   call finalize_timers()
+
+   STOP 8
 
    ! Initialize baseflow and perturbation state vectors
    call bf%zero(); call dx%zero(); call residual%zero()

--- a/example/roessler/main.f90
+++ b/example/roessler/main.f90
@@ -10,7 +10,7 @@ program demo
    use LightKrylov
    use LightKrylov, only: wp => dp
    use LightKrylov_Logger
-   use LightKrylov_Timer
+   use LightKrylov_Timing, only: timer => global_lightkrylov_timer
    use LightKrylov_Utils
    use lightkrylov_IterativeSolvers, only: gmres_rdp
    ! Roessler system
@@ -50,42 +50,9 @@ program demo
    ! Set up logging
    call logger_setup()
    call logger%configure(level=error_level, time_stamp=.false.)
-   !call logger%configuration(log_units=logunits)
-   !do i = 1, size(logunits)
-   !   print *, 'unit', logunits(i)
-   !end do
-   !call logger%remove_log_unit(logunits(1))
-   !call logger%configuration(log_units=logunits)
-   !do i = 1, size(logunits)
-   !   print *, 'unit', logunits(i)
-   !end do
-   !STOP 678
-!
-   !print *, time_lightkrylov()
-   !call global_timer%initialize()
-   !call global_timer%add_timer('my_test_timer')
-   !call global_timer%start('my_test_timer')
-   !print *, time_lightkrylov()
-   !call global_timer%enumerate()
-   !call global_timer%stop('my_test_timer')
-   !call global_timer%start('my_test_timer')
-   !if (time_lightkrylov()) call global_timer%start('svds_rsp')
-   !call global_timer%start('gmres_rdp')
-   !print '(A,*(I0,1X))', 'print ', ( i, i = 1, 1000) 
-   !call global_timer%stop('gmres_rdp')
-   !i = global_timer%get_timer_id('gmres_rdp')
-   !print *, 'ID', i
-   !!call global_timer%stop('gmres_test')
-   !call global_timer%remove_timer('gmres_rdp')
-   !call global_timer%enumerate()
-   !print *, time_lightkrylov()
-   !print '(A,*(I0,1X))', 'print ', ( i, i = 1, 1000)
-   !if (time_lightkrylov()) call global_timer%stop('svds_rsp')
-   !call global_timer%stop('my_test_timer')
-   !call global_timer%enumerate()
-   !call global_timer%finalize()
-!
-!   STOP 8
+
+   ! Set up timing
+   call timer%initialize()
 
    ! Initialize baseflow and perturbation state vectors
    call bf%zero(); call dx%zero(); call residual%zero()
@@ -275,5 +242,10 @@ program demo
    call rename(report_file_OTD, 'example/roessler/PO-chaos_OTD.txt')
    call rename(report_file_OTD_LE, 'example/roessler/PO-chaos_LE.txt')
    print *, ''
+
+   ! Print timing info for system evaulations
+   call sys%print_timer_info()
+   ! Finalize timing
+   call timer%finalize()
 
 end program demo

--- a/example/roessler/main.f90
+++ b/example/roessler/main.f90
@@ -92,6 +92,11 @@ program demo
    sys%jacobian = jacobian()
    sys%jacobian%X = bf
 
+   ! Reset eval timer
+   call sys%reset_timer()
+   ! Reset system timers
+   call timer%reset_all()
+
    ! Set tolerance
    tol = 1e-12_wp
 
@@ -134,6 +139,11 @@ program demo
    ! Compute the stability of the orbit
    sys%jacobian = floquet_operator()
    sys%jacobian%X = bf  ! <- periodic orbit
+   
+   ! Reset eval timer
+   call sys%reset_timer()
+   ! Reset system timers
+   call timer%reset_all()
 
    M = 0.0_wp
    Id = eye(npts)
@@ -244,7 +254,7 @@ program demo
    print *, ''
 
    ! Print timing info for system evaulations
-   call sys%print_timer_info()
+   call sys%finalize_timer()
    ! Finalize timing
    call timer%finalize()
 

--- a/src/AbstractLinops.f90
+++ b/src/AbstractLinops.f90
@@ -483,8 +483,14 @@ contains
         class(abstract_linop_rsp), intent(inout) :: self
         class(abstract_vector_rsp), intent(in) :: vec_in
         class(abstract_vector_rsp), intent(out) :: vec_out
+        ! internal 
+        character(len=128) :: msg
         self%matvec_counter = self%matvec_counter + 1
+        write(msg,'(I3,1X,A)') self%matvec_counter, 'start'
+        call logger%log_debug(msg, module=this_module, procedure='matvec')
         call self%matvec(vec_in, vec_out)
+        write(msg,'(I3,1X,A)') self%matvec_counter, 'end'
+        call logger%log_debug(msg, module=this_module, procedure='matvec')
         return
     end subroutine apply_matvec_rsp
 
@@ -492,16 +498,28 @@ contains
         class(abstract_linop_rsp), intent(inout) :: self
         class(abstract_vector_rsp), intent(in) :: vec_in
         class(abstract_vector_rsp), intent(out) :: vec_out
+        ! internal 
+        character(len=128) :: msg
         self%rmatvec_counter = self%rmatvec_counter + 1
+        write(msg,'(I3,1X,A)') self%rmatvec_counter, 'start'
+        call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         call self%rmatvec(vec_in, vec_out)
+         write(msg,'(I3,1X,A)') self%rmatvec_counter, 'end'
+        call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         return
     end subroutine apply_rmatvec_rsp
     subroutine apply_matvec_rdp(self, vec_in, vec_out)
         class(abstract_linop_rdp), intent(inout) :: self
         class(abstract_vector_rdp), intent(in) :: vec_in
         class(abstract_vector_rdp), intent(out) :: vec_out
+        ! internal 
+        character(len=128) :: msg
         self%matvec_counter = self%matvec_counter + 1
+        write(msg,'(I3,1X,A)') self%matvec_counter, 'start'
+        call logger%log_debug(msg, module=this_module, procedure='matvec')
         call self%matvec(vec_in, vec_out)
+        write(msg,'(I3,1X,A)') self%matvec_counter, 'end'
+        call logger%log_debug(msg, module=this_module, procedure='matvec')
         return
     end subroutine apply_matvec_rdp
 
@@ -509,16 +527,28 @@ contains
         class(abstract_linop_rdp), intent(inout) :: self
         class(abstract_vector_rdp), intent(in) :: vec_in
         class(abstract_vector_rdp), intent(out) :: vec_out
+        ! internal 
+        character(len=128) :: msg
         self%rmatvec_counter = self%rmatvec_counter + 1
+        write(msg,'(I3,1X,A)') self%rmatvec_counter, 'start'
+        call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         call self%rmatvec(vec_in, vec_out)
+         write(msg,'(I3,1X,A)') self%rmatvec_counter, 'end'
+        call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         return
     end subroutine apply_rmatvec_rdp
     subroutine apply_matvec_csp(self, vec_in, vec_out)
         class(abstract_linop_csp), intent(inout) :: self
         class(abstract_vector_csp), intent(in) :: vec_in
         class(abstract_vector_csp), intent(out) :: vec_out
+        ! internal 
+        character(len=128) :: msg
         self%matvec_counter = self%matvec_counter + 1
+        write(msg,'(I3,1X,A)') self%matvec_counter, 'start'
+        call logger%log_debug(msg, module=this_module, procedure='matvec')
         call self%matvec(vec_in, vec_out)
+        write(msg,'(I3,1X,A)') self%matvec_counter, 'end'
+        call logger%log_debug(msg, module=this_module, procedure='matvec')
         return
     end subroutine apply_matvec_csp
 
@@ -526,16 +556,28 @@ contains
         class(abstract_linop_csp), intent(inout) :: self
         class(abstract_vector_csp), intent(in) :: vec_in
         class(abstract_vector_csp), intent(out) :: vec_out
+        ! internal 
+        character(len=128) :: msg
         self%rmatvec_counter = self%rmatvec_counter + 1
+        write(msg,'(I3,1X,A)') self%rmatvec_counter, 'start'
+        call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         call self%rmatvec(vec_in, vec_out)
+         write(msg,'(I3,1X,A)') self%rmatvec_counter, 'end'
+        call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         return
     end subroutine apply_rmatvec_csp
     subroutine apply_matvec_cdp(self, vec_in, vec_out)
         class(abstract_linop_cdp), intent(inout) :: self
         class(abstract_vector_cdp), intent(in) :: vec_in
         class(abstract_vector_cdp), intent(out) :: vec_out
+        ! internal 
+        character(len=128) :: msg
         self%matvec_counter = self%matvec_counter + 1
+        write(msg,'(I3,1X,A)') self%matvec_counter, 'start'
+        call logger%log_debug(msg, module=this_module, procedure='matvec')
         call self%matvec(vec_in, vec_out)
+        write(msg,'(I3,1X,A)') self%matvec_counter, 'end'
+        call logger%log_debug(msg, module=this_module, procedure='matvec')
         return
     end subroutine apply_matvec_cdp
 
@@ -543,8 +585,14 @@ contains
         class(abstract_linop_cdp), intent(inout) :: self
         class(abstract_vector_cdp), intent(in) :: vec_in
         class(abstract_vector_cdp), intent(out) :: vec_out
+        ! internal 
+        character(len=128) :: msg
         self%rmatvec_counter = self%rmatvec_counter + 1
+        write(msg,'(I3,1X,A)') self%rmatvec_counter, 'start'
+        call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         call self%rmatvec(vec_in, vec_out)
+         write(msg,'(I3,1X,A)') self%rmatvec_counter, 'end'
+        call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         return
     end subroutine apply_rmatvec_cdp
 

--- a/src/AbstractLinops.f90
+++ b/src/AbstractLinops.f90
@@ -12,6 +12,7 @@ module LightKrylov_AbstractLinops
     use stdlib_optval, only: optval
     use LightKrylov_Logger
     use LightKrylov_Constants
+    use LightKrylov_Timer
     use LightKrylov_Utils
     use LightKrylov_AbstractVectors
     implicit none
@@ -29,6 +30,8 @@ module LightKrylov_AbstractLinops
         !!  @endwarning
         integer, private :: matvec_counter  = 0
         integer, private :: rmatvec_counter = 0
+        !type(timer_type) :: matvec_timer
+        !type(timer_type) :: rmatvec_timer
     contains
         procedure, pass(self), public :: get_counter
         !! Return matvec/rmatvec counter value
@@ -488,7 +491,9 @@ contains
         self%matvec_counter = self%matvec_counter + 1
         write(msg,'(I0,1X,A)') self%matvec_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='matvec')
+        !call self%matvec_timer%start()
         call self%matvec(vec_in, vec_out)
+        !call self%matvec_timer%stop()
         write(msg,'(I0,1X,A)') self%matvec_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='matvec')
         return
@@ -503,7 +508,9 @@ contains
         self%rmatvec_counter = self%rmatvec_counter + 1
         write(msg,'(I0,1X,A)') self%rmatvec_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
+        !call self%rmatvec_timer%start()
         call self%rmatvec(vec_in, vec_out)
+        !call self%rmatvec_timer%stop()
         write(msg,'(I0,1X,A)') self%rmatvec_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         return
@@ -517,7 +524,9 @@ contains
         self%matvec_counter = self%matvec_counter + 1
         write(msg,'(I0,1X,A)') self%matvec_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='matvec')
+        !call self%matvec_timer%start()
         call self%matvec(vec_in, vec_out)
+        !call self%matvec_timer%stop()
         write(msg,'(I0,1X,A)') self%matvec_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='matvec')
         return
@@ -532,7 +541,9 @@ contains
         self%rmatvec_counter = self%rmatvec_counter + 1
         write(msg,'(I0,1X,A)') self%rmatvec_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
+        !call self%rmatvec_timer%start()
         call self%rmatvec(vec_in, vec_out)
+        !call self%rmatvec_timer%stop()
         write(msg,'(I0,1X,A)') self%rmatvec_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         return
@@ -546,7 +557,9 @@ contains
         self%matvec_counter = self%matvec_counter + 1
         write(msg,'(I0,1X,A)') self%matvec_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='matvec')
+        !call self%matvec_timer%start()
         call self%matvec(vec_in, vec_out)
+        !call self%matvec_timer%stop()
         write(msg,'(I0,1X,A)') self%matvec_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='matvec')
         return
@@ -561,7 +574,9 @@ contains
         self%rmatvec_counter = self%rmatvec_counter + 1
         write(msg,'(I0,1X,A)') self%rmatvec_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
+        !call self%rmatvec_timer%start()
         call self%rmatvec(vec_in, vec_out)
+        !call self%rmatvec_timer%stop()
         write(msg,'(I0,1X,A)') self%rmatvec_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         return
@@ -575,7 +590,9 @@ contains
         self%matvec_counter = self%matvec_counter + 1
         write(msg,'(I0,1X,A)') self%matvec_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='matvec')
+        !call self%matvec_timer%start()
         call self%matvec(vec_in, vec_out)
+        !call self%matvec_timer%stop()
         write(msg,'(I0,1X,A)') self%matvec_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='matvec')
         return
@@ -590,7 +607,9 @@ contains
         self%rmatvec_counter = self%rmatvec_counter + 1
         write(msg,'(I0,1X,A)') self%rmatvec_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
+        !call self%rmatvec_timer%start()
         call self%rmatvec(vec_in, vec_out)
+        !call self%rmatvec_timer%stop()
         write(msg,'(I0,1X,A)') self%rmatvec_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         return

--- a/src/AbstractLinops.f90
+++ b/src/AbstractLinops.f90
@@ -504,7 +504,7 @@ contains
         write(msg,'(I3,1X,A)') self%rmatvec_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         call self%rmatvec(vec_in, vec_out)
-         write(msg,'(I3,1X,A)') self%rmatvec_counter, 'end'
+        write(msg,'(I3,1X,A)') self%rmatvec_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         return
     end subroutine apply_rmatvec_rsp
@@ -533,7 +533,7 @@ contains
         write(msg,'(I3,1X,A)') self%rmatvec_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         call self%rmatvec(vec_in, vec_out)
-         write(msg,'(I3,1X,A)') self%rmatvec_counter, 'end'
+        write(msg,'(I3,1X,A)') self%rmatvec_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         return
     end subroutine apply_rmatvec_rdp
@@ -562,7 +562,7 @@ contains
         write(msg,'(I3,1X,A)') self%rmatvec_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         call self%rmatvec(vec_in, vec_out)
-         write(msg,'(I3,1X,A)') self%rmatvec_counter, 'end'
+        write(msg,'(I3,1X,A)') self%rmatvec_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         return
     end subroutine apply_rmatvec_csp
@@ -591,7 +591,7 @@ contains
         write(msg,'(I3,1X,A)') self%rmatvec_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         call self%rmatvec(vec_in, vec_out)
-         write(msg,'(I3,1X,A)') self%rmatvec_counter, 'end'
+        write(msg,'(I3,1X,A)') self%rmatvec_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         return
     end subroutine apply_rmatvec_cdp

--- a/src/AbstractLinops.f90
+++ b/src/AbstractLinops.f90
@@ -39,6 +39,8 @@ module LightKrylov_AbstractLinops
         !! Reset matvec/rmatvec counter
         procedure, pass(self), public :: print_timer_info
         !! Print current timer information
+        procedure, pass(self), public :: reset_timer
+        !! Reset current timer information
     end type abstract_linop
 
     !------------------------------------------------------------------------------
@@ -493,6 +495,20 @@ contains
         call self%matvec_timer%print_info()
       end if
     end subroutine print_timer_info
+
+    subroutine reset_timer(self, trans)
+      !! Setter routine to reset the system evaluation timer
+      class(abstract_system), intent(inout) :: self
+      logical, optional, intent(in) :: trans
+      ! internal
+      logical :: transpose
+      transpose = optval(trans, .false.)
+      if (transpose) then
+        call self%rmatvec_timer%reset()
+      else
+        call self%matvec_timer%reset()
+      end if
+    end subroutine reset_timer
 
     !---------------------------------------------------------------------
     !-----     Wrappers for matvec/rmatvec to increment counters     -----

--- a/src/AbstractLinops.f90
+++ b/src/AbstractLinops.f90
@@ -486,10 +486,10 @@ contains
         ! internal 
         character(len=128) :: msg
         self%matvec_counter = self%matvec_counter + 1
-        write(msg,'(I3,1X,A)') self%matvec_counter, 'start'
+        write(msg,'(I0,1X,A)') self%matvec_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='matvec')
         call self%matvec(vec_in, vec_out)
-        write(msg,'(I3,1X,A)') self%matvec_counter, 'end'
+        write(msg,'(I0,1X,A)') self%matvec_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='matvec')
         return
     end subroutine apply_matvec_rsp
@@ -501,10 +501,10 @@ contains
         ! internal 
         character(len=128) :: msg
         self%rmatvec_counter = self%rmatvec_counter + 1
-        write(msg,'(I3,1X,A)') self%rmatvec_counter, 'start'
+        write(msg,'(I0,1X,A)') self%rmatvec_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         call self%rmatvec(vec_in, vec_out)
-        write(msg,'(I3,1X,A)') self%rmatvec_counter, 'end'
+        write(msg,'(I0,1X,A)') self%rmatvec_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         return
     end subroutine apply_rmatvec_rsp
@@ -515,10 +515,10 @@ contains
         ! internal 
         character(len=128) :: msg
         self%matvec_counter = self%matvec_counter + 1
-        write(msg,'(I3,1X,A)') self%matvec_counter, 'start'
+        write(msg,'(I0,1X,A)') self%matvec_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='matvec')
         call self%matvec(vec_in, vec_out)
-        write(msg,'(I3,1X,A)') self%matvec_counter, 'end'
+        write(msg,'(I0,1X,A)') self%matvec_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='matvec')
         return
     end subroutine apply_matvec_rdp
@@ -530,10 +530,10 @@ contains
         ! internal 
         character(len=128) :: msg
         self%rmatvec_counter = self%rmatvec_counter + 1
-        write(msg,'(I3,1X,A)') self%rmatvec_counter, 'start'
+        write(msg,'(I0,1X,A)') self%rmatvec_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         call self%rmatvec(vec_in, vec_out)
-        write(msg,'(I3,1X,A)') self%rmatvec_counter, 'end'
+        write(msg,'(I0,1X,A)') self%rmatvec_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         return
     end subroutine apply_rmatvec_rdp
@@ -544,10 +544,10 @@ contains
         ! internal 
         character(len=128) :: msg
         self%matvec_counter = self%matvec_counter + 1
-        write(msg,'(I3,1X,A)') self%matvec_counter, 'start'
+        write(msg,'(I0,1X,A)') self%matvec_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='matvec')
         call self%matvec(vec_in, vec_out)
-        write(msg,'(I3,1X,A)') self%matvec_counter, 'end'
+        write(msg,'(I0,1X,A)') self%matvec_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='matvec')
         return
     end subroutine apply_matvec_csp
@@ -559,10 +559,10 @@ contains
         ! internal 
         character(len=128) :: msg
         self%rmatvec_counter = self%rmatvec_counter + 1
-        write(msg,'(I3,1X,A)') self%rmatvec_counter, 'start'
+        write(msg,'(I0,1X,A)') self%rmatvec_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         call self%rmatvec(vec_in, vec_out)
-        write(msg,'(I3,1X,A)') self%rmatvec_counter, 'end'
+        write(msg,'(I0,1X,A)') self%rmatvec_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         return
     end subroutine apply_rmatvec_csp
@@ -573,10 +573,10 @@ contains
         ! internal 
         character(len=128) :: msg
         self%matvec_counter = self%matvec_counter + 1
-        write(msg,'(I3,1X,A)') self%matvec_counter, 'start'
+        write(msg,'(I0,1X,A)') self%matvec_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='matvec')
         call self%matvec(vec_in, vec_out)
-        write(msg,'(I3,1X,A)') self%matvec_counter, 'end'
+        write(msg,'(I0,1X,A)') self%matvec_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='matvec')
         return
     end subroutine apply_matvec_cdp
@@ -588,10 +588,10 @@ contains
         ! internal 
         character(len=128) :: msg
         self%rmatvec_counter = self%rmatvec_counter + 1
-        write(msg,'(I3,1X,A)') self%rmatvec_counter, 'start'
+        write(msg,'(I0,1X,A)') self%rmatvec_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         call self%rmatvec(vec_in, vec_out)
-        write(msg,'(I3,1X,A)') self%rmatvec_counter, 'end'
+        write(msg,'(I0,1X,A)') self%rmatvec_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         return
     end subroutine apply_rmatvec_cdp

--- a/src/AbstractLinops.f90
+++ b/src/AbstractLinops.f90
@@ -12,7 +12,7 @@ module LightKrylov_AbstractLinops
     use stdlib_optval, only: optval
     use LightKrylov_Logger
     use LightKrylov_Constants
-    use LightKrylov_Timer
+    use LightKrylov_Timing
     use LightKrylov_Utils
     use LightKrylov_AbstractVectors
     implicit none
@@ -30,13 +30,15 @@ module LightKrylov_AbstractLinops
         !!  @endwarning
         integer, private :: matvec_counter  = 0
         integer, private :: rmatvec_counter = 0
-        !type(timer_type) :: matvec_timer
-        !type(timer_type) :: rmatvec_timer
+        type(lightkrylov_timer) :: matvec_timer  = lightkrylov_timer('matvec timer')
+        type(lightkrylov_timer) :: rmatvec_timer = lightkrylov_timer('rmatvec timer')
     contains
         procedure, pass(self), public :: get_counter
         !! Return matvec/rmatvec counter value
         procedure, pass(self), public :: reset_counter
         !! Reset matvec/rmatvec counter
+        procedure, pass(self), public :: print_timer_info
+        !! Print current timer information
     end type abstract_linop
 
     !------------------------------------------------------------------------------
@@ -478,6 +480,20 @@ contains
       return
     end subroutine reset_counter
 
+    subroutine print_timer_info(self, trans)
+      !! Getter routine to print the current timing information for the system evaluation
+      class(abstract_linop), intent(inout) :: self
+      logical, optional, intent(in) :: trans
+      ! internal
+      logical :: transpose
+      transpose = optval(trans, .false.)
+      if (transpose) then
+        call self%rmatvec_timer%print_info()
+      else
+        call self%matvec_timer%print_info()
+      end if
+    end subroutine print_timer_info
+
     !---------------------------------------------------------------------
     !-----     Wrappers for matvec/rmatvec to increment counters     -----
     !---------------------------------------------------------------------
@@ -491,9 +507,9 @@ contains
         self%matvec_counter = self%matvec_counter + 1
         write(msg,'(I0,1X,A)') self%matvec_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='matvec')
-        !call self%matvec_timer%start()
+        call self%matvec_timer%start()
         call self%matvec(vec_in, vec_out)
-        !call self%matvec_timer%stop()
+        call self%matvec_timer%stop()
         write(msg,'(I0,1X,A)') self%matvec_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='matvec')
         return
@@ -508,9 +524,9 @@ contains
         self%rmatvec_counter = self%rmatvec_counter + 1
         write(msg,'(I0,1X,A)') self%rmatvec_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
-        !call self%rmatvec_timer%start()
+        call self%rmatvec_timer%start()
         call self%rmatvec(vec_in, vec_out)
-        !call self%rmatvec_timer%stop()
+        call self%rmatvec_timer%stop()
         write(msg,'(I0,1X,A)') self%rmatvec_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         return
@@ -524,9 +540,9 @@ contains
         self%matvec_counter = self%matvec_counter + 1
         write(msg,'(I0,1X,A)') self%matvec_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='matvec')
-        !call self%matvec_timer%start()
+        call self%matvec_timer%start()
         call self%matvec(vec_in, vec_out)
-        !call self%matvec_timer%stop()
+        call self%matvec_timer%stop()
         write(msg,'(I0,1X,A)') self%matvec_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='matvec')
         return
@@ -541,9 +557,9 @@ contains
         self%rmatvec_counter = self%rmatvec_counter + 1
         write(msg,'(I0,1X,A)') self%rmatvec_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
-        !call self%rmatvec_timer%start()
+        call self%rmatvec_timer%start()
         call self%rmatvec(vec_in, vec_out)
-        !call self%rmatvec_timer%stop()
+        call self%rmatvec_timer%stop()
         write(msg,'(I0,1X,A)') self%rmatvec_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         return
@@ -557,9 +573,9 @@ contains
         self%matvec_counter = self%matvec_counter + 1
         write(msg,'(I0,1X,A)') self%matvec_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='matvec')
-        !call self%matvec_timer%start()
+        call self%matvec_timer%start()
         call self%matvec(vec_in, vec_out)
-        !call self%matvec_timer%stop()
+        call self%matvec_timer%stop()
         write(msg,'(I0,1X,A)') self%matvec_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='matvec')
         return
@@ -574,9 +590,9 @@ contains
         self%rmatvec_counter = self%rmatvec_counter + 1
         write(msg,'(I0,1X,A)') self%rmatvec_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
-        !call self%rmatvec_timer%start()
+        call self%rmatvec_timer%start()
         call self%rmatvec(vec_in, vec_out)
-        !call self%rmatvec_timer%stop()
+        call self%rmatvec_timer%stop()
         write(msg,'(I0,1X,A)') self%rmatvec_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         return
@@ -590,9 +606,9 @@ contains
         self%matvec_counter = self%matvec_counter + 1
         write(msg,'(I0,1X,A)') self%matvec_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='matvec')
-        !call self%matvec_timer%start()
+        call self%matvec_timer%start()
         call self%matvec(vec_in, vec_out)
-        !call self%matvec_timer%stop()
+        call self%matvec_timer%stop()
         write(msg,'(I0,1X,A)') self%matvec_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='matvec')
         return
@@ -607,9 +623,9 @@ contains
         self%rmatvec_counter = self%rmatvec_counter + 1
         write(msg,'(I0,1X,A)') self%rmatvec_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
-        !call self%rmatvec_timer%start()
+        call self%rmatvec_timer%start()
         call self%rmatvec(vec_in, vec_out)
-        !call self%rmatvec_timer%stop()
+        call self%rmatvec_timer%stop()
         write(msg,'(I0,1X,A)') self%rmatvec_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         return

--- a/src/AbstractLinops.fypp
+++ b/src/AbstractLinops.fypp
@@ -232,8 +232,14 @@ contains
         class(abstract_linop_${type[0]}$${kind}$), intent(inout) :: self
         class(abstract_vector_${type[0]}$${kind}$), intent(in) :: vec_in
         class(abstract_vector_${type[0]}$${kind}$), intent(out) :: vec_out
+        ! internal 
+        character(len=128) :: msg
         self%matvec_counter = self%matvec_counter + 1
+        write(msg,'(I3,1X,A)') self%matvec_counter, 'start'
+        call logger%log_debug(msg, module=this_module, procedure='matvec')
         call self%matvec(vec_in, vec_out)
+        write(msg,'(I3,1X,A)') self%matvec_counter, 'end'
+        call logger%log_debug(msg, module=this_module, procedure='matvec')
         return
     end subroutine apply_matvec_${type[0]}$${kind}$
 
@@ -241,8 +247,14 @@ contains
         class(abstract_linop_${type[0]}$${kind}$), intent(inout) :: self
         class(abstract_vector_${type[0]}$${kind}$), intent(in) :: vec_in
         class(abstract_vector_${type[0]}$${kind}$), intent(out) :: vec_out
+        ! internal 
+        character(len=128) :: msg
         self%rmatvec_counter = self%rmatvec_counter + 1
+        write(msg,'(I3,1X,A)') self%rmatvec_counter, 'start'
+        call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         call self%rmatvec(vec_in, vec_out)
+         write(msg,'(I3,1X,A)') self%rmatvec_counter, 'end'
+        call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         return
     end subroutine apply_rmatvec_${type[0]}$${kind}$
     #:endfor

--- a/src/AbstractLinops.fypp
+++ b/src/AbstractLinops.fypp
@@ -41,6 +41,8 @@ module LightKrylov_AbstractLinops
         !! Reset matvec/rmatvec counter
         procedure, pass(self), public :: print_timer_info
         !! Print current timer information
+        procedure, pass(self), public :: reset_timer
+        !! Reset current timer information
     end type abstract_linop
 
     #:for kind, type in RC_KINDS_TYPES
@@ -241,6 +243,20 @@ contains
         call self%matvec_timer%print_info()
       end if
     end subroutine print_timer_info
+
+    subroutine reset_timer(self, trans)
+      !! Setter routine to reset the system evaluation timer
+      class(abstract_system), intent(inout) :: self
+      logical, optional, intent(in) :: trans
+      ! internal
+      logical :: transpose
+      transpose = optval(trans, .false.)
+      if (transpose) then
+        call self%rmatvec_timer%reset()
+      else
+        call self%matvec_timer%reset()
+      end if
+    end subroutine reset_timer
 
     !---------------------------------------------------------------------
     !-----     Wrappers for matvec/rmatvec to increment counters     -----

--- a/src/AbstractLinops.fypp
+++ b/src/AbstractLinops.fypp
@@ -235,10 +235,10 @@ contains
         ! internal 
         character(len=128) :: msg
         self%matvec_counter = self%matvec_counter + 1
-        write(msg,'(I3,1X,A)') self%matvec_counter, 'start'
+        write(msg,'(I0,1X,A)') self%matvec_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='matvec')
         call self%matvec(vec_in, vec_out)
-        write(msg,'(I3,1X,A)') self%matvec_counter, 'end'
+        write(msg,'(I0,1X,A)') self%matvec_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='matvec')
         return
     end subroutine apply_matvec_${type[0]}$${kind}$
@@ -250,10 +250,10 @@ contains
         ! internal 
         character(len=128) :: msg
         self%rmatvec_counter = self%rmatvec_counter + 1
-        write(msg,'(I3,1X,A)') self%rmatvec_counter, 'start'
+        write(msg,'(I0,1X,A)') self%rmatvec_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         call self%rmatvec(vec_in, vec_out)
-        write(msg,'(I3,1X,A)') self%rmatvec_counter, 'end'
+        write(msg,'(I0,1X,A)') self%rmatvec_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         return
     end subroutine apply_rmatvec_${type[0]}$${kind}$

--- a/src/AbstractLinops.fypp
+++ b/src/AbstractLinops.fypp
@@ -43,6 +43,8 @@ module LightKrylov_AbstractLinops
         !! Print current timer information
         procedure, pass(self), public :: reset_timer
         !! Reset current timer information
+        procedure, pass(self), public :: finalize_timer
+        !! Finalize timers and print complete history_info
     end type abstract_linop
 
     #:for kind, type in RC_KINDS_TYPES
@@ -203,7 +205,7 @@ contains
       end if
     end function get_counter
 
-    subroutine reset_counter(self, trans, procedure, counter)
+    subroutine reset_counter(self, trans, procedure, counter, reset_timer)
       class(abstract_linop), intent(inout) :: self
       logical, intent(in) :: trans
       !! matvec or rmatvec?
@@ -211,11 +213,15 @@ contains
       !! name of the caller routine
       integer, optional, intent(in) :: counter
       !! optional flag to reset to an integer other than zero.
+      logical, optional, intent(in) :: reset_timer
+      !! optional flag to reset also the timers (while saving the timing data)
       ! internals
       integer :: counter_, count_old
+      logical :: reset_timer_
       character(len=128) :: msg
       counter_ = optval(counter, 0)
       count_old = self%get_counter(trans)
+      reset_timer_ = optval(reset_timer, .true.)
       if ( count_old /= 0 .or. counter_ /= 0) then
         if (trans) then
             write(msg,'(A,I0,A,I0,A)') 'Total number of rmatvecs: ', count_old, '. Resetting counter to ', counter_, '.'
@@ -227,6 +233,7 @@ contains
             self%matvec_counter = counter_
         end if
       end if
+      if (reset_timer_) call self%reset_timer(trans)
       return
     end subroutine reset_counter
 
@@ -244,19 +251,27 @@ contains
       end if
     end subroutine print_timer_info
 
-    subroutine reset_timer(self, trans)
+    subroutine reset_timer(self, trans, save_history)
       !! Setter routine to reset the system evaluation timer
-      class(abstract_system), intent(inout) :: self
+      class(abstract_linop), intent(inout) :: self
       logical, optional, intent(in) :: trans
+      logical, optional, intent(in) :: save_history
       ! internal
       logical :: transpose
       transpose = optval(trans, .false.)
       if (transpose) then
-        call self%rmatvec_timer%reset()
+        call self%rmatvec_timer%reset(save_history)
       else
-        call self%matvec_timer%reset()
+        call self%matvec_timer%reset(save_history)
       end if
     end subroutine reset_timer
+
+    subroutine finalize_timer(self)
+      !! Setter routine to reset the system evaluation timer
+      class(abstract_linop), intent(inout) :: self
+      call self%matvec_timer%finalize()
+      call self%rmatvec_timer%finalize()
+    end subroutine finalize_timer
 
     !---------------------------------------------------------------------
     !-----     Wrappers for matvec/rmatvec to increment counters     -----

--- a/src/AbstractLinops.fypp
+++ b/src/AbstractLinops.fypp
@@ -14,6 +14,7 @@ module LightKrylov_AbstractLinops
     use stdlib_optval, only: optval
     use LightKrylov_Logger
     use LightKrylov_Constants
+    use LightKrylov_Timer
     use LightKrylov_Utils
     use LightKrylov_AbstractVectors
     implicit none
@@ -31,6 +32,8 @@ module LightKrylov_AbstractLinops
         !!  @endwarning
         integer, private :: matvec_counter  = 0
         integer, private :: rmatvec_counter = 0
+        !type(timer_type) :: matvec_timer
+        !type(timer_type) :: rmatvec_timer
     contains
         procedure, pass(self), public :: get_counter
         !! Return matvec/rmatvec counter value
@@ -237,7 +240,9 @@ contains
         self%matvec_counter = self%matvec_counter + 1
         write(msg,'(I0,1X,A)') self%matvec_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='matvec')
+        !call self%matvec_timer%start()
         call self%matvec(vec_in, vec_out)
+        !call self%matvec_timer%stop()
         write(msg,'(I0,1X,A)') self%matvec_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='matvec')
         return
@@ -252,7 +257,9 @@ contains
         self%rmatvec_counter = self%rmatvec_counter + 1
         write(msg,'(I0,1X,A)') self%rmatvec_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
+        !call self%rmatvec_timer%start()
         call self%rmatvec(vec_in, vec_out)
+        !call self%rmatvec_timer%stop()
         write(msg,'(I0,1X,A)') self%rmatvec_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         return

--- a/src/AbstractLinops.fypp
+++ b/src/AbstractLinops.fypp
@@ -253,7 +253,7 @@ contains
         write(msg,'(I3,1X,A)') self%rmatvec_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         call self%rmatvec(vec_in, vec_out)
-         write(msg,'(I3,1X,A)') self%rmatvec_counter, 'end'
+        write(msg,'(I3,1X,A)') self%rmatvec_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         return
     end subroutine apply_rmatvec_${type[0]}$${kind}$

--- a/src/AbstractLinops.fypp
+++ b/src/AbstractLinops.fypp
@@ -14,7 +14,7 @@ module LightKrylov_AbstractLinops
     use stdlib_optval, only: optval
     use LightKrylov_Logger
     use LightKrylov_Constants
-    use LightKrylov_Timer
+    use LightKrylov_Timing
     use LightKrylov_Utils
     use LightKrylov_AbstractVectors
     implicit none
@@ -32,13 +32,15 @@ module LightKrylov_AbstractLinops
         !!  @endwarning
         integer, private :: matvec_counter  = 0
         integer, private :: rmatvec_counter = 0
-        !type(timer_type) :: matvec_timer
-        !type(timer_type) :: rmatvec_timer
+        type(lightkrylov_timer) :: matvec_timer  = lightkrylov_timer('matvec timer')
+        type(lightkrylov_timer) :: rmatvec_timer = lightkrylov_timer('rmatvec timer')
     contains
         procedure, pass(self), public :: get_counter
         !! Return matvec/rmatvec counter value
         procedure, pass(self), public :: reset_counter
         !! Reset matvec/rmatvec counter
+        procedure, pass(self), public :: print_timer_info
+        !! Print current timer information
     end type abstract_linop
 
     #:for kind, type in RC_KINDS_TYPES
@@ -226,6 +228,20 @@ contains
       return
     end subroutine reset_counter
 
+    subroutine print_timer_info(self, trans)
+      !! Getter routine to print the current timing information for the system evaluation
+      class(abstract_linop), intent(inout) :: self
+      logical, optional, intent(in) :: trans
+      ! internal
+      logical :: transpose
+      transpose = optval(trans, .false.)
+      if (transpose) then
+        call self%rmatvec_timer%print_info()
+      else
+        call self%matvec_timer%print_info()
+      end if
+    end subroutine print_timer_info
+
     !---------------------------------------------------------------------
     !-----     Wrappers for matvec/rmatvec to increment counters     -----
     !---------------------------------------------------------------------
@@ -240,9 +256,9 @@ contains
         self%matvec_counter = self%matvec_counter + 1
         write(msg,'(I0,1X,A)') self%matvec_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='matvec')
-        !call self%matvec_timer%start()
+        call self%matvec_timer%start()
         call self%matvec(vec_in, vec_out)
-        !call self%matvec_timer%stop()
+        call self%matvec_timer%stop()
         write(msg,'(I0,1X,A)') self%matvec_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='matvec')
         return
@@ -257,9 +273,9 @@ contains
         self%rmatvec_counter = self%rmatvec_counter + 1
         write(msg,'(I0,1X,A)') self%rmatvec_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
-        !call self%rmatvec_timer%start()
+        call self%rmatvec_timer%start()
         call self%rmatvec(vec_in, vec_out)
-        !call self%rmatvec_timer%stop()
+        call self%rmatvec_timer%stop()
         write(msg,'(I0,1X,A)') self%rmatvec_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='rmatvec')
         return

--- a/src/AbstractSystems.f90
+++ b/src/AbstractSystems.f90
@@ -231,8 +231,14 @@ contains
         class(abstract_vector_rsp), intent(in)    :: vec_in
         class(abstract_vector_rsp), intent(out)   :: vec_out
         real(sp),                             intent(in)    :: atol
+        ! internal
+        character(len=128) :: msg
         self%eval_counter = self%eval_counter + 1
+        write(msg,'(I3,1X,A)') self%eval_counter, 'start'
+        call logger%log_debug(msg, module=this_module, procedure='response')
         call self%response(vec_in, vec_out, atol)
+        write(msg,'(I3,1X,A)') self%eval_counter, 'end'
+        call logger%log_debug(msg, module=this_module, procedure='response')
         return
     end subroutine eval_rsp
     subroutine eval_rdp(self, vec_in, vec_out, atol)
@@ -240,8 +246,14 @@ contains
         class(abstract_vector_rdp), intent(in)    :: vec_in
         class(abstract_vector_rdp), intent(out)   :: vec_out
         real(dp),                             intent(in)    :: atol
+        ! internal
+        character(len=128) :: msg
         self%eval_counter = self%eval_counter + 1
+        write(msg,'(I3,1X,A)') self%eval_counter, 'start'
+        call logger%log_debug(msg, module=this_module, procedure='response')
         call self%response(vec_in, vec_out, atol)
+        write(msg,'(I3,1X,A)') self%eval_counter, 'end'
+        call logger%log_debug(msg, module=this_module, procedure='response')
         return
     end subroutine eval_rdp
     subroutine eval_csp(self, vec_in, vec_out, atol)
@@ -249,8 +261,14 @@ contains
         class(abstract_vector_csp), intent(in)    :: vec_in
         class(abstract_vector_csp), intent(out)   :: vec_out
         real(sp),                             intent(in)    :: atol
+        ! internal
+        character(len=128) :: msg
         self%eval_counter = self%eval_counter + 1
+        write(msg,'(I3,1X,A)') self%eval_counter, 'start'
+        call logger%log_debug(msg, module=this_module, procedure='response')
         call self%response(vec_in, vec_out, atol)
+        write(msg,'(I3,1X,A)') self%eval_counter, 'end'
+        call logger%log_debug(msg, module=this_module, procedure='response')
         return
     end subroutine eval_csp
     subroutine eval_cdp(self, vec_in, vec_out, atol)
@@ -258,8 +276,14 @@ contains
         class(abstract_vector_cdp), intent(in)    :: vec_in
         class(abstract_vector_cdp), intent(out)   :: vec_out
         real(dp),                             intent(in)    :: atol
+        ! internal
+        character(len=128) :: msg
         self%eval_counter = self%eval_counter + 1
+        write(msg,'(I3,1X,A)') self%eval_counter, 'start'
+        call logger%log_debug(msg, module=this_module, procedure='response')
         call self%response(vec_in, vec_out, atol)
+        write(msg,'(I3,1X,A)') self%eval_counter, 'end'
+        call logger%log_debug(msg, module=this_module, procedure='response')
         return
     end subroutine eval_cdp
 

--- a/src/AbstractSystems.f90
+++ b/src/AbstractSystems.f90
@@ -25,6 +25,8 @@ module LightKrylov_AbstractSystems
         !! Reset eval counter
         procedure, pass(self), public :: print_timer_info
         !! Print current timer information
+        procedure, pass(self), public :: reset_timer
+        !! Reset current timer information
     end type abstract_system
 
     !----------------------------------------------------------------------------
@@ -231,6 +233,12 @@ contains
       class(abstract_system), intent(inout) :: self
       call self%eval_timer%print_info()
     end subroutine print_timer_info
+
+    subroutine reset_timer(self)
+      !! Setter routine to reset the system evaluation timer
+      class(abstract_system), intent(inout) :: self
+      call self%eval_timer%reset()
+    end subroutine reset_timer
 
     !---------------------------------------------------------------------
     !-----     Wrapper for system response to increment counters     -----

--- a/src/AbstractSystems.f90
+++ b/src/AbstractSystems.f90
@@ -4,6 +4,7 @@ module LightKrylov_AbstractSystems
     use stdlib_optval, only: optval
     use LightKrylov_Logger
     use LightKrylov_Constants
+    use LightKrylov_Timing
     use LightKrylov_AbstractVectors
     use LightKrylov_AbstractLinops
     implicit none
@@ -16,11 +17,14 @@ module LightKrylov_AbstractSystems
     type, abstract, public :: abstract_system
     private
         integer :: eval_counter = 0
+        type(lightkrylov_timer) :: eval_timer = lightkrylov_timer('system eval timer')
     contains
         procedure, pass(self), public :: get_eval_counter
         !! Return eval counter value
         procedure, pass(self), public :: reset_eval_counter
         !! Reset eval counter
+        procedure, pass(self), public :: print_timer_info
+        !! Print current timer information
     end type abstract_system
 
     !----------------------------------------------------------------------------
@@ -222,6 +226,12 @@ contains
       return
     end subroutine reset_eval_counter
 
+    subroutine print_timer_info(self)
+      !! Getter routine to print the current timing information for the system evaluation
+      class(abstract_system), intent(inout) :: self
+      call self%eval_timer%print_info()
+    end subroutine print_timer_info
+
     !---------------------------------------------------------------------
     !-----     Wrapper for system response to increment counters     -----
     !---------------------------------------------------------------------
@@ -236,7 +246,9 @@ contains
         self%eval_counter = self%eval_counter + 1
         write(msg,'(I0,1X,A)') self%eval_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='response')
+        call self%eval_timer%start()
         call self%response(vec_in, vec_out, atol)
+        call self%eval_timer%stop()
         write(msg,'(I0,1X,A)') self%eval_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='response')
         return
@@ -251,7 +263,9 @@ contains
         self%eval_counter = self%eval_counter + 1
         write(msg,'(I0,1X,A)') self%eval_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='response')
+        call self%eval_timer%start()
         call self%response(vec_in, vec_out, atol)
+        call self%eval_timer%stop()
         write(msg,'(I0,1X,A)') self%eval_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='response')
         return
@@ -266,7 +280,9 @@ contains
         self%eval_counter = self%eval_counter + 1
         write(msg,'(I0,1X,A)') self%eval_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='response')
+        call self%eval_timer%start()
         call self%response(vec_in, vec_out, atol)
+        call self%eval_timer%stop()
         write(msg,'(I0,1X,A)') self%eval_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='response')
         return
@@ -281,7 +297,9 @@ contains
         self%eval_counter = self%eval_counter + 1
         write(msg,'(I0,1X,A)') self%eval_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='response')
+        call self%eval_timer%start()
         call self%response(vec_in, vec_out, atol)
+        call self%eval_timer%stop()
         write(msg,'(I0,1X,A)') self%eval_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='response')
         return

--- a/src/AbstractSystems.f90
+++ b/src/AbstractSystems.f90
@@ -234,10 +234,10 @@ contains
         ! internal
         character(len=128) :: msg
         self%eval_counter = self%eval_counter + 1
-        write(msg,'(I3,1X,A)') self%eval_counter, 'start'
+        write(msg,'(I0,1X,A)') self%eval_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='response')
         call self%response(vec_in, vec_out, atol)
-        write(msg,'(I3,1X,A)') self%eval_counter, 'end'
+        write(msg,'(I0,1X,A)') self%eval_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='response')
         return
     end subroutine eval_rsp
@@ -249,10 +249,10 @@ contains
         ! internal
         character(len=128) :: msg
         self%eval_counter = self%eval_counter + 1
-        write(msg,'(I3,1X,A)') self%eval_counter, 'start'
+        write(msg,'(I0,1X,A)') self%eval_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='response')
         call self%response(vec_in, vec_out, atol)
-        write(msg,'(I3,1X,A)') self%eval_counter, 'end'
+        write(msg,'(I0,1X,A)') self%eval_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='response')
         return
     end subroutine eval_rdp
@@ -264,10 +264,10 @@ contains
         ! internal
         character(len=128) :: msg
         self%eval_counter = self%eval_counter + 1
-        write(msg,'(I3,1X,A)') self%eval_counter, 'start'
+        write(msg,'(I0,1X,A)') self%eval_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='response')
         call self%response(vec_in, vec_out, atol)
-        write(msg,'(I3,1X,A)') self%eval_counter, 'end'
+        write(msg,'(I0,1X,A)') self%eval_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='response')
         return
     end subroutine eval_csp
@@ -279,10 +279,10 @@ contains
         ! internal
         character(len=128) :: msg
         self%eval_counter = self%eval_counter + 1
-        write(msg,'(I3,1X,A)') self%eval_counter, 'start'
+        write(msg,'(I0,1X,A)') self%eval_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='response')
         call self%response(vec_in, vec_out, atol)
-        write(msg,'(I3,1X,A)') self%eval_counter, 'end'
+        write(msg,'(I0,1X,A)') self%eval_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='response')
         return
     end subroutine eval_cdp

--- a/src/AbstractSystems.fypp
+++ b/src/AbstractSystems.fypp
@@ -6,6 +6,7 @@ module LightKrylov_AbstractSystems
     use stdlib_optval, only: optval
     use LightKrylov_Logger
     use LightKrylov_Constants
+    use LightKrylov_Timing
     use LightKrylov_AbstractVectors
     use LightKrylov_AbstractLinops
     implicit none
@@ -18,11 +19,14 @@ module LightKrylov_AbstractSystems
     type, abstract, public :: abstract_system
     private
         integer :: eval_counter = 0
+        type(lightkrylov_timer) :: eval_timer = lightkrylov_timer('system eval timer')
     contains
         procedure, pass(self), public :: get_eval_counter
         !! Return eval counter value
         procedure, pass(self), public :: reset_eval_counter
         !! Reset eval counter
+        procedure, pass(self), public :: print_timer_info
+        !! Print current timer information
     end type abstract_system
 
     #:for kind, type in RC_KINDS_TYPES
@@ -100,6 +104,12 @@ contains
       return
     end subroutine reset_eval_counter
 
+    subroutine print_timer_info(self)
+      !! Getter routine to print the current timing information for the system evaluation
+      class(abstract_system), intent(inout) :: self
+      call self%eval_timer%print_info()
+    end subroutine print_timer_info
+
     !---------------------------------------------------------------------
     !-----     Wrapper for system response to increment counters     -----
     !---------------------------------------------------------------------
@@ -115,7 +125,9 @@ contains
         self%eval_counter = self%eval_counter + 1
         write(msg,'(I0,1X,A)') self%eval_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='response')
+        call self%eval_timer%start()
         call self%response(vec_in, vec_out, atol)
+        call self%eval_timer%stop()
         write(msg,'(I0,1X,A)') self%eval_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='response')
         return

--- a/src/AbstractSystems.fypp
+++ b/src/AbstractSystems.fypp
@@ -110,8 +110,14 @@ contains
         class(abstract_vector_${type[0]}$${kind}$), intent(in)    :: vec_in
         class(abstract_vector_${type[0]}$${kind}$), intent(out)   :: vec_out
         real(${kind}$),                             intent(in)    :: atol
+        ! internal
+        character(len=128) :: msg
         self%eval_counter = self%eval_counter + 1
+        write(msg,'(I3,1X,A)') self%eval_counter, 'start'
+        call logger%log_debug(msg, module=this_module, procedure='response')
         call self%response(vec_in, vec_out, atol)
+        write(msg,'(I3,1X,A)') self%eval_counter, 'end'
+        call logger%log_debug(msg, module=this_module, procedure='response')
         return
     end subroutine eval_${type[0]}$${kind}$
     #:endfor

--- a/src/AbstractSystems.fypp
+++ b/src/AbstractSystems.fypp
@@ -27,6 +27,8 @@ module LightKrylov_AbstractSystems
         !! Reset eval counter
         procedure, pass(self), public :: print_timer_info
         !! Print current timer information
+        procedure, pass(self), public :: reset_timer
+        !! Reset current timer information
     end type abstract_system
 
     #:for kind, type in RC_KINDS_TYPES
@@ -109,6 +111,12 @@ contains
       class(abstract_system), intent(inout) :: self
       call self%eval_timer%print_info()
     end subroutine print_timer_info
+
+    subroutine reset_timer(self)
+      !! Setter routine to reset the system evaluation timer
+      class(abstract_system), intent(inout) :: self
+      call self%eval_timer%reset()
+    end subroutine reset_timer
 
     !---------------------------------------------------------------------
     !-----     Wrapper for system response to increment counters     -----

--- a/src/AbstractSystems.fypp
+++ b/src/AbstractSystems.fypp
@@ -29,6 +29,8 @@ module LightKrylov_AbstractSystems
         !! Print current timer information
         procedure, pass(self), public :: reset_timer
         !! Reset current timer information
+        procedure, pass(self), public :: finalize_timer
+        !! Finalize timer and print complete history
     end type abstract_system
 
     #:for kind, type in RC_KINDS_TYPES
@@ -87,22 +89,27 @@ contains
       count = self%eval_counter
     end function get_eval_counter
 
-    subroutine reset_eval_counter(self, procedure, counter)
+    subroutine reset_eval_counter(self, procedure, counter, reset_timer)
       class(abstract_system), intent(inout) :: self
       character(len=*), intent(in) :: procedure
       !! name of the caller routine
       integer, optional, intent(in) :: counter
       !! optional flag to reset to an integer other than zero.
+      logical, optional, intent(in) :: reset_timer
+      !! optional flag to reset also the timers (while saving the timing data)
       ! internals
       integer :: counter_, count_old
+      logical :: reset_timer_
       character(len=128) :: msg
       counter_ = optval(counter, 0)
       count_old = self%get_eval_counter()
+      reset_timer_ = optval(reset_timer, .true.)
       if (count_old /= 0 .or. counter_ /= 0) then
         write(msg,'(A,I0,A,I0,A)') 'Total number of evals: ', count_old, '. Resetting counter to ', counter_, '.'
         call logger%log_message(msg, module=this_module, procedure='reset_eval_counter('//trim(procedure)//')')
         self%eval_counter = counter_
       end if
+      if (reset_timer_) call self%reset_timer()
       return
     end subroutine reset_eval_counter
 
@@ -112,11 +119,18 @@ contains
       call self%eval_timer%print_info()
     end subroutine print_timer_info
 
-    subroutine reset_timer(self)
+    subroutine reset_timer(self, save_history)
       !! Setter routine to reset the system evaluation timer
       class(abstract_system), intent(inout) :: self
-      call self%eval_timer%reset()
+      logical, optional, intent(in) :: save_history
+      call self%eval_timer%reset(save_history)
     end subroutine reset_timer
+
+    subroutine finalize_timer(self)
+      !! Setter routine to reset the system evaluation timer
+      class(abstract_system), intent(inout) :: self
+      call self%eval_timer%finalize()
+    end subroutine finalize_timer
 
     !---------------------------------------------------------------------
     !-----     Wrapper for system response to increment counters     -----

--- a/src/AbstractSystems.fypp
+++ b/src/AbstractSystems.fypp
@@ -113,10 +113,10 @@ contains
         ! internal
         character(len=128) :: msg
         self%eval_counter = self%eval_counter + 1
-        write(msg,'(I3,1X,A)') self%eval_counter, 'start'
+        write(msg,'(I0,1X,A)') self%eval_counter, 'start'
         call logger%log_debug(msg, module=this_module, procedure='response')
         call self%response(vec_in, vec_out, atol)
-        write(msg,'(I3,1X,A)') self%eval_counter, 'end'
+        write(msg,'(I0,1X,A)') self%eval_counter, 'end'
         call logger%log_debug(msg, module=this_module, procedure='response')
         return
     end subroutine eval_${type[0]}$${kind}$

--- a/src/BaseKrylov.f90
+++ b/src/BaseKrylov.f90
@@ -21,7 +21,7 @@ module lightkrylov_BaseKrylov
     !-------------------------------
     use LightKrylov_Constants
     use LightKrylov_Logger
-    !use LightKrylov_Timer
+    use LightKrylov_Timing, only: timer => global_lightkrylov_timer, time_lightkrylov
     use LightKrylov_Utils
     use LightKrylov_AbstractVectors
     use LightKrylov_AbstractLinops
@@ -677,11 +677,11 @@ contains
       integer :: info
 
       call logger%log_debug('start', module=this_module, procedure='orthonormalize_basis_rsp')
-      !if (time_lightkrylov()) call global_timer%start('orthonormalize_basis_rsp')
+      if (time_lightkrylov()) call timer%start('orthonormalize_basis_rsp')
       ! internals
       call qr(X, R, info)
       call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_rsp')
-      !if (time_lightkrylov()) call global_timer%end('orthonormalize_basis_rsp')
+      if (time_lightkrylov()) call timer%stop('orthonormalize_basis_rsp')
       call logger%log_debug('end', module=this_module, procedure='orthonormalize_basis_rsp')
       
       return
@@ -705,7 +705,7 @@ contains
       real(sp) :: proj_coefficients(size(X))
 
       call logger%log_debug('start', module=this_module, procedure='orthogonalize_vector_against_basis_rsp')
-      !if (time_lightkrylov()) call global_timer%start('orthonormalize_vector_against_basis_rsp')
+      if (time_lightkrylov()) call timer%start('orthonormalize_vector_against_basis_rsp')
       info = 0
 
       ! optional input argument
@@ -742,7 +742,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_vector_against_basis_rsp')
          beta = proj_coefficients
       end if
-      !if (time_lightkrylov()) call global_timer%stop('orthonormalize_vector_against_basis_rsp')
+      if (time_lightkrylov()) call timer%stop('orthonormalize_vector_against_basis_rsp')
       call logger%log_debug('end', module=this_module, procedure='orthogonalize_vector_against_basis_rsp')
       
       return
@@ -767,7 +767,7 @@ contains
       integer :: i
 
       call logger%log_debug('start', module=this_module, procedure='orthogonalize_basis_against_basis_rsp')
-      !if (time_lightkrylov()) call global_timer%start('orthonormalize_basis_against_basis_rsp')
+      if (time_lightkrylov()) call timer%start('orthonormalize_basis_against_basis_rsp')
       info = 0
 
       ! optional input argument
@@ -806,7 +806,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_basis_against_basis_rsp')
          beta = proj_coefficients
       end if
-      !if (time_lightkrylov()) call global_timer%stop('orthonormalize_basis_against_basis_rsp')
+      if (time_lightkrylov()) call timer%stop('orthonormalize_basis_against_basis_rsp')
       call logger%log_debug('end', module=this_module, procedure='orthogonalize_basis_against_basis_rsp')
       
       return
@@ -834,7 +834,7 @@ contains
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
       call logger%log_debug('start', module=this_module, procedure='DGS_vector_against_basis_rsp')
-      !if (time_lightkrylov()) call global_timer%start('DGS_vector_against_basis_rsp')
+      if (time_lightkrylov()) call timer%start('DGS_vector_against_basis_rsp')
       info = 0
 
       proj_coefficients = zero_rsp; wrk = zero_rsp
@@ -856,7 +856,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_vector_against_basis_rsp')
          beta = proj_coefficients
       end if
-      !if (time_lightkrylov()) call global_timer%stop('DGS_vector_against_basis_rsp')
+      if (time_lightkrylov()) call timer%stop('DGS_vector_against_basis_rsp')
       call logger%log_debug('end', module=this_module, procedure='DGS_vector_against_basis_rsp')
 
     end subroutine DGS_vector_against_basis_rsp
@@ -883,7 +883,7 @@ contains
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
       call logger%log_debug('start', module=this_module, procedure='DGS_basis_against_basis_rsp')
-      !if (time_lightkrylov()) call global_timer%start('DGS_basis_against_basis_rsp')
+      if (time_lightkrylov()) call timer%start('DGS_basis_against_basis_rsp')
       info = 0
 
       proj_coefficients = zero_rsp; wrk = zero_rsp
@@ -905,7 +905,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_basis_against_basis_rsp')
          beta = proj_coefficients
       end if
-      !if (time_lightkrylov()) call global_timer%stop('DGS_basis_against_basis_rsp')
+      if (time_lightkrylov()) call timer%stop('DGS_basis_against_basis_rsp')
       call logger%log_debug('end', module=this_module, procedure='DGS_basis_against_basis_rsp')
 
     end subroutine DGS_basis_against_basis_rsp  
@@ -942,11 +942,11 @@ contains
       integer :: info
 
       call logger%log_debug('start', module=this_module, procedure='orthonormalize_basis_rdp')
-      !if (time_lightkrylov()) call global_timer%start('orthonormalize_basis_rdp')
+      if (time_lightkrylov()) call timer%start('orthonormalize_basis_rdp')
       ! internals
       call qr(X, R, info)
       call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_rdp')
-      !if (time_lightkrylov()) call global_timer%end('orthonormalize_basis_rdp')
+      if (time_lightkrylov()) call timer%stop('orthonormalize_basis_rdp')
       call logger%log_debug('end', module=this_module, procedure='orthonormalize_basis_rdp')
       
       return
@@ -970,7 +970,7 @@ contains
       real(dp) :: proj_coefficients(size(X))
 
       call logger%log_debug('start', module=this_module, procedure='orthogonalize_vector_against_basis_rdp')
-      !if (time_lightkrylov()) call global_timer%start('orthonormalize_vector_against_basis_rdp')
+      if (time_lightkrylov()) call timer%start('orthonormalize_vector_against_basis_rdp')
       info = 0
 
       ! optional input argument
@@ -1007,7 +1007,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_vector_against_basis_rdp')
          beta = proj_coefficients
       end if
-      !if (time_lightkrylov()) call global_timer%stop('orthonormalize_vector_against_basis_rdp')
+      if (time_lightkrylov()) call timer%stop('orthonormalize_vector_against_basis_rdp')
       call logger%log_debug('end', module=this_module, procedure='orthogonalize_vector_against_basis_rdp')
       
       return
@@ -1032,7 +1032,7 @@ contains
       integer :: i
 
       call logger%log_debug('start', module=this_module, procedure='orthogonalize_basis_against_basis_rdp')
-      !if (time_lightkrylov()) call global_timer%start('orthonormalize_basis_against_basis_rdp')
+      if (time_lightkrylov()) call timer%start('orthonormalize_basis_against_basis_rdp')
       info = 0
 
       ! optional input argument
@@ -1071,7 +1071,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_basis_against_basis_rdp')
          beta = proj_coefficients
       end if
-      !if (time_lightkrylov()) call global_timer%stop('orthonormalize_basis_against_basis_rdp')
+      if (time_lightkrylov()) call timer%stop('orthonormalize_basis_against_basis_rdp')
       call logger%log_debug('end', module=this_module, procedure='orthogonalize_basis_against_basis_rdp')
       
       return
@@ -1099,7 +1099,7 @@ contains
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
       call logger%log_debug('start', module=this_module, procedure='DGS_vector_against_basis_rdp')
-      !if (time_lightkrylov()) call global_timer%start('DGS_vector_against_basis_rdp')
+      if (time_lightkrylov()) call timer%start('DGS_vector_against_basis_rdp')
       info = 0
 
       proj_coefficients = zero_rdp; wrk = zero_rdp
@@ -1121,7 +1121,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_vector_against_basis_rdp')
          beta = proj_coefficients
       end if
-      !if (time_lightkrylov()) call global_timer%stop('DGS_vector_against_basis_rdp')
+      if (time_lightkrylov()) call timer%stop('DGS_vector_against_basis_rdp')
       call logger%log_debug('end', module=this_module, procedure='DGS_vector_against_basis_rdp')
 
     end subroutine DGS_vector_against_basis_rdp
@@ -1148,7 +1148,7 @@ contains
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
       call logger%log_debug('start', module=this_module, procedure='DGS_basis_against_basis_rdp')
-      !if (time_lightkrylov()) call global_timer%start('DGS_basis_against_basis_rdp')
+      if (time_lightkrylov()) call timer%start('DGS_basis_against_basis_rdp')
       info = 0
 
       proj_coefficients = zero_rdp; wrk = zero_rdp
@@ -1170,7 +1170,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_basis_against_basis_rdp')
          beta = proj_coefficients
       end if
-      !if (time_lightkrylov()) call global_timer%stop('DGS_basis_against_basis_rdp')
+      if (time_lightkrylov()) call timer%stop('DGS_basis_against_basis_rdp')
       call logger%log_debug('end', module=this_module, procedure='DGS_basis_against_basis_rdp')
 
     end subroutine DGS_basis_against_basis_rdp  
@@ -1207,11 +1207,11 @@ contains
       integer :: info
 
       call logger%log_debug('start', module=this_module, procedure='orthonormalize_basis_csp')
-      !if (time_lightkrylov()) call global_timer%start('orthonormalize_basis_csp')
+      if (time_lightkrylov()) call timer%start('orthonormalize_basis_csp')
       ! internals
       call qr(X, R, info)
       call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_csp')
-      !if (time_lightkrylov()) call global_timer%end('orthonormalize_basis_csp')
+      if (time_lightkrylov()) call timer%stop('orthonormalize_basis_csp')
       call logger%log_debug('end', module=this_module, procedure='orthonormalize_basis_csp')
       
       return
@@ -1235,7 +1235,7 @@ contains
       complex(sp) :: proj_coefficients(size(X))
 
       call logger%log_debug('start', module=this_module, procedure='orthogonalize_vector_against_basis_csp')
-      !if (time_lightkrylov()) call global_timer%start('orthonormalize_vector_against_basis_csp')
+      if (time_lightkrylov()) call timer%start('orthonormalize_vector_against_basis_csp')
       info = 0
 
       ! optional input argument
@@ -1272,7 +1272,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_vector_against_basis_csp')
          beta = proj_coefficients
       end if
-      !if (time_lightkrylov()) call global_timer%stop('orthonormalize_vector_against_basis_csp')
+      if (time_lightkrylov()) call timer%stop('orthonormalize_vector_against_basis_csp')
       call logger%log_debug('end', module=this_module, procedure='orthogonalize_vector_against_basis_csp')
       
       return
@@ -1297,7 +1297,7 @@ contains
       integer :: i
 
       call logger%log_debug('start', module=this_module, procedure='orthogonalize_basis_against_basis_csp')
-      !if (time_lightkrylov()) call global_timer%start('orthonormalize_basis_against_basis_csp')
+      if (time_lightkrylov()) call timer%start('orthonormalize_basis_against_basis_csp')
       info = 0
 
       ! optional input argument
@@ -1336,7 +1336,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_basis_against_basis_csp')
          beta = proj_coefficients
       end if
-      !if (time_lightkrylov()) call global_timer%stop('orthonormalize_basis_against_basis_csp')
+      if (time_lightkrylov()) call timer%stop('orthonormalize_basis_against_basis_csp')
       call logger%log_debug('end', module=this_module, procedure='orthogonalize_basis_against_basis_csp')
       
       return
@@ -1364,7 +1364,7 @@ contains
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
       call logger%log_debug('start', module=this_module, procedure='DGS_vector_against_basis_csp')
-      !if (time_lightkrylov()) call global_timer%start('DGS_vector_against_basis_csp')
+      if (time_lightkrylov()) call timer%start('DGS_vector_against_basis_csp')
       info = 0
 
       proj_coefficients = zero_csp; wrk = zero_csp
@@ -1386,7 +1386,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_vector_against_basis_csp')
          beta = proj_coefficients
       end if
-      !if (time_lightkrylov()) call global_timer%stop('DGS_vector_against_basis_csp')
+      if (time_lightkrylov()) call timer%stop('DGS_vector_against_basis_csp')
       call logger%log_debug('end', module=this_module, procedure='DGS_vector_against_basis_csp')
 
     end subroutine DGS_vector_against_basis_csp
@@ -1413,7 +1413,7 @@ contains
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
       call logger%log_debug('start', module=this_module, procedure='DGS_basis_against_basis_csp')
-      !if (time_lightkrylov()) call global_timer%start('DGS_basis_against_basis_csp')
+      if (time_lightkrylov()) call timer%start('DGS_basis_against_basis_csp')
       info = 0
 
       proj_coefficients = zero_csp; wrk = zero_csp
@@ -1435,7 +1435,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_basis_against_basis_csp')
          beta = proj_coefficients
       end if
-      !if (time_lightkrylov()) call global_timer%stop('DGS_basis_against_basis_csp')
+      if (time_lightkrylov()) call timer%stop('DGS_basis_against_basis_csp')
       call logger%log_debug('end', module=this_module, procedure='DGS_basis_against_basis_csp')
 
     end subroutine DGS_basis_against_basis_csp  
@@ -1472,11 +1472,11 @@ contains
       integer :: info
 
       call logger%log_debug('start', module=this_module, procedure='orthonormalize_basis_cdp')
-      !if (time_lightkrylov()) call global_timer%start('orthonormalize_basis_cdp')
+      if (time_lightkrylov()) call timer%start('orthonormalize_basis_cdp')
       ! internals
       call qr(X, R, info)
       call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_cdp')
-      !if (time_lightkrylov()) call global_timer%end('orthonormalize_basis_cdp')
+      if (time_lightkrylov()) call timer%stop('orthonormalize_basis_cdp')
       call logger%log_debug('end', module=this_module, procedure='orthonormalize_basis_cdp')
       
       return
@@ -1500,7 +1500,7 @@ contains
       complex(dp) :: proj_coefficients(size(X))
 
       call logger%log_debug('start', module=this_module, procedure='orthogonalize_vector_against_basis_cdp')
-      !if (time_lightkrylov()) call global_timer%start('orthonormalize_vector_against_basis_cdp')
+      if (time_lightkrylov()) call timer%start('orthonormalize_vector_against_basis_cdp')
       info = 0
 
       ! optional input argument
@@ -1537,7 +1537,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_vector_against_basis_cdp')
          beta = proj_coefficients
       end if
-      !if (time_lightkrylov()) call global_timer%stop('orthonormalize_vector_against_basis_cdp')
+      if (time_lightkrylov()) call timer%stop('orthonormalize_vector_against_basis_cdp')
       call logger%log_debug('end', module=this_module, procedure='orthogonalize_vector_against_basis_cdp')
       
       return
@@ -1562,7 +1562,7 @@ contains
       integer :: i
 
       call logger%log_debug('start', module=this_module, procedure='orthogonalize_basis_against_basis_cdp')
-      !if (time_lightkrylov()) call global_timer%start('orthonormalize_basis_against_basis_cdp')
+      if (time_lightkrylov()) call timer%start('orthonormalize_basis_against_basis_cdp')
       info = 0
 
       ! optional input argument
@@ -1601,7 +1601,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_basis_against_basis_cdp')
          beta = proj_coefficients
       end if
-      !if (time_lightkrylov()) call global_timer%stop('orthonormalize_basis_against_basis_cdp')
+      if (time_lightkrylov()) call timer%stop('orthonormalize_basis_against_basis_cdp')
       call logger%log_debug('end', module=this_module, procedure='orthogonalize_basis_against_basis_cdp')
       
       return
@@ -1629,7 +1629,7 @@ contains
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
       call logger%log_debug('start', module=this_module, procedure='DGS_vector_against_basis_cdp')
-      !if (time_lightkrylov()) call global_timer%start('DGS_vector_against_basis_cdp')
+      if (time_lightkrylov()) call timer%start('DGS_vector_against_basis_cdp')
       info = 0
 
       proj_coefficients = zero_cdp; wrk = zero_cdp
@@ -1651,7 +1651,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_vector_against_basis_cdp')
          beta = proj_coefficients
       end if
-      !if (time_lightkrylov()) call global_timer%stop('DGS_vector_against_basis_cdp')
+      if (time_lightkrylov()) call timer%stop('DGS_vector_against_basis_cdp')
       call logger%log_debug('end', module=this_module, procedure='DGS_vector_against_basis_cdp')
 
     end subroutine DGS_vector_against_basis_cdp
@@ -1678,7 +1678,7 @@ contains
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
       call logger%log_debug('start', module=this_module, procedure='DGS_basis_against_basis_cdp')
-      !if (time_lightkrylov()) call global_timer%start('DGS_basis_against_basis_cdp')
+      if (time_lightkrylov()) call timer%start('DGS_basis_against_basis_cdp')
       info = 0
 
       proj_coefficients = zero_cdp; wrk = zero_cdp
@@ -1700,7 +1700,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_basis_against_basis_cdp')
          beta = proj_coefficients
       end if
-      !if (time_lightkrylov()) call global_timer%stop('DGS_basis_against_basis_cdp')
+      if (time_lightkrylov()) call timer%stop('DGS_basis_against_basis_cdp')
       call logger%log_debug('end', module=this_module, procedure='DGS_basis_against_basis_cdp')
 
     end subroutine DGS_basis_against_basis_cdp  
@@ -1730,7 +1730,7 @@ contains
         ! Deals with the optional args.
         tolerance = optval(tol, atol_sp)
 
-      	!if (time_lightkrylov()) call global_timer%start('qr_no_pivoting_rsp')
+      	if (time_lightkrylov()) call timer%start('qr_no_pivoting_rsp')
         call logger%log_debug('start', module=this_module, procedure='qr_no_pivoting_rsp')
         info = 0 ; flag = .false.; R = zero_rsp ; beta = zero_rsp
         do j = 1, size(Q)
@@ -1762,7 +1762,7 @@ contains
             ! Normalize column.
             call Q(j)%scal(one_rsp / beta)
         enddo
-      	!if (time_lightkrylov()) call global_timer%stop('qr_no_pivoting_rsp')
+      	if (time_lightkrylov()) call timer%stop('qr_no_pivoting_rsp')
         call logger%log_debug('end', module=this_module, procedure='qr_no_pivoting_rsp')
 
         return
@@ -1790,7 +1790,7 @@ contains
         character(len=128) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='qr_with_pivoting_rsp')
-      	!if (time_lightkrylov()) call global_timer%start('qr_with_pivoting_rsp')
+      	if (time_lightkrylov()) call timer%start('qr_with_pivoting_rsp')
         info = 0 ; kdim = size(Q)
         R = zero_rsp ; Rii = zero_rsp
         
@@ -1849,7 +1849,7 @@ contains
             enddo
 
         enddo qr_step
-      	!if (time_lightkrylov()) call global_timer%stop('qr_with_pivoting_rsp')
+      	if (time_lightkrylov()) call timer%stop('qr_with_pivoting_rsp')
         call logger%log_debug('end', module=this_module, procedure='qr_with_pivoting_rsp')
 
         return
@@ -2003,7 +2003,7 @@ contains
         ! Deals with the optional args.
         tolerance = optval(tol, atol_dp)
 
-      	!if (time_lightkrylov()) call global_timer%start('qr_no_pivoting_rdp')
+      	if (time_lightkrylov()) call timer%start('qr_no_pivoting_rdp')
         call logger%log_debug('start', module=this_module, procedure='qr_no_pivoting_rdp')
         info = 0 ; flag = .false.; R = zero_rdp ; beta = zero_rdp
         do j = 1, size(Q)
@@ -2035,7 +2035,7 @@ contains
             ! Normalize column.
             call Q(j)%scal(one_rdp / beta)
         enddo
-      	!if (time_lightkrylov()) call global_timer%stop('qr_no_pivoting_rdp')
+      	if (time_lightkrylov()) call timer%stop('qr_no_pivoting_rdp')
         call logger%log_debug('end', module=this_module, procedure='qr_no_pivoting_rdp')
 
         return
@@ -2063,7 +2063,7 @@ contains
         character(len=128) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='qr_with_pivoting_rdp')
-      	!if (time_lightkrylov()) call global_timer%start('qr_with_pivoting_rdp')
+      	if (time_lightkrylov()) call timer%start('qr_with_pivoting_rdp')
         info = 0 ; kdim = size(Q)
         R = zero_rdp ; Rii = zero_rdp
         
@@ -2122,7 +2122,7 @@ contains
             enddo
 
         enddo qr_step
-      	!if (time_lightkrylov()) call global_timer%stop('qr_with_pivoting_rdp')
+      	if (time_lightkrylov()) call timer%stop('qr_with_pivoting_rdp')
         call logger%log_debug('end', module=this_module, procedure='qr_with_pivoting_rdp')
 
         return
@@ -2276,7 +2276,7 @@ contains
         ! Deals with the optional args.
         tolerance = optval(tol, atol_sp)
 
-      	!if (time_lightkrylov()) call global_timer%start('qr_no_pivoting_csp')
+      	if (time_lightkrylov()) call timer%start('qr_no_pivoting_csp')
         call logger%log_debug('start', module=this_module, procedure='qr_no_pivoting_csp')
         info = 0 ; flag = .false.; R = zero_rsp ; beta = zero_rsp
         do j = 1, size(Q)
@@ -2308,7 +2308,7 @@ contains
             ! Normalize column.
             call Q(j)%scal(one_rsp / beta)
         enddo
-      	!if (time_lightkrylov()) call global_timer%stop('qr_no_pivoting_csp')
+      	if (time_lightkrylov()) call timer%stop('qr_no_pivoting_csp')
         call logger%log_debug('end', module=this_module, procedure='qr_no_pivoting_csp')
 
         return
@@ -2336,7 +2336,7 @@ contains
         character(len=128) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='qr_with_pivoting_csp')
-      	!if (time_lightkrylov()) call global_timer%start('qr_with_pivoting_csp')
+      	if (time_lightkrylov()) call timer%start('qr_with_pivoting_csp')
         info = 0 ; kdim = size(Q)
         R = zero_rsp ; Rii = zero_rsp
         
@@ -2395,7 +2395,7 @@ contains
             enddo
 
         enddo qr_step
-      	!if (time_lightkrylov()) call global_timer%stop('qr_with_pivoting_csp')
+      	if (time_lightkrylov()) call timer%stop('qr_with_pivoting_csp')
         call logger%log_debug('end', module=this_module, procedure='qr_with_pivoting_csp')
 
         return
@@ -2549,7 +2549,7 @@ contains
         ! Deals with the optional args.
         tolerance = optval(tol, atol_dp)
 
-      	!if (time_lightkrylov()) call global_timer%start('qr_no_pivoting_cdp')
+      	if (time_lightkrylov()) call timer%start('qr_no_pivoting_cdp')
         call logger%log_debug('start', module=this_module, procedure='qr_no_pivoting_cdp')
         info = 0 ; flag = .false.; R = zero_rdp ; beta = zero_rdp
         do j = 1, size(Q)
@@ -2581,7 +2581,7 @@ contains
             ! Normalize column.
             call Q(j)%scal(one_rdp / beta)
         enddo
-      	!if (time_lightkrylov()) call global_timer%stop('qr_no_pivoting_cdp')
+      	if (time_lightkrylov()) call timer%stop('qr_no_pivoting_cdp')
         call logger%log_debug('end', module=this_module, procedure='qr_no_pivoting_cdp')
 
         return
@@ -2609,7 +2609,7 @@ contains
         character(len=128) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='qr_with_pivoting_cdp')
-      	!if (time_lightkrylov()) call global_timer%start('qr_with_pivoting_cdp')
+      	if (time_lightkrylov()) call timer%start('qr_with_pivoting_cdp')
         info = 0 ; kdim = size(Q)
         R = zero_rdp ; Rii = zero_rdp
         
@@ -2668,7 +2668,7 @@ contains
             enddo
 
         enddo qr_step
-      	!if (time_lightkrylov()) call global_timer%stop('qr_with_pivoting_cdp')
+      	if (time_lightkrylov()) call timer%stop('qr_with_pivoting_cdp')
         call logger%log_debug('end', module=this_module, procedure='qr_with_pivoting_cdp')
 
         return
@@ -2836,6 +2836,9 @@ contains
         integer, allocatable :: perm(:)
         integer :: k, i, kdim, kpm, kp, kpp
 
+        call logger%log_debug('start', module=this_module, procedure='arnoldi_rsp')
+        if (time_lightkrylov()) call timer%start('arnoldi_rsp')
+
         ! Deals with optional non-unity blksize and allocations.
         p = optval(blksize, 1) ; allocate(res(p)) ; res = zero_rsp
         allocate(perm(size(H, 2))) ; perm = 0 ; info = 0
@@ -2889,6 +2892,9 @@ contains
 
         enddo blk_arnoldi
 
+        if (time_lightkrylov()) call timer%stop('arnoldi_rsp')
+        call logger%log_debug('end', module=this_module, procedure='arnoldi_rsp')
+
         return
     end subroutine arnoldi_rsp
 
@@ -2920,6 +2926,9 @@ contains
         real(dp), allocatable :: res(:)
         integer, allocatable :: perm(:)
         integer :: k, i, kdim, kpm, kp, kpp
+
+        call logger%log_debug('start', module=this_module, procedure='arnoldi_rdp')
+        if (time_lightkrylov()) call timer%start('arnoldi_rdp')
 
         ! Deals with optional non-unity blksize and allocations.
         p = optval(blksize, 1) ; allocate(res(p)) ; res = zero_rdp
@@ -2974,6 +2983,9 @@ contains
 
         enddo blk_arnoldi
 
+        if (time_lightkrylov()) call timer%stop('arnoldi_rdp')
+        call logger%log_debug('end', module=this_module, procedure='arnoldi_rdp')
+
         return
     end subroutine arnoldi_rdp
 
@@ -3005,6 +3017,9 @@ contains
         complex(sp), allocatable :: res(:)
         integer, allocatable :: perm(:)
         integer :: k, i, kdim, kpm, kp, kpp
+
+        call logger%log_debug('start', module=this_module, procedure='arnoldi_csp')
+        if (time_lightkrylov()) call timer%start('arnoldi_csp')
 
         ! Deals with optional non-unity blksize and allocations.
         p = optval(blksize, 1) ; allocate(res(p)) ; res = zero_rsp
@@ -3059,6 +3074,9 @@ contains
 
         enddo blk_arnoldi
 
+        if (time_lightkrylov()) call timer%stop('arnoldi_csp')
+        call logger%log_debug('end', module=this_module, procedure='arnoldi_csp')
+
         return
     end subroutine arnoldi_csp
 
@@ -3090,6 +3108,9 @@ contains
         complex(dp), allocatable :: res(:)
         integer, allocatable :: perm(:)
         integer :: k, i, kdim, kpm, kp, kpp
+
+        call logger%log_debug('start', module=this_module, procedure='arnoldi_cdp')
+        if (time_lightkrylov()) call timer%start('arnoldi_cdp')
 
         ! Deals with optional non-unity blksize and allocations.
         p = optval(blksize, 1) ; allocate(res(p)) ; res = zero_rdp
@@ -3144,6 +3165,9 @@ contains
 
         enddo blk_arnoldi
 
+        if (time_lightkrylov()) call timer%stop('arnoldi_cdp')
+        call logger%log_debug('end', module=this_module, procedure='arnoldi_cdp')
+
         return
     end subroutine arnoldi_cdp
 
@@ -3178,6 +3202,8 @@ contains
         real(sp) :: alpha, beta
         integer :: k, kdim
 
+        call logger%log_debug('start', module=this_module, procedure='lanczos_bidiagonalization_rsp')
+        if (time_lightkrylov()) call timer%start('lanczos_bidiagonalization_rsp')
         info = 0
 
         ! Krylov subspace dimension.
@@ -3228,6 +3254,9 @@ contains
 
         enddo lanczos
 
+        if (time_lightkrylov()) call timer%stop('lanczos_bidiagonalization_rsp')
+        call logger%log_debug('end', module=this_module, procedure='lanczos_bidiagonalization_rsp')
+
         return
     end subroutine lanczos_bidiagonalization_rsp
 
@@ -3256,6 +3285,8 @@ contains
         real(dp) :: alpha, beta
         integer :: k, kdim
 
+        call logger%log_debug('start', module=this_module, procedure='lanczos_bidiagonalization_rdp')
+        if (time_lightkrylov()) call timer%start('lanczos_bidiagonalization_rdp')
         info = 0
 
         ! Krylov subspace dimension.
@@ -3306,6 +3337,9 @@ contains
 
         enddo lanczos
 
+        if (time_lightkrylov()) call timer%stop('lanczos_bidiagonalization_rdp')
+        call logger%log_debug('end', module=this_module, procedure='lanczos_bidiagonalization_rdp')
+
         return
     end subroutine lanczos_bidiagonalization_rdp
 
@@ -3334,6 +3368,8 @@ contains
         complex(sp) :: alpha, beta
         integer :: k, kdim
 
+        call logger%log_debug('start', module=this_module, procedure='lanczos_bidiagonalization_csp')
+        if (time_lightkrylov()) call timer%start('lanczos_bidiagonalization_csp')
         info = 0
 
         ! Krylov subspace dimension.
@@ -3384,6 +3420,9 @@ contains
 
         enddo lanczos
 
+        if (time_lightkrylov()) call timer%stop('lanczos_bidiagonalization_csp')
+        call logger%log_debug('end', module=this_module, procedure='lanczos_bidiagonalization_csp')
+
         return
     end subroutine lanczos_bidiagonalization_csp
 
@@ -3412,6 +3451,8 @@ contains
         complex(dp) :: alpha, beta
         integer :: k, kdim
 
+        call logger%log_debug('start', module=this_module, procedure='lanczos_bidiagonalization_cdp')
+        if (time_lightkrylov()) call timer%start('lanczos_bidiagonalization_cdp')
         info = 0
 
         ! Krylov subspace dimension.
@@ -3462,6 +3503,9 @@ contains
 
         enddo lanczos
 
+        if (time_lightkrylov()) call timer%stop('lanczos_bidiagonalization_cdp')
+        call logger%log_debug('end', module=this_module, procedure='lanczos_bidiagonalization_cdp')
+
         return
     end subroutine lanczos_bidiagonalization_cdp
 
@@ -3485,6 +3529,9 @@ contains
         real(sp) :: tolerance
         real(sp) :: beta
         integer :: k, kdim
+
+        call logger%log_debug('start', module=this_module, procedure='lanczos_tridiagonalization_rsp')
+        if (time_lightkrylov()) call timer%start('lanczos_tridiagonalization_rsp')
 
         ! Deal with optional args.
         kdim = size(X) - 1
@@ -3512,6 +3559,9 @@ contains
                 call X(k+1)%scal(one_rsp / beta)
             endif
         enddo lanczos
+
+        if (time_lightkrylov()) call timer%stop('lanczos_tridiagonalization_rsp')
+        call logger%log_debug('end', module=this_module, procedure='lanczos_tridiagonalization_rsp')
 
         return
     end subroutine lanczos_tridiagonalization_rsp
@@ -3553,6 +3603,9 @@ contains
         real(dp) :: beta
         integer :: k, kdim
 
+        call logger%log_debug('start', module=this_module, procedure='lanczos_tridiagonalization_rdp')
+        if (time_lightkrylov()) call timer%start('lanczos_tridiagonalization_rdp')
+
         ! Deal with optional args.
         kdim = size(X) - 1
         k_start = optval(kstart, 1)
@@ -3579,6 +3632,9 @@ contains
                 call X(k+1)%scal(one_rdp / beta)
             endif
         enddo lanczos
+
+        if (time_lightkrylov()) call timer%stop('lanczos_tridiagonalization_rdp')
+        call logger%log_debug('end', module=this_module, procedure='lanczos_tridiagonalization_rdp')
 
         return
     end subroutine lanczos_tridiagonalization_rdp
@@ -3620,6 +3676,9 @@ contains
         real(sp) :: beta
         integer :: k, kdim
 
+        call logger%log_debug('start', module=this_module, procedure='lanczos_tridiagonalization_csp')
+        if (time_lightkrylov()) call timer%start('lanczos_tridiagonalization_csp')
+
         ! Deal with optional args.
         kdim = size(X) - 1
         k_start = optval(kstart, 1)
@@ -3646,6 +3705,9 @@ contains
                 call X(k+1)%scal(one_csp / beta)
             endif
         enddo lanczos
+
+        if (time_lightkrylov()) call timer%stop('lanczos_tridiagonalization_csp')
+        call logger%log_debug('end', module=this_module, procedure='lanczos_tridiagonalization_csp')
 
         return
     end subroutine lanczos_tridiagonalization_csp
@@ -3687,6 +3749,9 @@ contains
         real(dp) :: beta
         integer :: k, kdim
 
+        call logger%log_debug('start', module=this_module, procedure='lanczos_tridiagonalization_cdp')
+        if (time_lightkrylov()) call timer%start('lanczos_tridiagonalization_cdp')
+
         ! Deal with optional args.
         kdim = size(X) - 1
         k_start = optval(kstart, 1)
@@ -3713,6 +3778,9 @@ contains
                 call X(k+1)%scal(one_cdp / beta)
             endif
         enddo lanczos
+
+        if (time_lightkrylov()) call timer%stop('lanczos_tridiagonalization_cdp')
+        call logger%log_debug('end', module=this_module, procedure='lanczos_tridiagonalization_cdp')
 
         return
     end subroutine lanczos_tridiagonalization_cdp

--- a/src/BaseKrylov.f90
+++ b/src/BaseKrylov.f90
@@ -677,11 +677,11 @@ contains
       integer :: info
 
       call logger%log_debug('start', module=this_module, procedure='orthonormalize_basis_rsp')
-      !if (timeit()) call global_timer%start('orthonormalize_basis_rsp')
+      !if (time_lightkrylov()) call global_timer%start('orthonormalize_basis_rsp')
       ! internals
       call qr(X, R, info)
       call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_rsp')
-      !if (timeit()) call global_timer%end('orthonormalize_basis_rsp')
+      !if (time_lightkrylov()) call global_timer%end('orthonormalize_basis_rsp')
       call logger%log_debug('end', module=this_module, procedure='orthonormalize_basis_rsp')
       
       return
@@ -705,7 +705,7 @@ contains
       real(sp) :: proj_coefficients(size(X))
 
       call logger%log_debug('start', module=this_module, procedure='orthogonalize_vector_against_basis_rsp')
-      !if (timeit()) call global_timer%start('orthonormalize_vector_against_basis_rsp')
+      !if (time_lightkrylov()) call global_timer%start('orthonormalize_vector_against_basis_rsp')
       info = 0
 
       ! optional input argument
@@ -742,7 +742,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_vector_against_basis_rsp')
          beta = proj_coefficients
       end if
-      !if (timeit()) call global_timer%stop('orthonormalize_vector_against_basis_rsp')
+      !if (time_lightkrylov()) call global_timer%stop('orthonormalize_vector_against_basis_rsp')
       call logger%log_debug('end', module=this_module, procedure='orthogonalize_vector_against_basis_rsp')
       
       return
@@ -767,7 +767,7 @@ contains
       integer :: i
 
       call logger%log_debug('start', module=this_module, procedure='orthogonalize_basis_against_basis_rsp')
-      !if (timeit()) call global_timer%start('orthonormalize_basis_against_basis_rsp')
+      !if (time_lightkrylov()) call global_timer%start('orthonormalize_basis_against_basis_rsp')
       info = 0
 
       ! optional input argument
@@ -806,7 +806,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_basis_against_basis_rsp')
          beta = proj_coefficients
       end if
-      !if (timeit()) call global_timer%stop('orthonormalize_basis_against_basis_rsp')
+      !if (time_lightkrylov()) call global_timer%stop('orthonormalize_basis_against_basis_rsp')
       call logger%log_debug('end', module=this_module, procedure='orthogonalize_basis_against_basis_rsp')
       
       return
@@ -834,7 +834,7 @@ contains
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
       call logger%log_debug('start', module=this_module, procedure='DGS_vector_against_basis_rsp')
-      !if (timeit()) call global_timer%start('DGS_vector_against_basis_rsp')
+      !if (time_lightkrylov()) call global_timer%start('DGS_vector_against_basis_rsp')
       info = 0
 
       proj_coefficients = zero_rsp; wrk = zero_rsp
@@ -856,7 +856,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_vector_against_basis_rsp')
          beta = proj_coefficients
       end if
-      !if (timeit()) call global_timer%stop('DGS_vector_against_basis_rsp')
+      !if (time_lightkrylov()) call global_timer%stop('DGS_vector_against_basis_rsp')
       call logger%log_debug('end', module=this_module, procedure='DGS_vector_against_basis_rsp')
 
     end subroutine DGS_vector_against_basis_rsp
@@ -883,7 +883,7 @@ contains
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
       call logger%log_debug('start', module=this_module, procedure='DGS_basis_against_basis_rsp')
-      !if (timeit()) call global_timer%start('DGS_basis_against_basis_rsp')
+      !if (time_lightkrylov()) call global_timer%start('DGS_basis_against_basis_rsp')
       info = 0
 
       proj_coefficients = zero_rsp; wrk = zero_rsp
@@ -905,7 +905,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_basis_against_basis_rsp')
          beta = proj_coefficients
       end if
-      !if (timeit()) call global_timer%stop('DGS_basis_against_basis_rsp')
+      !if (time_lightkrylov()) call global_timer%stop('DGS_basis_against_basis_rsp')
       call logger%log_debug('end', module=this_module, procedure='DGS_basis_against_basis_rsp')
 
     end subroutine DGS_basis_against_basis_rsp  
@@ -942,11 +942,11 @@ contains
       integer :: info
 
       call logger%log_debug('start', module=this_module, procedure='orthonormalize_basis_rdp')
-      !if (timeit()) call global_timer%start('orthonormalize_basis_rdp')
+      !if (time_lightkrylov()) call global_timer%start('orthonormalize_basis_rdp')
       ! internals
       call qr(X, R, info)
       call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_rdp')
-      !if (timeit()) call global_timer%end('orthonormalize_basis_rdp')
+      !if (time_lightkrylov()) call global_timer%end('orthonormalize_basis_rdp')
       call logger%log_debug('end', module=this_module, procedure='orthonormalize_basis_rdp')
       
       return
@@ -970,7 +970,7 @@ contains
       real(dp) :: proj_coefficients(size(X))
 
       call logger%log_debug('start', module=this_module, procedure='orthogonalize_vector_against_basis_rdp')
-      !if (timeit()) call global_timer%start('orthonormalize_vector_against_basis_rdp')
+      !if (time_lightkrylov()) call global_timer%start('orthonormalize_vector_against_basis_rdp')
       info = 0
 
       ! optional input argument
@@ -1007,7 +1007,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_vector_against_basis_rdp')
          beta = proj_coefficients
       end if
-      !if (timeit()) call global_timer%stop('orthonormalize_vector_against_basis_rdp')
+      !if (time_lightkrylov()) call global_timer%stop('orthonormalize_vector_against_basis_rdp')
       call logger%log_debug('end', module=this_module, procedure='orthogonalize_vector_against_basis_rdp')
       
       return
@@ -1032,7 +1032,7 @@ contains
       integer :: i
 
       call logger%log_debug('start', module=this_module, procedure='orthogonalize_basis_against_basis_rdp')
-      !if (timeit()) call global_timer%start('orthonormalize_basis_against_basis_rdp')
+      !if (time_lightkrylov()) call global_timer%start('orthonormalize_basis_against_basis_rdp')
       info = 0
 
       ! optional input argument
@@ -1071,7 +1071,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_basis_against_basis_rdp')
          beta = proj_coefficients
       end if
-      !if (timeit()) call global_timer%stop('orthonormalize_basis_against_basis_rdp')
+      !if (time_lightkrylov()) call global_timer%stop('orthonormalize_basis_against_basis_rdp')
       call logger%log_debug('end', module=this_module, procedure='orthogonalize_basis_against_basis_rdp')
       
       return
@@ -1099,7 +1099,7 @@ contains
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
       call logger%log_debug('start', module=this_module, procedure='DGS_vector_against_basis_rdp')
-      !if (timeit()) call global_timer%start('DGS_vector_against_basis_rdp')
+      !if (time_lightkrylov()) call global_timer%start('DGS_vector_against_basis_rdp')
       info = 0
 
       proj_coefficients = zero_rdp; wrk = zero_rdp
@@ -1121,7 +1121,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_vector_against_basis_rdp')
          beta = proj_coefficients
       end if
-      !if (timeit()) call global_timer%stop('DGS_vector_against_basis_rdp')
+      !if (time_lightkrylov()) call global_timer%stop('DGS_vector_against_basis_rdp')
       call logger%log_debug('end', module=this_module, procedure='DGS_vector_against_basis_rdp')
 
     end subroutine DGS_vector_against_basis_rdp
@@ -1148,7 +1148,7 @@ contains
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
       call logger%log_debug('start', module=this_module, procedure='DGS_basis_against_basis_rdp')
-      !if (timeit()) call global_timer%start('DGS_basis_against_basis_rdp')
+      !if (time_lightkrylov()) call global_timer%start('DGS_basis_against_basis_rdp')
       info = 0
 
       proj_coefficients = zero_rdp; wrk = zero_rdp
@@ -1170,7 +1170,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_basis_against_basis_rdp')
          beta = proj_coefficients
       end if
-      !if (timeit()) call global_timer%stop('DGS_basis_against_basis_rdp')
+      !if (time_lightkrylov()) call global_timer%stop('DGS_basis_against_basis_rdp')
       call logger%log_debug('end', module=this_module, procedure='DGS_basis_against_basis_rdp')
 
     end subroutine DGS_basis_against_basis_rdp  
@@ -1207,11 +1207,11 @@ contains
       integer :: info
 
       call logger%log_debug('start', module=this_module, procedure='orthonormalize_basis_csp')
-      !if (timeit()) call global_timer%start('orthonormalize_basis_csp')
+      !if (time_lightkrylov()) call global_timer%start('orthonormalize_basis_csp')
       ! internals
       call qr(X, R, info)
       call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_csp')
-      !if (timeit()) call global_timer%end('orthonormalize_basis_csp')
+      !if (time_lightkrylov()) call global_timer%end('orthonormalize_basis_csp')
       call logger%log_debug('end', module=this_module, procedure='orthonormalize_basis_csp')
       
       return
@@ -1235,7 +1235,7 @@ contains
       complex(sp) :: proj_coefficients(size(X))
 
       call logger%log_debug('start', module=this_module, procedure='orthogonalize_vector_against_basis_csp')
-      !if (timeit()) call global_timer%start('orthonormalize_vector_against_basis_csp')
+      !if (time_lightkrylov()) call global_timer%start('orthonormalize_vector_against_basis_csp')
       info = 0
 
       ! optional input argument
@@ -1272,7 +1272,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_vector_against_basis_csp')
          beta = proj_coefficients
       end if
-      !if (timeit()) call global_timer%stop('orthonormalize_vector_against_basis_csp')
+      !if (time_lightkrylov()) call global_timer%stop('orthonormalize_vector_against_basis_csp')
       call logger%log_debug('end', module=this_module, procedure='orthogonalize_vector_against_basis_csp')
       
       return
@@ -1297,7 +1297,7 @@ contains
       integer :: i
 
       call logger%log_debug('start', module=this_module, procedure='orthogonalize_basis_against_basis_csp')
-      !if (timeit()) call global_timer%start('orthonormalize_basis_against_basis_csp')
+      !if (time_lightkrylov()) call global_timer%start('orthonormalize_basis_against_basis_csp')
       info = 0
 
       ! optional input argument
@@ -1336,7 +1336,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_basis_against_basis_csp')
          beta = proj_coefficients
       end if
-      !if (timeit()) call global_timer%stop('orthonormalize_basis_against_basis_csp')
+      !if (time_lightkrylov()) call global_timer%stop('orthonormalize_basis_against_basis_csp')
       call logger%log_debug('end', module=this_module, procedure='orthogonalize_basis_against_basis_csp')
       
       return
@@ -1364,7 +1364,7 @@ contains
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
       call logger%log_debug('start', module=this_module, procedure='DGS_vector_against_basis_csp')
-      !if (timeit()) call global_timer%start('DGS_vector_against_basis_csp')
+      !if (time_lightkrylov()) call global_timer%start('DGS_vector_against_basis_csp')
       info = 0
 
       proj_coefficients = zero_csp; wrk = zero_csp
@@ -1386,7 +1386,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_vector_against_basis_csp')
          beta = proj_coefficients
       end if
-      !if (timeit()) call global_timer%stop('DGS_vector_against_basis_csp')
+      !if (time_lightkrylov()) call global_timer%stop('DGS_vector_against_basis_csp')
       call logger%log_debug('end', module=this_module, procedure='DGS_vector_against_basis_csp')
 
     end subroutine DGS_vector_against_basis_csp
@@ -1413,7 +1413,7 @@ contains
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
       call logger%log_debug('start', module=this_module, procedure='DGS_basis_against_basis_csp')
-      !if (timeit()) call global_timer%start('DGS_basis_against_basis_csp')
+      !if (time_lightkrylov()) call global_timer%start('DGS_basis_against_basis_csp')
       info = 0
 
       proj_coefficients = zero_csp; wrk = zero_csp
@@ -1435,7 +1435,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_basis_against_basis_csp')
          beta = proj_coefficients
       end if
-      !if (timeit()) call global_timer%stop('DGS_basis_against_basis_csp')
+      !if (time_lightkrylov()) call global_timer%stop('DGS_basis_against_basis_csp')
       call logger%log_debug('end', module=this_module, procedure='DGS_basis_against_basis_csp')
 
     end subroutine DGS_basis_against_basis_csp  
@@ -1472,11 +1472,11 @@ contains
       integer :: info
 
       call logger%log_debug('start', module=this_module, procedure='orthonormalize_basis_cdp')
-      !if (timeit()) call global_timer%start('orthonormalize_basis_cdp')
+      !if (time_lightkrylov()) call global_timer%start('orthonormalize_basis_cdp')
       ! internals
       call qr(X, R, info)
       call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_cdp')
-      !if (timeit()) call global_timer%end('orthonormalize_basis_cdp')
+      !if (time_lightkrylov()) call global_timer%end('orthonormalize_basis_cdp')
       call logger%log_debug('end', module=this_module, procedure='orthonormalize_basis_cdp')
       
       return
@@ -1500,7 +1500,7 @@ contains
       complex(dp) :: proj_coefficients(size(X))
 
       call logger%log_debug('start', module=this_module, procedure='orthogonalize_vector_against_basis_cdp')
-      !if (timeit()) call global_timer%start('orthonormalize_vector_against_basis_cdp')
+      !if (time_lightkrylov()) call global_timer%start('orthonormalize_vector_against_basis_cdp')
       info = 0
 
       ! optional input argument
@@ -1537,7 +1537,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_vector_against_basis_cdp')
          beta = proj_coefficients
       end if
-      !if (timeit()) call global_timer%stop('orthonormalize_vector_against_basis_cdp')
+      !if (time_lightkrylov()) call global_timer%stop('orthonormalize_vector_against_basis_cdp')
       call logger%log_debug('end', module=this_module, procedure='orthogonalize_vector_against_basis_cdp')
       
       return
@@ -1562,7 +1562,7 @@ contains
       integer :: i
 
       call logger%log_debug('start', module=this_module, procedure='orthogonalize_basis_against_basis_cdp')
-      !if (timeit()) call global_timer%start('orthonormalize_basis_against_basis_cdp')
+      !if (time_lightkrylov()) call global_timer%start('orthonormalize_basis_against_basis_cdp')
       info = 0
 
       ! optional input argument
@@ -1601,7 +1601,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_basis_against_basis_cdp')
          beta = proj_coefficients
       end if
-      !if (timeit()) call global_timer%stop('orthonormalize_basis_against_basis_cdp')
+      !if (time_lightkrylov()) call global_timer%stop('orthonormalize_basis_against_basis_cdp')
       call logger%log_debug('end', module=this_module, procedure='orthogonalize_basis_against_basis_cdp')
       
       return
@@ -1629,7 +1629,7 @@ contains
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
       call logger%log_debug('start', module=this_module, procedure='DGS_vector_against_basis_cdp')
-      !if (timeit()) call global_timer%start('DGS_vector_against_basis_cdp')
+      !if (time_lightkrylov()) call global_timer%start('DGS_vector_against_basis_cdp')
       info = 0
 
       proj_coefficients = zero_cdp; wrk = zero_cdp
@@ -1651,7 +1651,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_vector_against_basis_cdp')
          beta = proj_coefficients
       end if
-      !if (timeit()) call global_timer%stop('DGS_vector_against_basis_cdp')
+      !if (time_lightkrylov()) call global_timer%stop('DGS_vector_against_basis_cdp')
       call logger%log_debug('end', module=this_module, procedure='DGS_vector_against_basis_cdp')
 
     end subroutine DGS_vector_against_basis_cdp
@@ -1678,7 +1678,7 @@ contains
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
       call logger%log_debug('start', module=this_module, procedure='DGS_basis_against_basis_cdp')
-      !if (timeit()) call global_timer%start('DGS_basis_against_basis_cdp')
+      !if (time_lightkrylov()) call global_timer%start('DGS_basis_against_basis_cdp')
       info = 0
 
       proj_coefficients = zero_cdp; wrk = zero_cdp
@@ -1700,7 +1700,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_basis_against_basis_cdp')
          beta = proj_coefficients
       end if
-      !if (timeit()) call global_timer%stop('DGS_basis_against_basis_cdp')
+      !if (time_lightkrylov()) call global_timer%stop('DGS_basis_against_basis_cdp')
       call logger%log_debug('end', module=this_module, procedure='DGS_basis_against_basis_cdp')
 
     end subroutine DGS_basis_against_basis_cdp  
@@ -1730,7 +1730,7 @@ contains
         ! Deals with the optional args.
         tolerance = optval(tol, atol_sp)
 
-      	!if (timeit()) call global_timer%start('qr_no_pivoting_rsp')
+      	!if (time_lightkrylov()) call global_timer%start('qr_no_pivoting_rsp')
         call logger%log_debug('start', module=this_module, procedure='qr_no_pivoting_rsp')
         info = 0 ; flag = .false.; R = zero_rsp ; beta = zero_rsp
         do j = 1, size(Q)
@@ -1762,7 +1762,7 @@ contains
             ! Normalize column.
             call Q(j)%scal(one_rsp / beta)
         enddo
-      	!if (timeit()) call global_timer%stop('qr_no_pivoting_rsp')
+      	!if (time_lightkrylov()) call global_timer%stop('qr_no_pivoting_rsp')
         call logger%log_debug('end', module=this_module, procedure='qr_no_pivoting_rsp')
 
         return
@@ -1790,7 +1790,7 @@ contains
         character(len=128) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='qr_with_pivoting_rsp')
-      	!if (timeit()) call global_timer%start('qr_with_pivoting_rsp')
+      	!if (time_lightkrylov()) call global_timer%start('qr_with_pivoting_rsp')
         info = 0 ; kdim = size(Q)
         R = zero_rsp ; Rii = zero_rsp
         
@@ -1849,7 +1849,7 @@ contains
             enddo
 
         enddo qr_step
-      	!if (timeit()) call global_timer%stop('qr_with_pivoting_rsp')
+      	!if (time_lightkrylov()) call global_timer%stop('qr_with_pivoting_rsp')
         call logger%log_debug('end', module=this_module, procedure='qr_with_pivoting_rsp')
 
         return
@@ -2003,7 +2003,7 @@ contains
         ! Deals with the optional args.
         tolerance = optval(tol, atol_dp)
 
-      	!if (timeit()) call global_timer%start('qr_no_pivoting_rdp')
+      	!if (time_lightkrylov()) call global_timer%start('qr_no_pivoting_rdp')
         call logger%log_debug('start', module=this_module, procedure='qr_no_pivoting_rdp')
         info = 0 ; flag = .false.; R = zero_rdp ; beta = zero_rdp
         do j = 1, size(Q)
@@ -2035,7 +2035,7 @@ contains
             ! Normalize column.
             call Q(j)%scal(one_rdp / beta)
         enddo
-      	!if (timeit()) call global_timer%stop('qr_no_pivoting_rdp')
+      	!if (time_lightkrylov()) call global_timer%stop('qr_no_pivoting_rdp')
         call logger%log_debug('end', module=this_module, procedure='qr_no_pivoting_rdp')
 
         return
@@ -2063,7 +2063,7 @@ contains
         character(len=128) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='qr_with_pivoting_rdp')
-      	!if (timeit()) call global_timer%start('qr_with_pivoting_rdp')
+      	!if (time_lightkrylov()) call global_timer%start('qr_with_pivoting_rdp')
         info = 0 ; kdim = size(Q)
         R = zero_rdp ; Rii = zero_rdp
         
@@ -2122,7 +2122,7 @@ contains
             enddo
 
         enddo qr_step
-      	!if (timeit()) call global_timer%stop('qr_with_pivoting_rdp')
+      	!if (time_lightkrylov()) call global_timer%stop('qr_with_pivoting_rdp')
         call logger%log_debug('end', module=this_module, procedure='qr_with_pivoting_rdp')
 
         return
@@ -2276,7 +2276,7 @@ contains
         ! Deals with the optional args.
         tolerance = optval(tol, atol_sp)
 
-      	!if (timeit()) call global_timer%start('qr_no_pivoting_csp')
+      	!if (time_lightkrylov()) call global_timer%start('qr_no_pivoting_csp')
         call logger%log_debug('start', module=this_module, procedure='qr_no_pivoting_csp')
         info = 0 ; flag = .false.; R = zero_rsp ; beta = zero_rsp
         do j = 1, size(Q)
@@ -2308,7 +2308,7 @@ contains
             ! Normalize column.
             call Q(j)%scal(one_rsp / beta)
         enddo
-      	!if (timeit()) call global_timer%stop('qr_no_pivoting_csp')
+      	!if (time_lightkrylov()) call global_timer%stop('qr_no_pivoting_csp')
         call logger%log_debug('end', module=this_module, procedure='qr_no_pivoting_csp')
 
         return
@@ -2336,7 +2336,7 @@ contains
         character(len=128) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='qr_with_pivoting_csp')
-      	!if (timeit()) call global_timer%start('qr_with_pivoting_csp')
+      	!if (time_lightkrylov()) call global_timer%start('qr_with_pivoting_csp')
         info = 0 ; kdim = size(Q)
         R = zero_rsp ; Rii = zero_rsp
         
@@ -2395,7 +2395,7 @@ contains
             enddo
 
         enddo qr_step
-      	!if (timeit()) call global_timer%stop('qr_with_pivoting_csp')
+      	!if (time_lightkrylov()) call global_timer%stop('qr_with_pivoting_csp')
         call logger%log_debug('end', module=this_module, procedure='qr_with_pivoting_csp')
 
         return
@@ -2549,7 +2549,7 @@ contains
         ! Deals with the optional args.
         tolerance = optval(tol, atol_dp)
 
-      	!if (timeit()) call global_timer%start('qr_no_pivoting_cdp')
+      	!if (time_lightkrylov()) call global_timer%start('qr_no_pivoting_cdp')
         call logger%log_debug('start', module=this_module, procedure='qr_no_pivoting_cdp')
         info = 0 ; flag = .false.; R = zero_rdp ; beta = zero_rdp
         do j = 1, size(Q)
@@ -2581,7 +2581,7 @@ contains
             ! Normalize column.
             call Q(j)%scal(one_rdp / beta)
         enddo
-      	!if (timeit()) call global_timer%stop('qr_no_pivoting_cdp')
+      	!if (time_lightkrylov()) call global_timer%stop('qr_no_pivoting_cdp')
         call logger%log_debug('end', module=this_module, procedure='qr_no_pivoting_cdp')
 
         return
@@ -2609,7 +2609,7 @@ contains
         character(len=128) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='qr_with_pivoting_cdp')
-      	!if (timeit()) call global_timer%start('qr_with_pivoting_cdp')
+      	!if (time_lightkrylov()) call global_timer%start('qr_with_pivoting_cdp')
         info = 0 ; kdim = size(Q)
         R = zero_rdp ; Rii = zero_rdp
         
@@ -2668,7 +2668,7 @@ contains
             enddo
 
         enddo qr_step
-      	!if (timeit()) call global_timer%stop('qr_with_pivoting_cdp')
+      	!if (time_lightkrylov()) call global_timer%stop('qr_with_pivoting_cdp')
         call logger%log_debug('end', module=this_module, procedure='qr_with_pivoting_cdp')
 
         return

--- a/src/BaseKrylov.f90
+++ b/src/BaseKrylov.f90
@@ -21,6 +21,7 @@ module lightkrylov_BaseKrylov
     !-------------------------------
     use LightKrylov_Constants
     use LightKrylov_Logger
+    !use LightKrylov_Timer
     use LightKrylov_Utils
     use LightKrylov_AbstractVectors
     use LightKrylov_AbstractLinops
@@ -676,9 +677,11 @@ contains
       integer :: info
 
       call logger%log_debug('start', module=this_module, procedure='orthonormalize_basis_rsp')
+      !if (timeit()) call global_timer%start('orthonormalize_basis_rsp')
       ! internals
       call qr(X, R, info)
       call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_rsp')
+      !if (timeit()) call global_timer%end('orthonormalize_basis_rsp')
       call logger%log_debug('end', module=this_module, procedure='orthonormalize_basis_rsp')
       
       return
@@ -702,6 +705,7 @@ contains
       real(sp) :: proj_coefficients(size(X))
 
       call logger%log_debug('start', module=this_module, procedure='orthogonalize_vector_against_basis_rsp')
+      !if (timeit()) call global_timer%start('orthonormalize_vector_against_basis_rsp')
       info = 0
 
       ! optional input argument
@@ -738,6 +742,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_vector_against_basis_rsp')
          beta = proj_coefficients
       end if
+      !if (timeit()) call global_timer%stop('orthonormalize_vector_against_basis_rsp')
       call logger%log_debug('end', module=this_module, procedure='orthogonalize_vector_against_basis_rsp')
       
       return
@@ -762,6 +767,7 @@ contains
       integer :: i
 
       call logger%log_debug('start', module=this_module, procedure='orthogonalize_basis_against_basis_rsp')
+      !if (timeit()) call global_timer%start('orthonormalize_basis_against_basis_rsp')
       info = 0
 
       ! optional input argument
@@ -800,6 +806,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_basis_against_basis_rsp')
          beta = proj_coefficients
       end if
+      !if (timeit()) call global_timer%stop('orthonormalize_basis_against_basis_rsp')
       call logger%log_debug('end', module=this_module, procedure='orthogonalize_basis_against_basis_rsp')
       
       return
@@ -827,6 +834,7 @@ contains
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
       call logger%log_debug('start', module=this_module, procedure='DGS_vector_against_basis_rsp')
+      !if (timeit()) call global_timer%start('DGS_vector_against_basis_rsp')
       info = 0
 
       proj_coefficients = zero_rsp; wrk = zero_rsp
@@ -848,6 +856,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_vector_against_basis_rsp')
          beta = proj_coefficients
       end if
+      !if (timeit()) call global_timer%stop('DGS_vector_against_basis_rsp')
       call logger%log_debug('end', module=this_module, procedure='DGS_vector_against_basis_rsp')
 
     end subroutine DGS_vector_against_basis_rsp
@@ -874,6 +883,7 @@ contains
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
       call logger%log_debug('start', module=this_module, procedure='DGS_basis_against_basis_rsp')
+      !if (timeit()) call global_timer%start('DGS_basis_against_basis_rsp')
       info = 0
 
       proj_coefficients = zero_rsp; wrk = zero_rsp
@@ -895,6 +905,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_basis_against_basis_rsp')
          beta = proj_coefficients
       end if
+      !if (timeit()) call global_timer%stop('DGS_basis_against_basis_rsp')
       call logger%log_debug('end', module=this_module, procedure='DGS_basis_against_basis_rsp')
 
     end subroutine DGS_basis_against_basis_rsp  
@@ -931,9 +942,11 @@ contains
       integer :: info
 
       call logger%log_debug('start', module=this_module, procedure='orthonormalize_basis_rdp')
+      !if (timeit()) call global_timer%start('orthonormalize_basis_rdp')
       ! internals
       call qr(X, R, info)
       call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_rdp')
+      !if (timeit()) call global_timer%end('orthonormalize_basis_rdp')
       call logger%log_debug('end', module=this_module, procedure='orthonormalize_basis_rdp')
       
       return
@@ -957,6 +970,7 @@ contains
       real(dp) :: proj_coefficients(size(X))
 
       call logger%log_debug('start', module=this_module, procedure='orthogonalize_vector_against_basis_rdp')
+      !if (timeit()) call global_timer%start('orthonormalize_vector_against_basis_rdp')
       info = 0
 
       ! optional input argument
@@ -993,6 +1007,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_vector_against_basis_rdp')
          beta = proj_coefficients
       end if
+      !if (timeit()) call global_timer%stop('orthonormalize_vector_against_basis_rdp')
       call logger%log_debug('end', module=this_module, procedure='orthogonalize_vector_against_basis_rdp')
       
       return
@@ -1017,6 +1032,7 @@ contains
       integer :: i
 
       call logger%log_debug('start', module=this_module, procedure='orthogonalize_basis_against_basis_rdp')
+      !if (timeit()) call global_timer%start('orthonormalize_basis_against_basis_rdp')
       info = 0
 
       ! optional input argument
@@ -1055,6 +1071,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_basis_against_basis_rdp')
          beta = proj_coefficients
       end if
+      !if (timeit()) call global_timer%stop('orthonormalize_basis_against_basis_rdp')
       call logger%log_debug('end', module=this_module, procedure='orthogonalize_basis_against_basis_rdp')
       
       return
@@ -1082,6 +1099,7 @@ contains
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
       call logger%log_debug('start', module=this_module, procedure='DGS_vector_against_basis_rdp')
+      !if (timeit()) call global_timer%start('DGS_vector_against_basis_rdp')
       info = 0
 
       proj_coefficients = zero_rdp; wrk = zero_rdp
@@ -1103,6 +1121,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_vector_against_basis_rdp')
          beta = proj_coefficients
       end if
+      !if (timeit()) call global_timer%stop('DGS_vector_against_basis_rdp')
       call logger%log_debug('end', module=this_module, procedure='DGS_vector_against_basis_rdp')
 
     end subroutine DGS_vector_against_basis_rdp
@@ -1129,6 +1148,7 @@ contains
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
       call logger%log_debug('start', module=this_module, procedure='DGS_basis_against_basis_rdp')
+      !if (timeit()) call global_timer%start('DGS_basis_against_basis_rdp')
       info = 0
 
       proj_coefficients = zero_rdp; wrk = zero_rdp
@@ -1150,6 +1170,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_basis_against_basis_rdp')
          beta = proj_coefficients
       end if
+      !if (timeit()) call global_timer%stop('DGS_basis_against_basis_rdp')
       call logger%log_debug('end', module=this_module, procedure='DGS_basis_against_basis_rdp')
 
     end subroutine DGS_basis_against_basis_rdp  
@@ -1186,9 +1207,11 @@ contains
       integer :: info
 
       call logger%log_debug('start', module=this_module, procedure='orthonormalize_basis_csp')
+      !if (timeit()) call global_timer%start('orthonormalize_basis_csp')
       ! internals
       call qr(X, R, info)
       call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_csp')
+      !if (timeit()) call global_timer%end('orthonormalize_basis_csp')
       call logger%log_debug('end', module=this_module, procedure='orthonormalize_basis_csp')
       
       return
@@ -1212,6 +1235,7 @@ contains
       complex(sp) :: proj_coefficients(size(X))
 
       call logger%log_debug('start', module=this_module, procedure='orthogonalize_vector_against_basis_csp')
+      !if (timeit()) call global_timer%start('orthonormalize_vector_against_basis_csp')
       info = 0
 
       ! optional input argument
@@ -1248,6 +1272,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_vector_against_basis_csp')
          beta = proj_coefficients
       end if
+      !if (timeit()) call global_timer%stop('orthonormalize_vector_against_basis_csp')
       call logger%log_debug('end', module=this_module, procedure='orthogonalize_vector_against_basis_csp')
       
       return
@@ -1272,6 +1297,7 @@ contains
       integer :: i
 
       call logger%log_debug('start', module=this_module, procedure='orthogonalize_basis_against_basis_csp')
+      !if (timeit()) call global_timer%start('orthonormalize_basis_against_basis_csp')
       info = 0
 
       ! optional input argument
@@ -1310,6 +1336,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_basis_against_basis_csp')
          beta = proj_coefficients
       end if
+      !if (timeit()) call global_timer%stop('orthonormalize_basis_against_basis_csp')
       call logger%log_debug('end', module=this_module, procedure='orthogonalize_basis_against_basis_csp')
       
       return
@@ -1337,6 +1364,7 @@ contains
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
       call logger%log_debug('start', module=this_module, procedure='DGS_vector_against_basis_csp')
+      !if (timeit()) call global_timer%start('DGS_vector_against_basis_csp')
       info = 0
 
       proj_coefficients = zero_csp; wrk = zero_csp
@@ -1358,6 +1386,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_vector_against_basis_csp')
          beta = proj_coefficients
       end if
+      !if (timeit()) call global_timer%stop('DGS_vector_against_basis_csp')
       call logger%log_debug('end', module=this_module, procedure='DGS_vector_against_basis_csp')
 
     end subroutine DGS_vector_against_basis_csp
@@ -1384,6 +1413,7 @@ contains
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
       call logger%log_debug('start', module=this_module, procedure='DGS_basis_against_basis_csp')
+      !if (timeit()) call global_timer%start('DGS_basis_against_basis_csp')
       info = 0
 
       proj_coefficients = zero_csp; wrk = zero_csp
@@ -1405,6 +1435,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_basis_against_basis_csp')
          beta = proj_coefficients
       end if
+      !if (timeit()) call global_timer%stop('DGS_basis_against_basis_csp')
       call logger%log_debug('end', module=this_module, procedure='DGS_basis_against_basis_csp')
 
     end subroutine DGS_basis_against_basis_csp  
@@ -1441,9 +1472,11 @@ contains
       integer :: info
 
       call logger%log_debug('start', module=this_module, procedure='orthonormalize_basis_cdp')
+      !if (timeit()) call global_timer%start('orthonormalize_basis_cdp')
       ! internals
       call qr(X, R, info)
       call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_cdp')
+      !if (timeit()) call global_timer%end('orthonormalize_basis_cdp')
       call logger%log_debug('end', module=this_module, procedure='orthonormalize_basis_cdp')
       
       return
@@ -1467,6 +1500,7 @@ contains
       complex(dp) :: proj_coefficients(size(X))
 
       call logger%log_debug('start', module=this_module, procedure='orthogonalize_vector_against_basis_cdp')
+      !if (timeit()) call global_timer%start('orthonormalize_vector_against_basis_cdp')
       info = 0
 
       ! optional input argument
@@ -1503,6 +1537,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_vector_against_basis_cdp')
          beta = proj_coefficients
       end if
+      !if (timeit()) call global_timer%stop('orthonormalize_vector_against_basis_cdp')
       call logger%log_debug('end', module=this_module, procedure='orthogonalize_vector_against_basis_cdp')
       
       return
@@ -1527,6 +1562,7 @@ contains
       integer :: i
 
       call logger%log_debug('start', module=this_module, procedure='orthogonalize_basis_against_basis_cdp')
+      !if (timeit()) call global_timer%start('orthonormalize_basis_against_basis_cdp')
       info = 0
 
       ! optional input argument
@@ -1565,6 +1601,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_basis_against_basis_cdp')
          beta = proj_coefficients
       end if
+      !if (timeit()) call global_timer%stop('orthonormalize_basis_against_basis_cdp')
       call logger%log_debug('end', module=this_module, procedure='orthogonalize_basis_against_basis_cdp')
       
       return
@@ -1592,6 +1629,7 @@ contains
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
       call logger%log_debug('start', module=this_module, procedure='DGS_vector_against_basis_cdp')
+      !if (timeit()) call global_timer%start('DGS_vector_against_basis_cdp')
       info = 0
 
       proj_coefficients = zero_cdp; wrk = zero_cdp
@@ -1613,6 +1651,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_vector_against_basis_cdp')
          beta = proj_coefficients
       end if
+      !if (timeit()) call global_timer%stop('DGS_vector_against_basis_cdp')
       call logger%log_debug('end', module=this_module, procedure='DGS_vector_against_basis_cdp')
 
     end subroutine DGS_vector_against_basis_cdp
@@ -1639,6 +1678,7 @@ contains
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
       call logger%log_debug('start', module=this_module, procedure='DGS_basis_against_basis_cdp')
+      !if (timeit()) call global_timer%start('DGS_basis_against_basis_cdp')
       info = 0
 
       proj_coefficients = zero_cdp; wrk = zero_cdp
@@ -1660,6 +1700,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_basis_against_basis_cdp')
          beta = proj_coefficients
       end if
+      !if (timeit()) call global_timer%stop('DGS_basis_against_basis_cdp')
       call logger%log_debug('end', module=this_module, procedure='DGS_basis_against_basis_cdp')
 
     end subroutine DGS_basis_against_basis_cdp  
@@ -1689,6 +1730,7 @@ contains
         ! Deals with the optional args.
         tolerance = optval(tol, atol_sp)
 
+      	!if (timeit()) call global_timer%start('qr_no_pivoting_rsp')
         call logger%log_debug('start', module=this_module, procedure='qr_no_pivoting_rsp')
         info = 0 ; flag = .false.; R = zero_rsp ; beta = zero_rsp
         do j = 1, size(Q)
@@ -1720,6 +1762,7 @@ contains
             ! Normalize column.
             call Q(j)%scal(one_rsp / beta)
         enddo
+      	!if (timeit()) call global_timer%stop('qr_no_pivoting_rsp')
         call logger%log_debug('end', module=this_module, procedure='qr_no_pivoting_rsp')
 
         return
@@ -1747,6 +1790,7 @@ contains
         character(len=128) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='qr_with_pivoting_rsp')
+      	!if (timeit()) call global_timer%start('qr_with_pivoting_rsp')
         info = 0 ; kdim = size(Q)
         R = zero_rsp ; Rii = zero_rsp
         
@@ -1805,6 +1849,7 @@ contains
             enddo
 
         enddo qr_step
+      	!if (timeit()) call global_timer%stop('qr_with_pivoting_rsp')
         call logger%log_debug('end', module=this_module, procedure='qr_with_pivoting_rsp')
 
         return
@@ -1958,6 +2003,7 @@ contains
         ! Deals with the optional args.
         tolerance = optval(tol, atol_dp)
 
+      	!if (timeit()) call global_timer%start('qr_no_pivoting_rdp')
         call logger%log_debug('start', module=this_module, procedure='qr_no_pivoting_rdp')
         info = 0 ; flag = .false.; R = zero_rdp ; beta = zero_rdp
         do j = 1, size(Q)
@@ -1989,6 +2035,7 @@ contains
             ! Normalize column.
             call Q(j)%scal(one_rdp / beta)
         enddo
+      	!if (timeit()) call global_timer%stop('qr_no_pivoting_rdp')
         call logger%log_debug('end', module=this_module, procedure='qr_no_pivoting_rdp')
 
         return
@@ -2016,6 +2063,7 @@ contains
         character(len=128) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='qr_with_pivoting_rdp')
+      	!if (timeit()) call global_timer%start('qr_with_pivoting_rdp')
         info = 0 ; kdim = size(Q)
         R = zero_rdp ; Rii = zero_rdp
         
@@ -2074,6 +2122,7 @@ contains
             enddo
 
         enddo qr_step
+      	!if (timeit()) call global_timer%stop('qr_with_pivoting_rdp')
         call logger%log_debug('end', module=this_module, procedure='qr_with_pivoting_rdp')
 
         return
@@ -2227,6 +2276,7 @@ contains
         ! Deals with the optional args.
         tolerance = optval(tol, atol_sp)
 
+      	!if (timeit()) call global_timer%start('qr_no_pivoting_csp')
         call logger%log_debug('start', module=this_module, procedure='qr_no_pivoting_csp')
         info = 0 ; flag = .false.; R = zero_rsp ; beta = zero_rsp
         do j = 1, size(Q)
@@ -2258,6 +2308,7 @@ contains
             ! Normalize column.
             call Q(j)%scal(one_rsp / beta)
         enddo
+      	!if (timeit()) call global_timer%stop('qr_no_pivoting_csp')
         call logger%log_debug('end', module=this_module, procedure='qr_no_pivoting_csp')
 
         return
@@ -2285,6 +2336,7 @@ contains
         character(len=128) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='qr_with_pivoting_csp')
+      	!if (timeit()) call global_timer%start('qr_with_pivoting_csp')
         info = 0 ; kdim = size(Q)
         R = zero_rsp ; Rii = zero_rsp
         
@@ -2343,6 +2395,7 @@ contains
             enddo
 
         enddo qr_step
+      	!if (timeit()) call global_timer%stop('qr_with_pivoting_csp')
         call logger%log_debug('end', module=this_module, procedure='qr_with_pivoting_csp')
 
         return
@@ -2496,6 +2549,7 @@ contains
         ! Deals with the optional args.
         tolerance = optval(tol, atol_dp)
 
+      	!if (timeit()) call global_timer%start('qr_no_pivoting_cdp')
         call logger%log_debug('start', module=this_module, procedure='qr_no_pivoting_cdp')
         info = 0 ; flag = .false.; R = zero_rdp ; beta = zero_rdp
         do j = 1, size(Q)
@@ -2527,6 +2581,7 @@ contains
             ! Normalize column.
             call Q(j)%scal(one_rdp / beta)
         enddo
+      	!if (timeit()) call global_timer%stop('qr_no_pivoting_cdp')
         call logger%log_debug('end', module=this_module, procedure='qr_no_pivoting_cdp')
 
         return
@@ -2554,6 +2609,7 @@ contains
         character(len=128) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='qr_with_pivoting_cdp')
+      	!if (timeit()) call global_timer%start('qr_with_pivoting_cdp')
         info = 0 ; kdim = size(Q)
         R = zero_rdp ; Rii = zero_rdp
         
@@ -2612,6 +2668,7 @@ contains
             enddo
 
         enddo qr_step
+      	!if (timeit()) call global_timer%stop('qr_with_pivoting_cdp')
         call logger%log_debug('end', module=this_module, procedure='qr_with_pivoting_cdp')
 
         return

--- a/src/BaseKrylov.f90
+++ b/src/BaseKrylov.f90
@@ -675,9 +675,11 @@ contains
       real(sp) :: R(size(X),size(X))
       integer :: info
 
+      call logger%log_debug('start', module=this_module, procedure='orthonormalize_basis_rsp')
       ! internals
       call qr(X, R, info)
       call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_rsp')
+      call logger%log_debug('end', module=this_module, procedure='orthonormalize_basis_rsp')
       
       return
     end subroutine orthonormalize_basis_rsp
@@ -699,6 +701,7 @@ contains
       ! internals
       real(sp) :: proj_coefficients(size(X))
 
+      call logger%log_debug('start', module=this_module, procedure='orthogonalize_vector_against_basis_rsp')
       info = 0
 
       ! optional input argument
@@ -735,6 +738,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_vector_against_basis_rsp')
          beta = proj_coefficients
       end if
+      call logger%log_debug('end', module=this_module, procedure='orthogonalize_vector_against_basis_rsp')
       
       return
     end subroutine orthogonalize_vector_against_basis_rsp
@@ -757,6 +761,7 @@ contains
       real(sp) :: proj_coefficients(size(X), size(Y))
       integer :: i
 
+      call logger%log_debug('start', module=this_module, procedure='orthogonalize_basis_against_basis_rsp')
       info = 0
 
       ! optional input argument
@@ -795,6 +800,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_basis_against_basis_rsp')
          beta = proj_coefficients
       end if
+      call logger%log_debug('end', module=this_module, procedure='orthogonalize_basis_against_basis_rsp')
       
       return
     end subroutine orthogonalize_basis_against_basis_rsp
@@ -820,6 +826,7 @@ contains
       ! optional input argument
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
+      call logger%log_debug('start', module=this_module, procedure='DGS_vector_against_basis_rsp')
       info = 0
 
       proj_coefficients = zero_rsp; wrk = zero_rsp
@@ -841,6 +848,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_vector_against_basis_rsp')
          beta = proj_coefficients
       end if
+      call logger%log_debug('end', module=this_module, procedure='DGS_vector_against_basis_rsp')
 
     end subroutine DGS_vector_against_basis_rsp
 
@@ -865,6 +873,7 @@ contains
       ! optional input argument
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
+      call logger%log_debug('start', module=this_module, procedure='DGS_basis_against_basis_rsp')
       info = 0
 
       proj_coefficients = zero_rsp; wrk = zero_rsp
@@ -886,6 +895,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_basis_against_basis_rsp')
          beta = proj_coefficients
       end if
+      call logger%log_debug('end', module=this_module, procedure='DGS_basis_against_basis_rsp')
 
     end subroutine DGS_basis_against_basis_rsp  
 
@@ -920,9 +930,11 @@ contains
       real(dp) :: R(size(X),size(X))
       integer :: info
 
+      call logger%log_debug('start', module=this_module, procedure='orthonormalize_basis_rdp')
       ! internals
       call qr(X, R, info)
       call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_rdp')
+      call logger%log_debug('end', module=this_module, procedure='orthonormalize_basis_rdp')
       
       return
     end subroutine orthonormalize_basis_rdp
@@ -944,6 +956,7 @@ contains
       ! internals
       real(dp) :: proj_coefficients(size(X))
 
+      call logger%log_debug('start', module=this_module, procedure='orthogonalize_vector_against_basis_rdp')
       info = 0
 
       ! optional input argument
@@ -980,6 +993,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_vector_against_basis_rdp')
          beta = proj_coefficients
       end if
+      call logger%log_debug('end', module=this_module, procedure='orthogonalize_vector_against_basis_rdp')
       
       return
     end subroutine orthogonalize_vector_against_basis_rdp
@@ -1002,6 +1016,7 @@ contains
       real(dp) :: proj_coefficients(size(X), size(Y))
       integer :: i
 
+      call logger%log_debug('start', module=this_module, procedure='orthogonalize_basis_against_basis_rdp')
       info = 0
 
       ! optional input argument
@@ -1040,6 +1055,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_basis_against_basis_rdp')
          beta = proj_coefficients
       end if
+      call logger%log_debug('end', module=this_module, procedure='orthogonalize_basis_against_basis_rdp')
       
       return
     end subroutine orthogonalize_basis_against_basis_rdp
@@ -1065,6 +1081,7 @@ contains
       ! optional input argument
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
+      call logger%log_debug('start', module=this_module, procedure='DGS_vector_against_basis_rdp')
       info = 0
 
       proj_coefficients = zero_rdp; wrk = zero_rdp
@@ -1086,6 +1103,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_vector_against_basis_rdp')
          beta = proj_coefficients
       end if
+      call logger%log_debug('end', module=this_module, procedure='DGS_vector_against_basis_rdp')
 
     end subroutine DGS_vector_against_basis_rdp
 
@@ -1110,6 +1128,7 @@ contains
       ! optional input argument
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
+      call logger%log_debug('start', module=this_module, procedure='DGS_basis_against_basis_rdp')
       info = 0
 
       proj_coefficients = zero_rdp; wrk = zero_rdp
@@ -1131,6 +1150,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_basis_against_basis_rdp')
          beta = proj_coefficients
       end if
+      call logger%log_debug('end', module=this_module, procedure='DGS_basis_against_basis_rdp')
 
     end subroutine DGS_basis_against_basis_rdp  
 
@@ -1165,9 +1185,11 @@ contains
       complex(sp) :: R(size(X),size(X))
       integer :: info
 
+      call logger%log_debug('start', module=this_module, procedure='orthonormalize_basis_csp')
       ! internals
       call qr(X, R, info)
       call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_csp')
+      call logger%log_debug('end', module=this_module, procedure='orthonormalize_basis_csp')
       
       return
     end subroutine orthonormalize_basis_csp
@@ -1189,6 +1211,7 @@ contains
       ! internals
       complex(sp) :: proj_coefficients(size(X))
 
+      call logger%log_debug('start', module=this_module, procedure='orthogonalize_vector_against_basis_csp')
       info = 0
 
       ! optional input argument
@@ -1225,6 +1248,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_vector_against_basis_csp')
          beta = proj_coefficients
       end if
+      call logger%log_debug('end', module=this_module, procedure='orthogonalize_vector_against_basis_csp')
       
       return
     end subroutine orthogonalize_vector_against_basis_csp
@@ -1247,6 +1271,7 @@ contains
       complex(sp) :: proj_coefficients(size(X), size(Y))
       integer :: i
 
+      call logger%log_debug('start', module=this_module, procedure='orthogonalize_basis_against_basis_csp')
       info = 0
 
       ! optional input argument
@@ -1285,6 +1310,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_basis_against_basis_csp')
          beta = proj_coefficients
       end if
+      call logger%log_debug('end', module=this_module, procedure='orthogonalize_basis_against_basis_csp')
       
       return
     end subroutine orthogonalize_basis_against_basis_csp
@@ -1310,6 +1336,7 @@ contains
       ! optional input argument
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
+      call logger%log_debug('start', module=this_module, procedure='DGS_vector_against_basis_csp')
       info = 0
 
       proj_coefficients = zero_csp; wrk = zero_csp
@@ -1331,6 +1358,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_vector_against_basis_csp')
          beta = proj_coefficients
       end if
+      call logger%log_debug('end', module=this_module, procedure='DGS_vector_against_basis_csp')
 
     end subroutine DGS_vector_against_basis_csp
 
@@ -1355,6 +1383,7 @@ contains
       ! optional input argument
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
+      call logger%log_debug('start', module=this_module, procedure='DGS_basis_against_basis_csp')
       info = 0
 
       proj_coefficients = zero_csp; wrk = zero_csp
@@ -1376,6 +1405,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_basis_against_basis_csp')
          beta = proj_coefficients
       end if
+      call logger%log_debug('end', module=this_module, procedure='DGS_basis_against_basis_csp')
 
     end subroutine DGS_basis_against_basis_csp  
 
@@ -1410,9 +1440,11 @@ contains
       complex(dp) :: R(size(X),size(X))
       integer :: info
 
+      call logger%log_debug('start', module=this_module, procedure='orthonormalize_basis_cdp')
       ! internals
       call qr(X, R, info)
       call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_cdp')
+      call logger%log_debug('end', module=this_module, procedure='orthonormalize_basis_cdp')
       
       return
     end subroutine orthonormalize_basis_cdp
@@ -1434,6 +1466,7 @@ contains
       ! internals
       complex(dp) :: proj_coefficients(size(X))
 
+      call logger%log_debug('start', module=this_module, procedure='orthogonalize_vector_against_basis_cdp')
       info = 0
 
       ! optional input argument
@@ -1470,6 +1503,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_vector_against_basis_cdp')
          beta = proj_coefficients
       end if
+      call logger%log_debug('end', module=this_module, procedure='orthogonalize_vector_against_basis_cdp')
       
       return
     end subroutine orthogonalize_vector_against_basis_cdp
@@ -1492,6 +1526,7 @@ contains
       complex(dp) :: proj_coefficients(size(X), size(Y))
       integer :: i
 
+      call logger%log_debug('start', module=this_module, procedure='orthogonalize_basis_against_basis_cdp')
       info = 0
 
       ! optional input argument
@@ -1530,6 +1565,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_basis_against_basis_cdp')
          beta = proj_coefficients
       end if
+      call logger%log_debug('end', module=this_module, procedure='orthogonalize_basis_against_basis_cdp')
       
       return
     end subroutine orthogonalize_basis_against_basis_cdp
@@ -1555,6 +1591,7 @@ contains
       ! optional input argument
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
+      call logger%log_debug('start', module=this_module, procedure='DGS_vector_against_basis_cdp')
       info = 0
 
       proj_coefficients = zero_cdp; wrk = zero_cdp
@@ -1576,6 +1613,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_vector_against_basis_cdp')
          beta = proj_coefficients
       end if
+      call logger%log_debug('end', module=this_module, procedure='DGS_vector_against_basis_cdp')
 
     end subroutine DGS_vector_against_basis_cdp
 
@@ -1600,6 +1638,7 @@ contains
       ! optional input argument
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
+      call logger%log_debug('start', module=this_module, procedure='DGS_basis_against_basis_cdp')
       info = 0
 
       proj_coefficients = zero_cdp; wrk = zero_cdp
@@ -1621,6 +1660,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_basis_against_basis_cdp')
          beta = proj_coefficients
       end if
+      call logger%log_debug('end', module=this_module, procedure='DGS_basis_against_basis_cdp')
 
     end subroutine DGS_basis_against_basis_cdp  
 
@@ -1649,6 +1689,7 @@ contains
         ! Deals with the optional args.
         tolerance = optval(tol, atol_sp)
 
+        call logger%log_debug('start', module=this_module, procedure='qr_no_pivoting_rsp')
         info = 0 ; flag = .false.; R = zero_rsp ; beta = zero_rsp
         do j = 1, size(Q)
             if (j > 1) then
@@ -1679,6 +1720,7 @@ contains
             ! Normalize column.
             call Q(j)%scal(one_rsp / beta)
         enddo
+        call logger%log_debug('end', module=this_module, procedure='qr_no_pivoting_rsp')
 
         return
     end subroutine qr_no_pivoting_rsp
@@ -1704,6 +1746,7 @@ contains
         real(sp)  :: Rii(size(Q))
         character(len=128) :: msg
 
+        call logger%log_debug('start', module=this_module, procedure='qr_with_pivoting_rsp')
         info = 0 ; kdim = size(Q)
         R = zero_rsp ; Rii = zero_rsp
         
@@ -1762,6 +1805,7 @@ contains
             enddo
 
         enddo qr_step
+        call logger%log_debug('end', module=this_module, procedure='qr_with_pivoting_rsp')
 
         return
     end subroutine qr_with_pivoting_rsp
@@ -1914,6 +1958,7 @@ contains
         ! Deals with the optional args.
         tolerance = optval(tol, atol_dp)
 
+        call logger%log_debug('start', module=this_module, procedure='qr_no_pivoting_rdp')
         info = 0 ; flag = .false.; R = zero_rdp ; beta = zero_rdp
         do j = 1, size(Q)
             if (j > 1) then
@@ -1944,6 +1989,7 @@ contains
             ! Normalize column.
             call Q(j)%scal(one_rdp / beta)
         enddo
+        call logger%log_debug('end', module=this_module, procedure='qr_no_pivoting_rdp')
 
         return
     end subroutine qr_no_pivoting_rdp
@@ -1969,6 +2015,7 @@ contains
         real(dp)  :: Rii(size(Q))
         character(len=128) :: msg
 
+        call logger%log_debug('start', module=this_module, procedure='qr_with_pivoting_rdp')
         info = 0 ; kdim = size(Q)
         R = zero_rdp ; Rii = zero_rdp
         
@@ -2027,6 +2074,7 @@ contains
             enddo
 
         enddo qr_step
+        call logger%log_debug('end', module=this_module, procedure='qr_with_pivoting_rdp')
 
         return
     end subroutine qr_with_pivoting_rdp
@@ -2179,6 +2227,7 @@ contains
         ! Deals with the optional args.
         tolerance = optval(tol, atol_sp)
 
+        call logger%log_debug('start', module=this_module, procedure='qr_no_pivoting_csp')
         info = 0 ; flag = .false.; R = zero_rsp ; beta = zero_rsp
         do j = 1, size(Q)
             if (j > 1) then
@@ -2209,6 +2258,7 @@ contains
             ! Normalize column.
             call Q(j)%scal(one_rsp / beta)
         enddo
+        call logger%log_debug('end', module=this_module, procedure='qr_no_pivoting_csp')
 
         return
     end subroutine qr_no_pivoting_csp
@@ -2234,6 +2284,7 @@ contains
         complex(sp)  :: Rii(size(Q))
         character(len=128) :: msg
 
+        call logger%log_debug('start', module=this_module, procedure='qr_with_pivoting_csp')
         info = 0 ; kdim = size(Q)
         R = zero_rsp ; Rii = zero_rsp
         
@@ -2292,6 +2343,7 @@ contains
             enddo
 
         enddo qr_step
+        call logger%log_debug('end', module=this_module, procedure='qr_with_pivoting_csp')
 
         return
     end subroutine qr_with_pivoting_csp
@@ -2444,6 +2496,7 @@ contains
         ! Deals with the optional args.
         tolerance = optval(tol, atol_dp)
 
+        call logger%log_debug('start', module=this_module, procedure='qr_no_pivoting_cdp')
         info = 0 ; flag = .false.; R = zero_rdp ; beta = zero_rdp
         do j = 1, size(Q)
             if (j > 1) then
@@ -2474,6 +2527,7 @@ contains
             ! Normalize column.
             call Q(j)%scal(one_rdp / beta)
         enddo
+        call logger%log_debug('end', module=this_module, procedure='qr_no_pivoting_cdp')
 
         return
     end subroutine qr_no_pivoting_cdp
@@ -2499,6 +2553,7 @@ contains
         complex(dp)  :: Rii(size(Q))
         character(len=128) :: msg
 
+        call logger%log_debug('start', module=this_module, procedure='qr_with_pivoting_cdp')
         info = 0 ; kdim = size(Q)
         R = zero_rdp ; Rii = zero_rdp
         
@@ -2557,6 +2612,7 @@ contains
             enddo
 
         enddo qr_step
+        call logger%log_debug('end', module=this_module, procedure='qr_with_pivoting_cdp')
 
         return
     end subroutine qr_with_pivoting_cdp

--- a/src/BaseKrylov.f90
+++ b/src/BaseKrylov.f90
@@ -676,13 +676,11 @@ contains
       real(sp) :: R(size(X),size(X))
       integer :: info
 
-      call logger%log_debug('start', module=this_module, procedure='orthonormalize_basis_rsp')
       if (time_lightkrylov()) call timer%start('orthonormalize_basis_rsp')
       ! internals
       call qr(X, R, info)
       call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_rsp')
       if (time_lightkrylov()) call timer%stop('orthonormalize_basis_rsp')
-      call logger%log_debug('end', module=this_module, procedure='orthonormalize_basis_rsp')
       
       return
     end subroutine orthonormalize_basis_rsp
@@ -704,7 +702,6 @@ contains
       ! internals
       real(sp) :: proj_coefficients(size(X))
 
-      call logger%log_debug('start', module=this_module, procedure='orthogonalize_vector_against_basis_rsp')
       if (time_lightkrylov()) call timer%start('orthonormalize_vector_against_basis_rsp')
       info = 0
 
@@ -743,7 +740,6 @@ contains
          beta = proj_coefficients
       end if
       if (time_lightkrylov()) call timer%stop('orthonormalize_vector_against_basis_rsp')
-      call logger%log_debug('end', module=this_module, procedure='orthogonalize_vector_against_basis_rsp')
       
       return
     end subroutine orthogonalize_vector_against_basis_rsp
@@ -766,7 +762,6 @@ contains
       real(sp) :: proj_coefficients(size(X), size(Y))
       integer :: i
 
-      call logger%log_debug('start', module=this_module, procedure='orthogonalize_basis_against_basis_rsp')
       if (time_lightkrylov()) call timer%start('orthonormalize_basis_against_basis_rsp')
       info = 0
 
@@ -807,7 +802,6 @@ contains
          beta = proj_coefficients
       end if
       if (time_lightkrylov()) call timer%stop('orthonormalize_basis_against_basis_rsp')
-      call logger%log_debug('end', module=this_module, procedure='orthogonalize_basis_against_basis_rsp')
       
       return
     end subroutine orthogonalize_basis_against_basis_rsp
@@ -833,7 +827,6 @@ contains
       ! optional input argument
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
-      call logger%log_debug('start', module=this_module, procedure='DGS_vector_against_basis_rsp')
       if (time_lightkrylov()) call timer%start('DGS_vector_against_basis_rsp')
       info = 0
 
@@ -857,8 +850,7 @@ contains
          beta = proj_coefficients
       end if
       if (time_lightkrylov()) call timer%stop('DGS_vector_against_basis_rsp')
-      call logger%log_debug('end', module=this_module, procedure='DGS_vector_against_basis_rsp')
-
+      
     end subroutine DGS_vector_against_basis_rsp
 
     subroutine DGS_basis_against_basis_rsp(y, X, info, if_chk_orthonormal, beta)
@@ -882,7 +874,6 @@ contains
       ! optional input argument
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
-      call logger%log_debug('start', module=this_module, procedure='DGS_basis_against_basis_rsp')
       if (time_lightkrylov()) call timer%start('DGS_basis_against_basis_rsp')
       info = 0
 
@@ -906,8 +897,7 @@ contains
          beta = proj_coefficients
       end if
       if (time_lightkrylov()) call timer%stop('DGS_basis_against_basis_rsp')
-      call logger%log_debug('end', module=this_module, procedure='DGS_basis_against_basis_rsp')
-
+      
     end subroutine DGS_basis_against_basis_rsp  
 
     subroutine initialize_krylov_subspace_rdp(X, X0)
@@ -941,13 +931,11 @@ contains
       real(dp) :: R(size(X),size(X))
       integer :: info
 
-      call logger%log_debug('start', module=this_module, procedure='orthonormalize_basis_rdp')
       if (time_lightkrylov()) call timer%start('orthonormalize_basis_rdp')
       ! internals
       call qr(X, R, info)
       call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_rdp')
       if (time_lightkrylov()) call timer%stop('orthonormalize_basis_rdp')
-      call logger%log_debug('end', module=this_module, procedure='orthonormalize_basis_rdp')
       
       return
     end subroutine orthonormalize_basis_rdp
@@ -969,7 +957,6 @@ contains
       ! internals
       real(dp) :: proj_coefficients(size(X))
 
-      call logger%log_debug('start', module=this_module, procedure='orthogonalize_vector_against_basis_rdp')
       if (time_lightkrylov()) call timer%start('orthonormalize_vector_against_basis_rdp')
       info = 0
 
@@ -1008,7 +995,6 @@ contains
          beta = proj_coefficients
       end if
       if (time_lightkrylov()) call timer%stop('orthonormalize_vector_against_basis_rdp')
-      call logger%log_debug('end', module=this_module, procedure='orthogonalize_vector_against_basis_rdp')
       
       return
     end subroutine orthogonalize_vector_against_basis_rdp
@@ -1031,7 +1017,6 @@ contains
       real(dp) :: proj_coefficients(size(X), size(Y))
       integer :: i
 
-      call logger%log_debug('start', module=this_module, procedure='orthogonalize_basis_against_basis_rdp')
       if (time_lightkrylov()) call timer%start('orthonormalize_basis_against_basis_rdp')
       info = 0
 
@@ -1072,7 +1057,6 @@ contains
          beta = proj_coefficients
       end if
       if (time_lightkrylov()) call timer%stop('orthonormalize_basis_against_basis_rdp')
-      call logger%log_debug('end', module=this_module, procedure='orthogonalize_basis_against_basis_rdp')
       
       return
     end subroutine orthogonalize_basis_against_basis_rdp
@@ -1098,7 +1082,6 @@ contains
       ! optional input argument
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
-      call logger%log_debug('start', module=this_module, procedure='DGS_vector_against_basis_rdp')
       if (time_lightkrylov()) call timer%start('DGS_vector_against_basis_rdp')
       info = 0
 
@@ -1122,8 +1105,7 @@ contains
          beta = proj_coefficients
       end if
       if (time_lightkrylov()) call timer%stop('DGS_vector_against_basis_rdp')
-      call logger%log_debug('end', module=this_module, procedure='DGS_vector_against_basis_rdp')
-
+      
     end subroutine DGS_vector_against_basis_rdp
 
     subroutine DGS_basis_against_basis_rdp(y, X, info, if_chk_orthonormal, beta)
@@ -1147,7 +1129,6 @@ contains
       ! optional input argument
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
-      call logger%log_debug('start', module=this_module, procedure='DGS_basis_against_basis_rdp')
       if (time_lightkrylov()) call timer%start('DGS_basis_against_basis_rdp')
       info = 0
 
@@ -1171,8 +1152,7 @@ contains
          beta = proj_coefficients
       end if
       if (time_lightkrylov()) call timer%stop('DGS_basis_against_basis_rdp')
-      call logger%log_debug('end', module=this_module, procedure='DGS_basis_against_basis_rdp')
-
+      
     end subroutine DGS_basis_against_basis_rdp  
 
     subroutine initialize_krylov_subspace_csp(X, X0)
@@ -1206,13 +1186,11 @@ contains
       complex(sp) :: R(size(X),size(X))
       integer :: info
 
-      call logger%log_debug('start', module=this_module, procedure='orthonormalize_basis_csp')
       if (time_lightkrylov()) call timer%start('orthonormalize_basis_csp')
       ! internals
       call qr(X, R, info)
       call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_csp')
       if (time_lightkrylov()) call timer%stop('orthonormalize_basis_csp')
-      call logger%log_debug('end', module=this_module, procedure='orthonormalize_basis_csp')
       
       return
     end subroutine orthonormalize_basis_csp
@@ -1234,7 +1212,6 @@ contains
       ! internals
       complex(sp) :: proj_coefficients(size(X))
 
-      call logger%log_debug('start', module=this_module, procedure='orthogonalize_vector_against_basis_csp')
       if (time_lightkrylov()) call timer%start('orthonormalize_vector_against_basis_csp')
       info = 0
 
@@ -1273,7 +1250,6 @@ contains
          beta = proj_coefficients
       end if
       if (time_lightkrylov()) call timer%stop('orthonormalize_vector_against_basis_csp')
-      call logger%log_debug('end', module=this_module, procedure='orthogonalize_vector_against_basis_csp')
       
       return
     end subroutine orthogonalize_vector_against_basis_csp
@@ -1296,7 +1272,6 @@ contains
       complex(sp) :: proj_coefficients(size(X), size(Y))
       integer :: i
 
-      call logger%log_debug('start', module=this_module, procedure='orthogonalize_basis_against_basis_csp')
       if (time_lightkrylov()) call timer%start('orthonormalize_basis_against_basis_csp')
       info = 0
 
@@ -1337,7 +1312,6 @@ contains
          beta = proj_coefficients
       end if
       if (time_lightkrylov()) call timer%stop('orthonormalize_basis_against_basis_csp')
-      call logger%log_debug('end', module=this_module, procedure='orthogonalize_basis_against_basis_csp')
       
       return
     end subroutine orthogonalize_basis_against_basis_csp
@@ -1363,7 +1337,6 @@ contains
       ! optional input argument
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
-      call logger%log_debug('start', module=this_module, procedure='DGS_vector_against_basis_csp')
       if (time_lightkrylov()) call timer%start('DGS_vector_against_basis_csp')
       info = 0
 
@@ -1387,8 +1360,7 @@ contains
          beta = proj_coefficients
       end if
       if (time_lightkrylov()) call timer%stop('DGS_vector_against_basis_csp')
-      call logger%log_debug('end', module=this_module, procedure='DGS_vector_against_basis_csp')
-
+      
     end subroutine DGS_vector_against_basis_csp
 
     subroutine DGS_basis_against_basis_csp(y, X, info, if_chk_orthonormal, beta)
@@ -1412,7 +1384,6 @@ contains
       ! optional input argument
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
-      call logger%log_debug('start', module=this_module, procedure='DGS_basis_against_basis_csp')
       if (time_lightkrylov()) call timer%start('DGS_basis_against_basis_csp')
       info = 0
 
@@ -1436,8 +1407,7 @@ contains
          beta = proj_coefficients
       end if
       if (time_lightkrylov()) call timer%stop('DGS_basis_against_basis_csp')
-      call logger%log_debug('end', module=this_module, procedure='DGS_basis_against_basis_csp')
-
+      
     end subroutine DGS_basis_against_basis_csp  
 
     subroutine initialize_krylov_subspace_cdp(X, X0)
@@ -1471,13 +1441,11 @@ contains
       complex(dp) :: R(size(X),size(X))
       integer :: info
 
-      call logger%log_debug('start', module=this_module, procedure='orthonormalize_basis_cdp')
       if (time_lightkrylov()) call timer%start('orthonormalize_basis_cdp')
       ! internals
       call qr(X, R, info)
       call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_cdp')
       if (time_lightkrylov()) call timer%stop('orthonormalize_basis_cdp')
-      call logger%log_debug('end', module=this_module, procedure='orthonormalize_basis_cdp')
       
       return
     end subroutine orthonormalize_basis_cdp
@@ -1499,7 +1467,6 @@ contains
       ! internals
       complex(dp) :: proj_coefficients(size(X))
 
-      call logger%log_debug('start', module=this_module, procedure='orthogonalize_vector_against_basis_cdp')
       if (time_lightkrylov()) call timer%start('orthonormalize_vector_against_basis_cdp')
       info = 0
 
@@ -1538,7 +1505,6 @@ contains
          beta = proj_coefficients
       end if
       if (time_lightkrylov()) call timer%stop('orthonormalize_vector_against_basis_cdp')
-      call logger%log_debug('end', module=this_module, procedure='orthogonalize_vector_against_basis_cdp')
       
       return
     end subroutine orthogonalize_vector_against_basis_cdp
@@ -1561,7 +1527,6 @@ contains
       complex(dp) :: proj_coefficients(size(X), size(Y))
       integer :: i
 
-      call logger%log_debug('start', module=this_module, procedure='orthogonalize_basis_against_basis_cdp')
       if (time_lightkrylov()) call timer%start('orthonormalize_basis_against_basis_cdp')
       info = 0
 
@@ -1602,7 +1567,6 @@ contains
          beta = proj_coefficients
       end if
       if (time_lightkrylov()) call timer%stop('orthonormalize_basis_against_basis_cdp')
-      call logger%log_debug('end', module=this_module, procedure='orthogonalize_basis_against_basis_cdp')
       
       return
     end subroutine orthogonalize_basis_against_basis_cdp
@@ -1628,7 +1592,6 @@ contains
       ! optional input argument
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
-      call logger%log_debug('start', module=this_module, procedure='DGS_vector_against_basis_cdp')
       if (time_lightkrylov()) call timer%start('DGS_vector_against_basis_cdp')
       info = 0
 
@@ -1652,8 +1615,7 @@ contains
          beta = proj_coefficients
       end if
       if (time_lightkrylov()) call timer%stop('DGS_vector_against_basis_cdp')
-      call logger%log_debug('end', module=this_module, procedure='DGS_vector_against_basis_cdp')
-
+      
     end subroutine DGS_vector_against_basis_cdp
 
     subroutine DGS_basis_against_basis_cdp(y, X, info, if_chk_orthonormal, beta)
@@ -1677,7 +1639,6 @@ contains
       ! optional input argument
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
-      call logger%log_debug('start', module=this_module, procedure='DGS_basis_against_basis_cdp')
       if (time_lightkrylov()) call timer%start('DGS_basis_against_basis_cdp')
       info = 0
 
@@ -1701,8 +1662,7 @@ contains
          beta = proj_coefficients
       end if
       if (time_lightkrylov()) call timer%stop('DGS_basis_against_basis_cdp')
-      call logger%log_debug('end', module=this_module, procedure='DGS_basis_against_basis_cdp')
-
+      
     end subroutine DGS_basis_against_basis_cdp  
 
 
@@ -1731,7 +1691,6 @@ contains
         tolerance = optval(tol, atol_sp)
 
       	if (time_lightkrylov()) call timer%start('qr_no_pivoting_rsp')
-        call logger%log_debug('start', module=this_module, procedure='qr_no_pivoting_rsp')
         info = 0 ; flag = .false.; R = zero_rsp ; beta = zero_rsp
         do j = 1, size(Q)
             if (j > 1) then
@@ -1763,8 +1722,7 @@ contains
             call Q(j)%scal(one_rsp / beta)
         enddo
       	if (time_lightkrylov()) call timer%stop('qr_no_pivoting_rsp')
-        call logger%log_debug('end', module=this_module, procedure='qr_no_pivoting_rsp')
-
+        
         return
     end subroutine qr_no_pivoting_rsp
 
@@ -1789,8 +1747,7 @@ contains
         real(sp)  :: Rii(size(Q))
         character(len=128) :: msg
 
-        call logger%log_debug('start', module=this_module, procedure='qr_with_pivoting_rsp')
-      	if (time_lightkrylov()) call timer%start('qr_with_pivoting_rsp')
+        if (time_lightkrylov()) call timer%start('qr_with_pivoting_rsp')
         info = 0 ; kdim = size(Q)
         R = zero_rsp ; Rii = zero_rsp
         
@@ -1850,8 +1807,7 @@ contains
 
         enddo qr_step
       	if (time_lightkrylov()) call timer%stop('qr_with_pivoting_rsp')
-        call logger%log_debug('end', module=this_module, procedure='qr_with_pivoting_rsp')
-
+        
         return
     end subroutine qr_with_pivoting_rsp
 
@@ -2004,7 +1960,6 @@ contains
         tolerance = optval(tol, atol_dp)
 
       	if (time_lightkrylov()) call timer%start('qr_no_pivoting_rdp')
-        call logger%log_debug('start', module=this_module, procedure='qr_no_pivoting_rdp')
         info = 0 ; flag = .false.; R = zero_rdp ; beta = zero_rdp
         do j = 1, size(Q)
             if (j > 1) then
@@ -2036,8 +1991,7 @@ contains
             call Q(j)%scal(one_rdp / beta)
         enddo
       	if (time_lightkrylov()) call timer%stop('qr_no_pivoting_rdp')
-        call logger%log_debug('end', module=this_module, procedure='qr_no_pivoting_rdp')
-
+        
         return
     end subroutine qr_no_pivoting_rdp
 
@@ -2062,8 +2016,7 @@ contains
         real(dp)  :: Rii(size(Q))
         character(len=128) :: msg
 
-        call logger%log_debug('start', module=this_module, procedure='qr_with_pivoting_rdp')
-      	if (time_lightkrylov()) call timer%start('qr_with_pivoting_rdp')
+        if (time_lightkrylov()) call timer%start('qr_with_pivoting_rdp')
         info = 0 ; kdim = size(Q)
         R = zero_rdp ; Rii = zero_rdp
         
@@ -2123,8 +2076,7 @@ contains
 
         enddo qr_step
       	if (time_lightkrylov()) call timer%stop('qr_with_pivoting_rdp')
-        call logger%log_debug('end', module=this_module, procedure='qr_with_pivoting_rdp')
-
+        
         return
     end subroutine qr_with_pivoting_rdp
 
@@ -2277,7 +2229,6 @@ contains
         tolerance = optval(tol, atol_sp)
 
       	if (time_lightkrylov()) call timer%start('qr_no_pivoting_csp')
-        call logger%log_debug('start', module=this_module, procedure='qr_no_pivoting_csp')
         info = 0 ; flag = .false.; R = zero_rsp ; beta = zero_rsp
         do j = 1, size(Q)
             if (j > 1) then
@@ -2309,8 +2260,7 @@ contains
             call Q(j)%scal(one_rsp / beta)
         enddo
       	if (time_lightkrylov()) call timer%stop('qr_no_pivoting_csp')
-        call logger%log_debug('end', module=this_module, procedure='qr_no_pivoting_csp')
-
+        
         return
     end subroutine qr_no_pivoting_csp
 
@@ -2335,8 +2285,7 @@ contains
         complex(sp)  :: Rii(size(Q))
         character(len=128) :: msg
 
-        call logger%log_debug('start', module=this_module, procedure='qr_with_pivoting_csp')
-      	if (time_lightkrylov()) call timer%start('qr_with_pivoting_csp')
+        if (time_lightkrylov()) call timer%start('qr_with_pivoting_csp')
         info = 0 ; kdim = size(Q)
         R = zero_rsp ; Rii = zero_rsp
         
@@ -2396,8 +2345,7 @@ contains
 
         enddo qr_step
       	if (time_lightkrylov()) call timer%stop('qr_with_pivoting_csp')
-        call logger%log_debug('end', module=this_module, procedure='qr_with_pivoting_csp')
-
+        
         return
     end subroutine qr_with_pivoting_csp
 
@@ -2550,7 +2498,6 @@ contains
         tolerance = optval(tol, atol_dp)
 
       	if (time_lightkrylov()) call timer%start('qr_no_pivoting_cdp')
-        call logger%log_debug('start', module=this_module, procedure='qr_no_pivoting_cdp')
         info = 0 ; flag = .false.; R = zero_rdp ; beta = zero_rdp
         do j = 1, size(Q)
             if (j > 1) then
@@ -2582,8 +2529,7 @@ contains
             call Q(j)%scal(one_rdp / beta)
         enddo
       	if (time_lightkrylov()) call timer%stop('qr_no_pivoting_cdp')
-        call logger%log_debug('end', module=this_module, procedure='qr_no_pivoting_cdp')
-
+        
         return
     end subroutine qr_no_pivoting_cdp
 
@@ -2608,8 +2554,7 @@ contains
         complex(dp)  :: Rii(size(Q))
         character(len=128) :: msg
 
-        call logger%log_debug('start', module=this_module, procedure='qr_with_pivoting_cdp')
-      	if (time_lightkrylov()) call timer%start('qr_with_pivoting_cdp')
+        if (time_lightkrylov()) call timer%start('qr_with_pivoting_cdp')
         info = 0 ; kdim = size(Q)
         R = zero_rdp ; Rii = zero_rdp
         
@@ -2669,8 +2614,7 @@ contains
 
         enddo qr_step
       	if (time_lightkrylov()) call timer%stop('qr_with_pivoting_cdp')
-        call logger%log_debug('end', module=this_module, procedure='qr_with_pivoting_cdp')
-
+        
         return
     end subroutine qr_with_pivoting_cdp
 
@@ -2836,7 +2780,6 @@ contains
         integer, allocatable :: perm(:)
         integer :: k, i, kdim, kpm, kp, kpp
 
-        call logger%log_debug('start', module=this_module, procedure='arnoldi_rsp')
         if (time_lightkrylov()) call timer%start('arnoldi_rsp')
 
         ! Deals with optional non-unity blksize and allocations.
@@ -2893,8 +2836,7 @@ contains
         enddo blk_arnoldi
 
         if (time_lightkrylov()) call timer%stop('arnoldi_rsp')
-        call logger%log_debug('end', module=this_module, procedure='arnoldi_rsp')
-
+        
         return
     end subroutine arnoldi_rsp
 
@@ -2927,7 +2869,6 @@ contains
         integer, allocatable :: perm(:)
         integer :: k, i, kdim, kpm, kp, kpp
 
-        call logger%log_debug('start', module=this_module, procedure='arnoldi_rdp')
         if (time_lightkrylov()) call timer%start('arnoldi_rdp')
 
         ! Deals with optional non-unity blksize and allocations.
@@ -2984,8 +2925,7 @@ contains
         enddo blk_arnoldi
 
         if (time_lightkrylov()) call timer%stop('arnoldi_rdp')
-        call logger%log_debug('end', module=this_module, procedure='arnoldi_rdp')
-
+        
         return
     end subroutine arnoldi_rdp
 
@@ -3018,7 +2958,6 @@ contains
         integer, allocatable :: perm(:)
         integer :: k, i, kdim, kpm, kp, kpp
 
-        call logger%log_debug('start', module=this_module, procedure='arnoldi_csp')
         if (time_lightkrylov()) call timer%start('arnoldi_csp')
 
         ! Deals with optional non-unity blksize and allocations.
@@ -3075,8 +3014,7 @@ contains
         enddo blk_arnoldi
 
         if (time_lightkrylov()) call timer%stop('arnoldi_csp')
-        call logger%log_debug('end', module=this_module, procedure='arnoldi_csp')
-
+        
         return
     end subroutine arnoldi_csp
 
@@ -3109,7 +3047,6 @@ contains
         integer, allocatable :: perm(:)
         integer :: k, i, kdim, kpm, kp, kpp
 
-        call logger%log_debug('start', module=this_module, procedure='arnoldi_cdp')
         if (time_lightkrylov()) call timer%start('arnoldi_cdp')
 
         ! Deals with optional non-unity blksize and allocations.
@@ -3166,8 +3103,7 @@ contains
         enddo blk_arnoldi
 
         if (time_lightkrylov()) call timer%stop('arnoldi_cdp')
-        call logger%log_debug('end', module=this_module, procedure='arnoldi_cdp')
-
+        
         return
     end subroutine arnoldi_cdp
 
@@ -3202,7 +3138,6 @@ contains
         real(sp) :: alpha, beta
         integer :: k, kdim
 
-        call logger%log_debug('start', module=this_module, procedure='lanczos_bidiagonalization_rsp')
         if (time_lightkrylov()) call timer%start('lanczos_bidiagonalization_rsp')
         info = 0
 
@@ -3255,8 +3190,7 @@ contains
         enddo lanczos
 
         if (time_lightkrylov()) call timer%stop('lanczos_bidiagonalization_rsp')
-        call logger%log_debug('end', module=this_module, procedure='lanczos_bidiagonalization_rsp')
-
+        
         return
     end subroutine lanczos_bidiagonalization_rsp
 
@@ -3285,7 +3219,6 @@ contains
         real(dp) :: alpha, beta
         integer :: k, kdim
 
-        call logger%log_debug('start', module=this_module, procedure='lanczos_bidiagonalization_rdp')
         if (time_lightkrylov()) call timer%start('lanczos_bidiagonalization_rdp')
         info = 0
 
@@ -3338,8 +3271,7 @@ contains
         enddo lanczos
 
         if (time_lightkrylov()) call timer%stop('lanczos_bidiagonalization_rdp')
-        call logger%log_debug('end', module=this_module, procedure='lanczos_bidiagonalization_rdp')
-
+        
         return
     end subroutine lanczos_bidiagonalization_rdp
 
@@ -3368,7 +3300,6 @@ contains
         complex(sp) :: alpha, beta
         integer :: k, kdim
 
-        call logger%log_debug('start', module=this_module, procedure='lanczos_bidiagonalization_csp')
         if (time_lightkrylov()) call timer%start('lanczos_bidiagonalization_csp')
         info = 0
 
@@ -3421,8 +3352,7 @@ contains
         enddo lanczos
 
         if (time_lightkrylov()) call timer%stop('lanczos_bidiagonalization_csp')
-        call logger%log_debug('end', module=this_module, procedure='lanczos_bidiagonalization_csp')
-
+        
         return
     end subroutine lanczos_bidiagonalization_csp
 
@@ -3451,7 +3381,6 @@ contains
         complex(dp) :: alpha, beta
         integer :: k, kdim
 
-        call logger%log_debug('start', module=this_module, procedure='lanczos_bidiagonalization_cdp')
         if (time_lightkrylov()) call timer%start('lanczos_bidiagonalization_cdp')
         info = 0
 
@@ -3504,8 +3433,7 @@ contains
         enddo lanczos
 
         if (time_lightkrylov()) call timer%stop('lanczos_bidiagonalization_cdp')
-        call logger%log_debug('end', module=this_module, procedure='lanczos_bidiagonalization_cdp')
-
+        
         return
     end subroutine lanczos_bidiagonalization_cdp
 
@@ -3530,7 +3458,6 @@ contains
         real(sp) :: beta
         integer :: k, kdim
 
-        call logger%log_debug('start', module=this_module, procedure='lanczos_tridiagonalization_rsp')
         if (time_lightkrylov()) call timer%start('lanczos_tridiagonalization_rsp')
 
         ! Deal with optional args.
@@ -3561,8 +3488,7 @@ contains
         enddo lanczos
 
         if (time_lightkrylov()) call timer%stop('lanczos_tridiagonalization_rsp')
-        call logger%log_debug('end', module=this_module, procedure='lanczos_tridiagonalization_rsp')
-
+        
         return
     end subroutine lanczos_tridiagonalization_rsp
 
@@ -3603,7 +3529,6 @@ contains
         real(dp) :: beta
         integer :: k, kdim
 
-        call logger%log_debug('start', module=this_module, procedure='lanczos_tridiagonalization_rdp')
         if (time_lightkrylov()) call timer%start('lanczos_tridiagonalization_rdp')
 
         ! Deal with optional args.
@@ -3634,8 +3559,7 @@ contains
         enddo lanczos
 
         if (time_lightkrylov()) call timer%stop('lanczos_tridiagonalization_rdp')
-        call logger%log_debug('end', module=this_module, procedure='lanczos_tridiagonalization_rdp')
-
+        
         return
     end subroutine lanczos_tridiagonalization_rdp
 
@@ -3676,7 +3600,6 @@ contains
         real(sp) :: beta
         integer :: k, kdim
 
-        call logger%log_debug('start', module=this_module, procedure='lanczos_tridiagonalization_csp')
         if (time_lightkrylov()) call timer%start('lanczos_tridiagonalization_csp')
 
         ! Deal with optional args.
@@ -3707,8 +3630,7 @@ contains
         enddo lanczos
 
         if (time_lightkrylov()) call timer%stop('lanczos_tridiagonalization_csp')
-        call logger%log_debug('end', module=this_module, procedure='lanczos_tridiagonalization_csp')
-
+        
         return
     end subroutine lanczos_tridiagonalization_csp
 
@@ -3749,7 +3671,6 @@ contains
         real(dp) :: beta
         integer :: k, kdim
 
-        call logger%log_debug('start', module=this_module, procedure='lanczos_tridiagonalization_cdp')
         if (time_lightkrylov()) call timer%start('lanczos_tridiagonalization_cdp')
 
         ! Deal with optional args.
@@ -3780,8 +3701,7 @@ contains
         enddo lanczos
 
         if (time_lightkrylov()) call timer%stop('lanczos_tridiagonalization_cdp')
-        call logger%log_debug('end', module=this_module, procedure='lanczos_tridiagonalization_cdp')
-
+        
         return
     end subroutine lanczos_tridiagonalization_cdp
 

--- a/src/BaseKrylov.fypp
+++ b/src/BaseKrylov.fypp
@@ -622,11 +622,11 @@ contains
       integer :: info
 
       call logger%log_debug('start', module=this_module, procedure='orthonormalize_basis_${type[0]}$${kind}$')
-      !if (timeit()) call global_timer%start('orthonormalize_basis_${type[0]}$${kind}$')
+      !if (time_lightkrylov()) call global_timer%start('orthonormalize_basis_${type[0]}$${kind}$')
       ! internals
       call qr(X, R, info)
       call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_${type[0]}$${kind}$')
-      !if (timeit()) call global_timer%end('orthonormalize_basis_${type[0]}$${kind}$')
+      !if (time_lightkrylov()) call global_timer%end('orthonormalize_basis_${type[0]}$${kind}$')
       call logger%log_debug('end', module=this_module, procedure='orthonormalize_basis_${type[0]}$${kind}$')
       
       return
@@ -650,7 +650,7 @@ contains
       ${type}$ :: proj_coefficients(size(X))
 
       call logger%log_debug('start', module=this_module, procedure='orthogonalize_vector_against_basis_${type[0]}$${kind}$')
-      !if (timeit()) call global_timer%start('orthonormalize_vector_against_basis_${type[0]}$${kind}$')
+      !if (time_lightkrylov()) call global_timer%start('orthonormalize_vector_against_basis_${type[0]}$${kind}$')
       info = 0
 
       ! optional input argument
@@ -687,7 +687,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_vector_against_basis_${type[0]}$${kind}$')
          beta = proj_coefficients
       end if
-      !if (timeit()) call global_timer%stop('orthonormalize_vector_against_basis_${type[0]}$${kind}$')
+      !if (time_lightkrylov()) call global_timer%stop('orthonormalize_vector_against_basis_${type[0]}$${kind}$')
       call logger%log_debug('end', module=this_module, procedure='orthogonalize_vector_against_basis_${type[0]}$${kind}$')
       
       return
@@ -712,7 +712,7 @@ contains
       integer :: i
 
       call logger%log_debug('start', module=this_module, procedure='orthogonalize_basis_against_basis_${type[0]}$${kind}$')
-      !if (timeit()) call global_timer%start('orthonormalize_basis_against_basis_${type[0]}$${kind}$')
+      !if (time_lightkrylov()) call global_timer%start('orthonormalize_basis_against_basis_${type[0]}$${kind}$')
       info = 0
 
       ! optional input argument
@@ -751,7 +751,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_basis_against_basis_${type[0]}$${kind}$')
          beta = proj_coefficients
       end if
-      !if (timeit()) call global_timer%stop('orthonormalize_basis_against_basis_${type[0]}$${kind}$')
+      !if (time_lightkrylov()) call global_timer%stop('orthonormalize_basis_against_basis_${type[0]}$${kind}$')
       call logger%log_debug('end', module=this_module, procedure='orthogonalize_basis_against_basis_${type[0]}$${kind}$')
       
       return
@@ -779,7 +779,7 @@ contains
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
       call logger%log_debug('start', module=this_module, procedure='DGS_vector_against_basis_${type[0]}$${kind}$')
-      !if (timeit()) call global_timer%start('DGS_vector_against_basis_${type[0]}$${kind}$')
+      !if (time_lightkrylov()) call global_timer%start('DGS_vector_against_basis_${type[0]}$${kind}$')
       info = 0
 
       proj_coefficients = zero_${type[0]}$${kind}$; wrk = zero_${type[0]}$${kind}$
@@ -801,7 +801,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_vector_against_basis_${type[0]}$${kind}$')
          beta = proj_coefficients
       end if
-      !if (timeit()) call global_timer%stop('DGS_vector_against_basis_${type[0]}$${kind}$')
+      !if (time_lightkrylov()) call global_timer%stop('DGS_vector_against_basis_${type[0]}$${kind}$')
       call logger%log_debug('end', module=this_module, procedure='DGS_vector_against_basis_${type[0]}$${kind}$')
 
     end subroutine DGS_vector_against_basis_${type[0]}$${kind}$
@@ -828,7 +828,7 @@ contains
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
       call logger%log_debug('start', module=this_module, procedure='DGS_basis_against_basis_${type[0]}$${kind}$')
-      !if (timeit()) call global_timer%start('DGS_basis_against_basis_${type[0]}$${kind}$')
+      !if (time_lightkrylov()) call global_timer%start('DGS_basis_against_basis_${type[0]}$${kind}$')
       info = 0
 
       proj_coefficients = zero_${type[0]}$${kind}$; wrk = zero_${type[0]}$${kind}$
@@ -848,7 +848,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_basis_against_basis_${type[0]}$${kind}$')
          beta = proj_coefficients
       end if
-      !if (timeit()) call global_timer%stop('DGS_basis_against_basis_${type[0]}$${kind}$')
+      !if (time_lightkrylov()) call global_timer%stop('DGS_basis_against_basis_${type[0]}$${kind}$')
       call logger%log_debug('end', module=this_module, procedure='DGS_basis_against_basis_${type[0]}$${kind}$')
 
     end subroutine DGS_basis_against_basis_${type[0]}$${kind}$  
@@ -880,7 +880,7 @@ contains
         ! Deals with the optional args.
         tolerance = optval(tol, atol_${kind}$)
 
-      	!if (timeit()) call global_timer%start('qr_no_pivoting_${type[0]}$${kind}$')
+      	!if (time_lightkrylov()) call global_timer%start('qr_no_pivoting_${type[0]}$${kind}$')
         call logger%log_debug('start', module=this_module, procedure='qr_no_pivoting_${type[0]}$${kind}$')
         info = 0 ; flag = .false.; R = zero_r${kind}$ ; beta = zero_r${kind}$
         do j = 1, size(Q)
@@ -912,7 +912,7 @@ contains
             ! Normalize column.
             call Q(j)%scal(one_r${kind}$ / beta)
         enddo
-      	!if (timeit()) call global_timer%stop('qr_no_pivoting_${type[0]}$${kind}$')
+      	!if (time_lightkrylov()) call global_timer%stop('qr_no_pivoting_${type[0]}$${kind}$')
         call logger%log_debug('end', module=this_module, procedure='qr_no_pivoting_${type[0]}$${kind}$')
 
         return
@@ -940,7 +940,7 @@ contains
         character(len=128) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='qr_with_pivoting_${type[0]}$${kind}$')
-      	!if (timeit()) call global_timer%start('qr_with_pivoting_${type[0]}$${kind}$')
+      	!if (time_lightkrylov()) call global_timer%start('qr_with_pivoting_${type[0]}$${kind}$')
         info = 0 ; kdim = size(Q)
         R = zero_r${kind}$ ; Rii = zero_r${kind}$
         
@@ -999,7 +999,7 @@ contains
             enddo
 
         enddo qr_step
-      	!if (timeit()) call global_timer%stop('qr_with_pivoting_${type[0]}$${kind}$')
+      	!if (time_lightkrylov()) call global_timer%stop('qr_with_pivoting_${type[0]}$${kind}$')
         call logger%log_debug('end', module=this_module, procedure='qr_with_pivoting_${type[0]}$${kind}$')
 
         return

--- a/src/BaseKrylov.fypp
+++ b/src/BaseKrylov.fypp
@@ -621,13 +621,11 @@ contains
       ${type}$ :: R(size(X),size(X))
       integer :: info
 
-      call logger%log_debug('start', module=this_module, procedure='orthonormalize_basis_${type[0]}$${kind}$')
       if (time_lightkrylov()) call timer%start('orthonormalize_basis_${type[0]}$${kind}$')
       ! internals
       call qr(X, R, info)
       call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_${type[0]}$${kind}$')
       if (time_lightkrylov()) call timer%stop('orthonormalize_basis_${type[0]}$${kind}$')
-      call logger%log_debug('end', module=this_module, procedure='orthonormalize_basis_${type[0]}$${kind}$')
       
       return
     end subroutine orthonormalize_basis_${type[0]}$${kind}$
@@ -649,7 +647,6 @@ contains
       ! internals
       ${type}$ :: proj_coefficients(size(X))
 
-      call logger%log_debug('start', module=this_module, procedure='orthogonalize_vector_against_basis_${type[0]}$${kind}$')
       if (time_lightkrylov()) call timer%start('orthonormalize_vector_against_basis_${type[0]}$${kind}$')
       info = 0
 
@@ -688,7 +685,6 @@ contains
          beta = proj_coefficients
       end if
       if (time_lightkrylov()) call timer%stop('orthonormalize_vector_against_basis_${type[0]}$${kind}$')
-      call logger%log_debug('end', module=this_module, procedure='orthogonalize_vector_against_basis_${type[0]}$${kind}$')
       
       return
     end subroutine orthogonalize_vector_against_basis_${type[0]}$${kind}$
@@ -711,7 +707,6 @@ contains
       ${type}$ :: proj_coefficients(size(X), size(Y))
       integer :: i
 
-      call logger%log_debug('start', module=this_module, procedure='orthogonalize_basis_against_basis_${type[0]}$${kind}$')
       if (time_lightkrylov()) call timer%start('orthonormalize_basis_against_basis_${type[0]}$${kind}$')
       info = 0
 
@@ -752,7 +747,6 @@ contains
          beta = proj_coefficients
       end if
       if (time_lightkrylov()) call timer%stop('orthonormalize_basis_against_basis_${type[0]}$${kind}$')
-      call logger%log_debug('end', module=this_module, procedure='orthogonalize_basis_against_basis_${type[0]}$${kind}$')
       
       return
     end subroutine orthogonalize_basis_against_basis_${type[0]}$${kind}$
@@ -778,7 +772,6 @@ contains
       ! optional input argument
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
-      call logger%log_debug('start', module=this_module, procedure='DGS_vector_against_basis_${type[0]}$${kind}$')
       if (time_lightkrylov()) call timer%start('DGS_vector_against_basis_${type[0]}$${kind}$')
       info = 0
 
@@ -802,8 +795,7 @@ contains
          beta = proj_coefficients
       end if
       if (time_lightkrylov()) call timer%stop('DGS_vector_against_basis_${type[0]}$${kind}$')
-      call logger%log_debug('end', module=this_module, procedure='DGS_vector_against_basis_${type[0]}$${kind}$')
-
+      
     end subroutine DGS_vector_against_basis_${type[0]}$${kind}$
 
     subroutine DGS_basis_against_basis_${type[0]}$${kind}$(y, X, info, if_chk_orthonormal, beta)
@@ -827,7 +819,6 @@ contains
       ! optional input argument
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
-      call logger%log_debug('start', module=this_module, procedure='DGS_basis_against_basis_${type[0]}$${kind}$')
       if (time_lightkrylov()) call timer%start('DGS_basis_against_basis_${type[0]}$${kind}$')
       info = 0
 
@@ -849,8 +840,7 @@ contains
          beta = proj_coefficients
       end if
       if (time_lightkrylov()) call timer%stop('DGS_basis_against_basis_${type[0]}$${kind}$')
-      call logger%log_debug('end', module=this_module, procedure='DGS_basis_against_basis_${type[0]}$${kind}$')
-
+      
     end subroutine DGS_basis_against_basis_${type[0]}$${kind}$  
 
     #:endfor
@@ -881,7 +871,6 @@ contains
         tolerance = optval(tol, atol_${kind}$)
 
       	if (time_lightkrylov()) call timer%start('qr_no_pivoting_${type[0]}$${kind}$')
-        call logger%log_debug('start', module=this_module, procedure='qr_no_pivoting_${type[0]}$${kind}$')
         info = 0 ; flag = .false.; R = zero_r${kind}$ ; beta = zero_r${kind}$
         do j = 1, size(Q)
             if (j > 1) then
@@ -913,8 +902,7 @@ contains
             call Q(j)%scal(one_r${kind}$ / beta)
         enddo
       	if (time_lightkrylov()) call timer%stop('qr_no_pivoting_${type[0]}$${kind}$')
-        call logger%log_debug('end', module=this_module, procedure='qr_no_pivoting_${type[0]}$${kind}$')
-
+        
         return
     end subroutine qr_no_pivoting_${type[0]}$${kind}$
 
@@ -939,8 +927,7 @@ contains
         ${type}$  :: Rii(size(Q))
         character(len=128) :: msg
 
-        call logger%log_debug('start', module=this_module, procedure='qr_with_pivoting_${type[0]}$${kind}$')
-      	if (time_lightkrylov()) call timer%start('qr_with_pivoting_${type[0]}$${kind}$')
+        if (time_lightkrylov()) call timer%start('qr_with_pivoting_${type[0]}$${kind}$')
         info = 0 ; kdim = size(Q)
         R = zero_r${kind}$ ; Rii = zero_r${kind}$
         
@@ -1000,8 +987,7 @@ contains
 
         enddo qr_step
       	if (time_lightkrylov()) call timer%stop('qr_with_pivoting_${type[0]}$${kind}$')
-        call logger%log_debug('end', module=this_module, procedure='qr_with_pivoting_${type[0]}$${kind}$')
-
+        
         return
     end subroutine qr_with_pivoting_${type[0]}$${kind}$
 
@@ -1169,7 +1155,6 @@ contains
         integer, allocatable :: perm(:)
         integer :: k, i, kdim, kpm, kp, kpp
 
-        call logger%log_debug('start', module=this_module, procedure='arnoldi_${type[0]}$${kind}$')
         if (time_lightkrylov()) call timer%start('arnoldi_${type[0]}$${kind}$')
 
         ! Deals with optional non-unity blksize and allocations.
@@ -1226,8 +1211,7 @@ contains
         enddo blk_arnoldi
 
         if (time_lightkrylov()) call timer%stop('arnoldi_${type[0]}$${kind}$')
-        call logger%log_debug('end', module=this_module, procedure='arnoldi_${type[0]}$${kind}$')
-
+        
         return
     end subroutine arnoldi_${type[0]}$${kind}$
 
@@ -1264,7 +1248,6 @@ contains
         ${type}$ :: alpha, beta
         integer :: k, kdim
 
-        call logger%log_debug('start', module=this_module, procedure='lanczos_bidiagonalization_${type[0]}$${kind}$')
         if (time_lightkrylov()) call timer%start('lanczos_bidiagonalization_${type[0]}$${kind}$')
         info = 0
 
@@ -1317,8 +1300,7 @@ contains
         enddo lanczos
 
         if (time_lightkrylov()) call timer%stop('lanczos_bidiagonalization_${type[0]}$${kind}$')
-        call logger%log_debug('end', module=this_module, procedure='lanczos_bidiagonalization_${type[0]}$${kind}$')
-
+        
         return
     end subroutine lanczos_bidiagonalization_${type[0]}$${kind}$
 
@@ -1349,7 +1331,6 @@ contains
         real(${kind}$) :: beta
         integer :: k, kdim
 
-        call logger%log_debug('start', module=this_module, procedure='lanczos_tridiagonalization_${type[0]}$${kind}$')
         if (time_lightkrylov()) call timer%start('lanczos_tridiagonalization_${type[0]}$${kind}$')
 
         ! Deal with optional args.
@@ -1380,8 +1361,7 @@ contains
         enddo lanczos
 
         if (time_lightkrylov()) call timer%stop('lanczos_tridiagonalization_${type[0]}$${kind}$')
-        call logger%log_debug('end', module=this_module, procedure='lanczos_tridiagonalization_${type[0]}$${kind}$')
-
+        
         return
     end subroutine lanczos_tridiagonalization_${type[0]}$${kind}$
 

--- a/src/BaseKrylov.fypp
+++ b/src/BaseKrylov.fypp
@@ -23,6 +23,7 @@ module lightkrylov_BaseKrylov
     !-------------------------------
     use LightKrylov_Constants
     use LightKrylov_Logger
+    !use LightKrylov_Timer
     use LightKrylov_Utils
     use LightKrylov_AbstractVectors
     use LightKrylov_AbstractLinops
@@ -621,9 +622,11 @@ contains
       integer :: info
 
       call logger%log_debug('start', module=this_module, procedure='orthonormalize_basis_${type[0]}$${kind}$')
+      !if (timeit()) call global_timer%start('orthonormalize_basis_${type[0]}$${kind}$')
       ! internals
       call qr(X, R, info)
       call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_${type[0]}$${kind}$')
+      !if (timeit()) call global_timer%end('orthonormalize_basis_${type[0]}$${kind}$')
       call logger%log_debug('end', module=this_module, procedure='orthonormalize_basis_${type[0]}$${kind}$')
       
       return
@@ -647,6 +650,7 @@ contains
       ${type}$ :: proj_coefficients(size(X))
 
       call logger%log_debug('start', module=this_module, procedure='orthogonalize_vector_against_basis_${type[0]}$${kind}$')
+      !if (timeit()) call global_timer%start('orthonormalize_vector_against_basis_${type[0]}$${kind}$')
       info = 0
 
       ! optional input argument
@@ -683,6 +687,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_vector_against_basis_${type[0]}$${kind}$')
          beta = proj_coefficients
       end if
+      !if (timeit()) call global_timer%stop('orthonormalize_vector_against_basis_${type[0]}$${kind}$')
       call logger%log_debug('end', module=this_module, procedure='orthogonalize_vector_against_basis_${type[0]}$${kind}$')
       
       return
@@ -707,6 +712,7 @@ contains
       integer :: i
 
       call logger%log_debug('start', module=this_module, procedure='orthogonalize_basis_against_basis_${type[0]}$${kind}$')
+      !if (timeit()) call global_timer%start('orthonormalize_basis_against_basis_${type[0]}$${kind}$')
       info = 0
 
       ! optional input argument
@@ -745,6 +751,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_basis_against_basis_${type[0]}$${kind}$')
          beta = proj_coefficients
       end if
+      !if (timeit()) call global_timer%stop('orthonormalize_basis_against_basis_${type[0]}$${kind}$')
       call logger%log_debug('end', module=this_module, procedure='orthogonalize_basis_against_basis_${type[0]}$${kind}$')
       
       return
@@ -772,6 +779,7 @@ contains
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
       call logger%log_debug('start', module=this_module, procedure='DGS_vector_against_basis_${type[0]}$${kind}$')
+      !if (timeit()) call global_timer%start('DGS_vector_against_basis_${type[0]}$${kind}$')
       info = 0
 
       proj_coefficients = zero_${type[0]}$${kind}$; wrk = zero_${type[0]}$${kind}$
@@ -793,6 +801,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_vector_against_basis_${type[0]}$${kind}$')
          beta = proj_coefficients
       end if
+      !if (timeit()) call global_timer%stop('DGS_vector_against_basis_${type[0]}$${kind}$')
       call logger%log_debug('end', module=this_module, procedure='DGS_vector_against_basis_${type[0]}$${kind}$')
 
     end subroutine DGS_vector_against_basis_${type[0]}$${kind}$
@@ -819,6 +828,7 @@ contains
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
       call logger%log_debug('start', module=this_module, procedure='DGS_basis_against_basis_${type[0]}$${kind}$')
+      !if (timeit()) call global_timer%start('DGS_basis_against_basis_${type[0]}$${kind}$')
       info = 0
 
       proj_coefficients = zero_${type[0]}$${kind}$; wrk = zero_${type[0]}$${kind}$
@@ -838,6 +848,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_basis_against_basis_${type[0]}$${kind}$')
          beta = proj_coefficients
       end if
+      !if (timeit()) call global_timer%stop('DGS_basis_against_basis_${type[0]}$${kind}$')
       call logger%log_debug('end', module=this_module, procedure='DGS_basis_against_basis_${type[0]}$${kind}$')
 
     end subroutine DGS_basis_against_basis_${type[0]}$${kind}$  
@@ -869,6 +880,7 @@ contains
         ! Deals with the optional args.
         tolerance = optval(tol, atol_${kind}$)
 
+      	!if (timeit()) call global_timer%start('qr_no_pivoting_${type[0]}$${kind}$')
         call logger%log_debug('start', module=this_module, procedure='qr_no_pivoting_${type[0]}$${kind}$')
         info = 0 ; flag = .false.; R = zero_r${kind}$ ; beta = zero_r${kind}$
         do j = 1, size(Q)
@@ -900,6 +912,7 @@ contains
             ! Normalize column.
             call Q(j)%scal(one_r${kind}$ / beta)
         enddo
+      	!if (timeit()) call global_timer%stop('qr_no_pivoting_${type[0]}$${kind}$')
         call logger%log_debug('end', module=this_module, procedure='qr_no_pivoting_${type[0]}$${kind}$')
 
         return
@@ -927,6 +940,7 @@ contains
         character(len=128) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='qr_with_pivoting_${type[0]}$${kind}$')
+      	!if (timeit()) call global_timer%start('qr_with_pivoting_${type[0]}$${kind}$')
         info = 0 ; kdim = size(Q)
         R = zero_r${kind}$ ; Rii = zero_r${kind}$
         
@@ -985,6 +999,7 @@ contains
             enddo
 
         enddo qr_step
+      	!if (timeit()) call global_timer%stop('qr_with_pivoting_${type[0]}$${kind}$')
         call logger%log_debug('end', module=this_module, procedure='qr_with_pivoting_${type[0]}$${kind}$')
 
         return

--- a/src/BaseKrylov.fypp
+++ b/src/BaseKrylov.fypp
@@ -23,7 +23,7 @@ module lightkrylov_BaseKrylov
     !-------------------------------
     use LightKrylov_Constants
     use LightKrylov_Logger
-    !use LightKrylov_Timer
+    use LightKrylov_Timing, only: timer => global_lightkrylov_timer, time_lightkrylov
     use LightKrylov_Utils
     use LightKrylov_AbstractVectors
     use LightKrylov_AbstractLinops
@@ -622,11 +622,11 @@ contains
       integer :: info
 
       call logger%log_debug('start', module=this_module, procedure='orthonormalize_basis_${type[0]}$${kind}$')
-      !if (time_lightkrylov()) call global_timer%start('orthonormalize_basis_${type[0]}$${kind}$')
+      if (time_lightkrylov()) call timer%start('orthonormalize_basis_${type[0]}$${kind}$')
       ! internals
       call qr(X, R, info)
       call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_${type[0]}$${kind}$')
-      !if (time_lightkrylov()) call global_timer%end('orthonormalize_basis_${type[0]}$${kind}$')
+      if (time_lightkrylov()) call timer%stop('orthonormalize_basis_${type[0]}$${kind}$')
       call logger%log_debug('end', module=this_module, procedure='orthonormalize_basis_${type[0]}$${kind}$')
       
       return
@@ -650,7 +650,7 @@ contains
       ${type}$ :: proj_coefficients(size(X))
 
       call logger%log_debug('start', module=this_module, procedure='orthogonalize_vector_against_basis_${type[0]}$${kind}$')
-      !if (time_lightkrylov()) call global_timer%start('orthonormalize_vector_against_basis_${type[0]}$${kind}$')
+      if (time_lightkrylov()) call timer%start('orthonormalize_vector_against_basis_${type[0]}$${kind}$')
       info = 0
 
       ! optional input argument
@@ -687,7 +687,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_vector_against_basis_${type[0]}$${kind}$')
          beta = proj_coefficients
       end if
-      !if (time_lightkrylov()) call global_timer%stop('orthonormalize_vector_against_basis_${type[0]}$${kind}$')
+      if (time_lightkrylov()) call timer%stop('orthonormalize_vector_against_basis_${type[0]}$${kind}$')
       call logger%log_debug('end', module=this_module, procedure='orthogonalize_vector_against_basis_${type[0]}$${kind}$')
       
       return
@@ -712,7 +712,7 @@ contains
       integer :: i
 
       call logger%log_debug('start', module=this_module, procedure='orthogonalize_basis_against_basis_${type[0]}$${kind}$')
-      !if (time_lightkrylov()) call global_timer%start('orthonormalize_basis_against_basis_${type[0]}$${kind}$')
+      if (time_lightkrylov()) call timer%start('orthonormalize_basis_against_basis_${type[0]}$${kind}$')
       info = 0
 
       ! optional input argument
@@ -751,7 +751,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_basis_against_basis_${type[0]}$${kind}$')
          beta = proj_coefficients
       end if
-      !if (time_lightkrylov()) call global_timer%stop('orthonormalize_basis_against_basis_${type[0]}$${kind}$')
+      if (time_lightkrylov()) call timer%stop('orthonormalize_basis_against_basis_${type[0]}$${kind}$')
       call logger%log_debug('end', module=this_module, procedure='orthogonalize_basis_against_basis_${type[0]}$${kind}$')
       
       return
@@ -779,7 +779,7 @@ contains
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
       call logger%log_debug('start', module=this_module, procedure='DGS_vector_against_basis_${type[0]}$${kind}$')
-      !if (time_lightkrylov()) call global_timer%start('DGS_vector_against_basis_${type[0]}$${kind}$')
+      if (time_lightkrylov()) call timer%start('DGS_vector_against_basis_${type[0]}$${kind}$')
       info = 0
 
       proj_coefficients = zero_${type[0]}$${kind}$; wrk = zero_${type[0]}$${kind}$
@@ -801,7 +801,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_vector_against_basis_${type[0]}$${kind}$')
          beta = proj_coefficients
       end if
-      !if (time_lightkrylov()) call global_timer%stop('DGS_vector_against_basis_${type[0]}$${kind}$')
+      if (time_lightkrylov()) call timer%stop('DGS_vector_against_basis_${type[0]}$${kind}$')
       call logger%log_debug('end', module=this_module, procedure='DGS_vector_against_basis_${type[0]}$${kind}$')
 
     end subroutine DGS_vector_against_basis_${type[0]}$${kind}$
@@ -828,7 +828,7 @@ contains
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
       call logger%log_debug('start', module=this_module, procedure='DGS_basis_against_basis_${type[0]}$${kind}$')
-      !if (time_lightkrylov()) call global_timer%start('DGS_basis_against_basis_${type[0]}$${kind}$')
+      if (time_lightkrylov()) call timer%start('DGS_basis_against_basis_${type[0]}$${kind}$')
       info = 0
 
       proj_coefficients = zero_${type[0]}$${kind}$; wrk = zero_${type[0]}$${kind}$
@@ -848,7 +848,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_basis_against_basis_${type[0]}$${kind}$')
          beta = proj_coefficients
       end if
-      !if (time_lightkrylov()) call global_timer%stop('DGS_basis_against_basis_${type[0]}$${kind}$')
+      if (time_lightkrylov()) call timer%stop('DGS_basis_against_basis_${type[0]}$${kind}$')
       call logger%log_debug('end', module=this_module, procedure='DGS_basis_against_basis_${type[0]}$${kind}$')
 
     end subroutine DGS_basis_against_basis_${type[0]}$${kind}$  
@@ -880,7 +880,7 @@ contains
         ! Deals with the optional args.
         tolerance = optval(tol, atol_${kind}$)
 
-      	!if (time_lightkrylov()) call global_timer%start('qr_no_pivoting_${type[0]}$${kind}$')
+      	if (time_lightkrylov()) call timer%start('qr_no_pivoting_${type[0]}$${kind}$')
         call logger%log_debug('start', module=this_module, procedure='qr_no_pivoting_${type[0]}$${kind}$')
         info = 0 ; flag = .false.; R = zero_r${kind}$ ; beta = zero_r${kind}$
         do j = 1, size(Q)
@@ -912,7 +912,7 @@ contains
             ! Normalize column.
             call Q(j)%scal(one_r${kind}$ / beta)
         enddo
-      	!if (time_lightkrylov()) call global_timer%stop('qr_no_pivoting_${type[0]}$${kind}$')
+      	if (time_lightkrylov()) call timer%stop('qr_no_pivoting_${type[0]}$${kind}$')
         call logger%log_debug('end', module=this_module, procedure='qr_no_pivoting_${type[0]}$${kind}$')
 
         return
@@ -940,7 +940,7 @@ contains
         character(len=128) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='qr_with_pivoting_${type[0]}$${kind}$')
-      	!if (time_lightkrylov()) call global_timer%start('qr_with_pivoting_${type[0]}$${kind}$')
+      	if (time_lightkrylov()) call timer%start('qr_with_pivoting_${type[0]}$${kind}$')
         info = 0 ; kdim = size(Q)
         R = zero_r${kind}$ ; Rii = zero_r${kind}$
         
@@ -999,7 +999,7 @@ contains
             enddo
 
         enddo qr_step
-      	!if (time_lightkrylov()) call global_timer%stop('qr_with_pivoting_${type[0]}$${kind}$')
+      	if (time_lightkrylov()) call timer%stop('qr_with_pivoting_${type[0]}$${kind}$')
         call logger%log_debug('end', module=this_module, procedure='qr_with_pivoting_${type[0]}$${kind}$')
 
         return
@@ -1169,6 +1169,9 @@ contains
         integer, allocatable :: perm(:)
         integer :: k, i, kdim, kpm, kp, kpp
 
+        call logger%log_debug('start', module=this_module, procedure='arnoldi_${type[0]}$${kind}$')
+        if (time_lightkrylov()) call timer%start('arnoldi_${type[0]}$${kind}$')
+
         ! Deals with optional non-unity blksize and allocations.
         p = optval(blksize, 1) ; allocate(res(p)) ; res = zero_r${kind}$
         allocate(perm(size(H, 2))) ; perm = 0 ; info = 0
@@ -1222,6 +1225,9 @@ contains
 
         enddo blk_arnoldi
 
+        if (time_lightkrylov()) call timer%stop('arnoldi_${type[0]}$${kind}$')
+        call logger%log_debug('end', module=this_module, procedure='arnoldi_${type[0]}$${kind}$')
+
         return
     end subroutine arnoldi_${type[0]}$${kind}$
 
@@ -1258,6 +1264,8 @@ contains
         ${type}$ :: alpha, beta
         integer :: k, kdim
 
+        call logger%log_debug('start', module=this_module, procedure='lanczos_bidiagonalization_${type[0]}$${kind}$')
+        if (time_lightkrylov()) call timer%start('lanczos_bidiagonalization_${type[0]}$${kind}$')
         info = 0
 
         ! Krylov subspace dimension.
@@ -1308,6 +1316,9 @@ contains
 
         enddo lanczos
 
+        if (time_lightkrylov()) call timer%stop('lanczos_bidiagonalization_${type[0]}$${kind}$')
+        call logger%log_debug('end', module=this_module, procedure='lanczos_bidiagonalization_${type[0]}$${kind}$')
+
         return
     end subroutine lanczos_bidiagonalization_${type[0]}$${kind}$
 
@@ -1338,6 +1349,9 @@ contains
         real(${kind}$) :: beta
         integer :: k, kdim
 
+        call logger%log_debug('start', module=this_module, procedure='lanczos_tridiagonalization_${type[0]}$${kind}$')
+        if (time_lightkrylov()) call timer%start('lanczos_tridiagonalization_${type[0]}$${kind}$')
+
         ! Deal with optional args.
         kdim = size(X) - 1
         k_start = optval(kstart, 1)
@@ -1364,6 +1378,9 @@ contains
                 call X(k+1)%scal(one_${type[0]}$${kind}$ / beta)
             endif
         enddo lanczos
+
+        if (time_lightkrylov()) call timer%stop('lanczos_tridiagonalization_${type[0]}$${kind}$')
+        call logger%log_debug('end', module=this_module, procedure='lanczos_tridiagonalization_${type[0]}$${kind}$')
 
         return
     end subroutine lanczos_tridiagonalization_${type[0]}$${kind}$

--- a/src/BaseKrylov.fypp
+++ b/src/BaseKrylov.fypp
@@ -620,9 +620,11 @@ contains
       ${type}$ :: R(size(X),size(X))
       integer :: info
 
+      call logger%log_debug('start', module=this_module, procedure='orthonormalize_basis_${type[0]}$${kind}$')
       ! internals
       call qr(X, R, info)
       call check_info(info, 'qr', module=this_module, procedure='orthonormalize_basis_${type[0]}$${kind}$')
+      call logger%log_debug('end', module=this_module, procedure='orthonormalize_basis_${type[0]}$${kind}$')
       
       return
     end subroutine orthonormalize_basis_${type[0]}$${kind}$
@@ -644,6 +646,7 @@ contains
       ! internals
       ${type}$ :: proj_coefficients(size(X))
 
+      call logger%log_debug('start', module=this_module, procedure='orthogonalize_vector_against_basis_${type[0]}$${kind}$')
       info = 0
 
       ! optional input argument
@@ -680,6 +683,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_vector_against_basis_${type[0]}$${kind}$')
          beta = proj_coefficients
       end if
+      call logger%log_debug('end', module=this_module, procedure='orthogonalize_vector_against_basis_${type[0]}$${kind}$')
       
       return
     end subroutine orthogonalize_vector_against_basis_${type[0]}$${kind}$
@@ -702,6 +706,7 @@ contains
       ${type}$ :: proj_coefficients(size(X), size(Y))
       integer :: i
 
+      call logger%log_debug('start', module=this_module, procedure='orthogonalize_basis_against_basis_${type[0]}$${kind}$')
       info = 0
 
       ! optional input argument
@@ -740,6 +745,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'orthogonalize_basis_against_basis_${type[0]}$${kind}$')
          beta = proj_coefficients
       end if
+      call logger%log_debug('end', module=this_module, procedure='orthogonalize_basis_against_basis_${type[0]}$${kind}$')
       
       return
     end subroutine orthogonalize_basis_against_basis_${type[0]}$${kind}$
@@ -765,6 +771,7 @@ contains
       ! optional input argument
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
+      call logger%log_debug('start', module=this_module, procedure='DGS_vector_against_basis_${type[0]}$${kind}$')
       info = 0
 
       proj_coefficients = zero_${type[0]}$${kind}$; wrk = zero_${type[0]}$${kind}$
@@ -786,6 +793,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_vector_against_basis_${type[0]}$${kind}$')
          beta = proj_coefficients
       end if
+      call logger%log_debug('end', module=this_module, procedure='DGS_vector_against_basis_${type[0]}$${kind}$')
 
     end subroutine DGS_vector_against_basis_${type[0]}$${kind}$
 
@@ -810,6 +818,7 @@ contains
       ! optional input argument
       chk_X_orthonormality = optval(if_chk_orthonormal, .true.) ! default to true!
 
+      call logger%log_debug('start', module=this_module, procedure='DGS_basis_against_basis_${type[0]}$${kind}$')
       info = 0
 
       proj_coefficients = zero_${type[0]}$${kind}$; wrk = zero_${type[0]}$${kind}$
@@ -829,6 +838,7 @@ contains
          call assert_shape(beta, shape(proj_coefficients), 'beta', this_module, 'DGS_basis_against_basis_${type[0]}$${kind}$')
          beta = proj_coefficients
       end if
+      call logger%log_debug('end', module=this_module, procedure='DGS_basis_against_basis_${type[0]}$${kind}$')
 
     end subroutine DGS_basis_against_basis_${type[0]}$${kind}$  
 
@@ -859,6 +869,7 @@ contains
         ! Deals with the optional args.
         tolerance = optval(tol, atol_${kind}$)
 
+        call logger%log_debug('start', module=this_module, procedure='qr_no_pivoting_${type[0]}$${kind}$')
         info = 0 ; flag = .false.; R = zero_r${kind}$ ; beta = zero_r${kind}$
         do j = 1, size(Q)
             if (j > 1) then
@@ -889,6 +900,7 @@ contains
             ! Normalize column.
             call Q(j)%scal(one_r${kind}$ / beta)
         enddo
+        call logger%log_debug('end', module=this_module, procedure='qr_no_pivoting_${type[0]}$${kind}$')
 
         return
     end subroutine qr_no_pivoting_${type[0]}$${kind}$
@@ -914,6 +926,7 @@ contains
         ${type}$  :: Rii(size(Q))
         character(len=128) :: msg
 
+        call logger%log_debug('start', module=this_module, procedure='qr_with_pivoting_${type[0]}$${kind}$')
         info = 0 ; kdim = size(Q)
         R = zero_r${kind}$ ; Rii = zero_r${kind}$
         
@@ -972,6 +985,7 @@ contains
             enddo
 
         enddo qr_step
+        call logger%log_debug('end', module=this_module, procedure='qr_with_pivoting_${type[0]}$${kind}$')
 
         return
     end subroutine qr_with_pivoting_${type[0]}$${kind}$

--- a/src/ExpmLib.f90
+++ b/src/ExpmLib.f90
@@ -20,8 +20,8 @@ module lightkrylov_expmlib
     implicit none
     private
     
-    character(len=*), parameter, private :: this_module      = 'LK_ExpmLib'
-    character(len=*), parameter, private :: this_module_long = 'LightKrylov_ExpmLib'
+    character(len=*), parameter :: this_module      = 'LK_ExpmLib'
+    character(len=*), parameter :: this_module_long = 'LightKrylov_ExpmLib'
 
     public :: abstract_exptA_rsp
     public :: abstract_exptA_rdp

--- a/src/ExpmLib.fypp
+++ b/src/ExpmLib.fypp
@@ -22,8 +22,8 @@ module lightkrylov_expmlib
     implicit none
     private
     
-    character(len=*), parameter, private :: this_module      = 'LK_ExpmLib'
-    character(len=*), parameter, private :: this_module_long = 'LightKrylov_ExpmLib'
+    character(len=*), parameter :: this_module      = 'LK_ExpmLib'
+    character(len=*), parameter :: this_module_long = 'LightKrylov_ExpmLib'
 
     #:for kind, type in RC_KINDS_TYPES
     public :: abstract_exptA_${type[0]}$${kind}$

--- a/src/IterativeSolvers.f90
+++ b/src/IterativeSolvers.f90
@@ -820,7 +820,6 @@ contains
         ! Eigenvalue selection.
         procedure(eigvals_select_sp), pointer :: select_
 
-        call logger%log_debug('start', module=this_module, procedure='eigs_rsp')
         if (time_lightkrylov()) call timer%start('eigs_rsp')
         ! Deals with optional parameters.
         nev = size(X)
@@ -924,8 +923,7 @@ contains
 
         info = niter
         if (time_lightkrylov()) call timer%stop('eigs_rsp')
-        call logger%log_debug('end', module=this_module, procedure='eigs_rsp')
-
+        
         return
     end subroutine eigs_rsp
 
@@ -973,7 +971,6 @@ contains
         ! Eigenvalue selection.
         procedure(eigvals_select_dp), pointer :: select_
 
-        call logger%log_debug('start', module=this_module, procedure='eigs_rdp')
         if (time_lightkrylov()) call timer%start('eigs_rdp')
         ! Deals with optional parameters.
         nev = size(X)
@@ -1077,8 +1074,7 @@ contains
 
         info = niter
         if (time_lightkrylov()) call timer%stop('eigs_rdp')
-        call logger%log_debug('end', module=this_module, procedure='eigs_rdp')
-
+        
         return
     end subroutine eigs_rdp
 
@@ -1125,7 +1121,6 @@ contains
         ! Eigenvalue selection.
         procedure(eigvals_select_sp), pointer :: select_
 
-        call logger%log_debug('start', module=this_module, procedure='eigs_csp')
         if (time_lightkrylov()) call timer%start('eigs_csp')
         ! Deals with optional parameters.
         nev = size(X)
@@ -1220,8 +1215,7 @@ contains
 
         info = niter
         if (time_lightkrylov()) call timer%stop('eigs_csp')
-        call logger%log_debug('end', module=this_module, procedure='eigs_csp')
-
+        
         return
     end subroutine eigs_csp
 
@@ -1268,7 +1262,6 @@ contains
         ! Eigenvalue selection.
         procedure(eigvals_select_dp), pointer :: select_
 
-        call logger%log_debug('start', module=this_module, procedure='eigs_cdp')
         if (time_lightkrylov()) call timer%start('eigs_cdp')
         ! Deals with optional parameters.
         nev = size(X)
@@ -1363,8 +1356,7 @@ contains
 
         info = niter
         if (time_lightkrylov()) call timer%stop('eigs_cdp')
-        call logger%log_debug('end', module=this_module, procedure='eigs_cdp')
-
+        
         return
     end subroutine eigs_cdp
 
@@ -1415,7 +1407,6 @@ contains
         real(sp) :: beta
         character(len=256) :: msg
 
-        call logger%log_debug('start', module=this_module, procedure='eighs_rsp')
         if (time_lightkrylov()) call timer%start('eighs_rsp')
         ! Deaks with the optional args.
         nev = size(X)
@@ -1481,8 +1472,7 @@ contains
         
         info = k
         if (time_lightkrylov()) call timer%stop('eighs_rsp')
-        call logger%log_debug('end', module=this_module, procedure='eighs_rsp')
-
+        
         return
     end subroutine eighs_rsp
 
@@ -1528,7 +1518,6 @@ contains
         real(dp) :: beta
         character(len=256) :: msg
 
-        call logger%log_debug('start', module=this_module, procedure='eighs_rdp')
         if (time_lightkrylov()) call timer%start('eighs_rdp')
         ! Deaks with the optional args.
         nev = size(X)
@@ -1594,8 +1583,7 @@ contains
         
         info = k
         if (time_lightkrylov()) call timer%stop('eighs_rdp')
-        call logger%log_debug('end', module=this_module, procedure='eighs_rdp')
-
+        
         return
     end subroutine eighs_rdp
 
@@ -1641,7 +1629,6 @@ contains
         complex(sp) :: beta
         character(len=256) :: msg
 
-        call logger%log_debug('start', module=this_module, procedure='eighs_csp')
         if (time_lightkrylov()) call timer%start('eighs_csp')
         ! Deaks with the optional args.
         nev = size(X)
@@ -1707,8 +1694,7 @@ contains
         
         info = k
         if (time_lightkrylov()) call timer%stop('eighs_csp')
-        call logger%log_debug('end', module=this_module, procedure='eighs_csp')
-
+        
         return
     end subroutine eighs_csp
 
@@ -1754,7 +1740,6 @@ contains
         complex(dp) :: beta
         character(len=256) :: msg
 
-        call logger%log_debug('start', module=this_module, procedure='eighs_cdp')
         if (time_lightkrylov()) call timer%start('eighs_cdp')
         ! Deaks with the optional args.
         nev = size(X)
@@ -1820,8 +1805,7 @@ contains
         
         info = k
         if (time_lightkrylov()) call timer%stop('eighs_cdp')
-        call logger%log_debug('end', module=this_module, procedure='eighs_cdp')
-
+        
         return
     end subroutine eighs_cdp
 
@@ -1867,7 +1851,6 @@ contains
         real(sp) :: tol, u0_norm
         character(len=256) :: msg
 
-        call logger%log_debug('start', module=this_module, procedure='svds_rsp')
         if (time_lightkrylov()) call timer%start('svds_rsp')
         ! Deals with the optional arguments.
         nsv = size(U)
@@ -1930,8 +1913,7 @@ contains
             enddo
         enddo
         if (time_lightkrylov()) call timer%stop('svds_rsp')
-        call logger%log_debug('end', module=this_module, procedure='svds_rsp')
-
+        
         return
     end subroutine svds_rsp
 
@@ -1972,7 +1954,6 @@ contains
         real(dp) :: tol, u0_norm
         character(len=256) :: msg
 
-        call logger%log_debug('start', module=this_module, procedure='svds_rdp')
         if (time_lightkrylov()) call timer%start('svds_rdp')
         ! Deals with the optional arguments.
         nsv = size(U)
@@ -2035,8 +2016,7 @@ contains
             enddo
         enddo
         if (time_lightkrylov()) call timer%stop('svds_rdp')
-        call logger%log_debug('end', module=this_module, procedure='svds_rdp')
-
+        
         return
     end subroutine svds_rdp
 
@@ -2077,7 +2057,6 @@ contains
         real(sp) :: tol, u0_norm
         character(len=256) :: msg
 
-        call logger%log_debug('start', module=this_module, procedure='svds_csp')
         if (time_lightkrylov()) call timer%start('svds_csp')
         ! Deals with the optional arguments.
         nsv = size(U)
@@ -2140,8 +2119,7 @@ contains
             enddo
         enddo
         if (time_lightkrylov()) call timer%stop('svds_csp')
-        call logger%log_debug('end', module=this_module, procedure='svds_csp')
-
+        
         return
     end subroutine svds_csp
 
@@ -2182,7 +2160,6 @@ contains
         real(dp) :: tol, u0_norm
         character(len=256) :: msg
 
-        call logger%log_debug('start', module=this_module, procedure='svds_cdp')
         if (time_lightkrylov()) call timer%start('svds_cdp')
         ! Deals with the optional arguments.
         nsv = size(U)
@@ -2245,8 +2222,7 @@ contains
             enddo
         enddo
         if (time_lightkrylov()) call timer%stop('svds_cdp')
-        call logger%log_debug('end', module=this_module, procedure='svds_cdp')
-
+        
         return
     end subroutine svds_cdp
 
@@ -2305,7 +2281,6 @@ contains
         class(abstract_vector_rsp), allocatable :: dx, wrk
         character(len=256) :: msg
 
-        call logger%log_debug('start', module=this_module, procedure='gmres_rsp')
         if (time_lightkrylov()) call timer%start('gmres_rsp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_sp)
@@ -2450,7 +2425,6 @@ contains
 
         call A%reset_counter(trans, 'gmres%post')
         if (time_lightkrylov()) call timer%stop('gmres_rsp')
-        call logger%log_debug('end', module=this_module, procedure='gmres_rsp')
         
         return
     end subroutine gmres_rsp
@@ -2505,7 +2479,6 @@ contains
         class(abstract_vector_rdp), allocatable :: dx, wrk
         character(len=256) :: msg
 
-        call logger%log_debug('start', module=this_module, procedure='gmres_rdp')
         if (time_lightkrylov()) call timer%start('gmres_rdp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_dp)
@@ -2650,7 +2623,6 @@ contains
 
         call A%reset_counter(trans, 'gmres%post')
         if (time_lightkrylov()) call timer%stop('gmres_rdp')
-        call logger%log_debug('end', module=this_module, procedure='gmres_rdp')
         
         return
     end subroutine gmres_rdp
@@ -2705,7 +2677,6 @@ contains
         class(abstract_vector_csp), allocatable :: dx, wrk
         character(len=256) :: msg
 
-        call logger%log_debug('start', module=this_module, procedure='gmres_csp')
         if (time_lightkrylov()) call timer%start('gmres_csp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_sp)
@@ -2850,7 +2821,6 @@ contains
 
         call A%reset_counter(trans, 'gmres%post')
         if (time_lightkrylov()) call timer%stop('gmres_csp')
-        call logger%log_debug('end', module=this_module, procedure='gmres_csp')
         
         return
     end subroutine gmres_csp
@@ -2905,7 +2875,6 @@ contains
         class(abstract_vector_cdp), allocatable :: dx, wrk
         character(len=256) :: msg
 
-        call logger%log_debug('start', module=this_module, procedure='gmres_cdp')
         if (time_lightkrylov()) call timer%start('gmres_cdp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_dp)
@@ -3050,7 +3019,6 @@ contains
 
         call A%reset_counter(trans, 'gmres%post')
         if (time_lightkrylov()) call timer%stop('gmres_cdp')
-        call logger%log_debug('end', module=this_module, procedure='gmres_cdp')
         
         return
     end subroutine gmres_cdp

--- a/src/IterativeSolvers.f90
+++ b/src/IterativeSolvers.f90
@@ -31,6 +31,7 @@ module lightkrylov_IterativeSolvers
     use LightKrylov_Constants
     Use LightKrylov_Logger
     use LightKrylov_Utils
+    !use LightKrylov_Timer
     use LightKrylov_AbstractVectors
     use LightKrylov_AbstractLinops
     use LightKrylov_BaseKrylov
@@ -820,6 +821,7 @@ contains
         procedure(eigvals_select_sp), pointer :: select_
 
         call logger%log_debug('start', module=this_module, procedure='eigs_rsp')
+        !if (timeit()) call global_timer%start('eigs_rsp')
         ! Deals with optional parameters.
         nev = size(X)
         kdim_   = optval(kdim, 4*nev)
@@ -921,6 +923,7 @@ contains
         enddo
 
         info = niter
+        !if (timeit()) call global_timer%stop('eigs_rsp')
         call logger%log_debug('end', module=this_module, procedure='eigs_rsp')
 
         return
@@ -971,6 +974,7 @@ contains
         procedure(eigvals_select_dp), pointer :: select_
 
         call logger%log_debug('start', module=this_module, procedure='eigs_rdp')
+        !if (timeit()) call global_timer%start('eigs_rdp')
         ! Deals with optional parameters.
         nev = size(X)
         kdim_   = optval(kdim, 4*nev)
@@ -1072,6 +1076,7 @@ contains
         enddo
 
         info = niter
+        !if (timeit()) call global_timer%stop('eigs_rdp')
         call logger%log_debug('end', module=this_module, procedure='eigs_rdp')
 
         return
@@ -1121,6 +1126,7 @@ contains
         procedure(eigvals_select_sp), pointer :: select_
 
         call logger%log_debug('start', module=this_module, procedure='eigs_csp')
+        !if (timeit()) call global_timer%start('eigs_csp')
         ! Deals with optional parameters.
         nev = size(X)
         kdim_   = optval(kdim, 4*nev)
@@ -1213,6 +1219,7 @@ contains
         enddo
 
         info = niter
+        !if (timeit()) call global_timer%stop('eigs_csp')
         call logger%log_debug('end', module=this_module, procedure='eigs_csp')
 
         return
@@ -1262,6 +1269,7 @@ contains
         procedure(eigvals_select_dp), pointer :: select_
 
         call logger%log_debug('start', module=this_module, procedure='eigs_cdp')
+        !if (timeit()) call global_timer%start('eigs_cdp')
         ! Deals with optional parameters.
         nev = size(X)
         kdim_   = optval(kdim, 4*nev)
@@ -1354,6 +1362,7 @@ contains
         enddo
 
         info = niter
+        !if (timeit()) call global_timer%stop('eigs_cdp')
         call logger%log_debug('end', module=this_module, procedure='eigs_cdp')
 
         return
@@ -1407,6 +1416,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='eighs_rsp')
+        !if (timeit()) call global_timer%start('eighs_rsp')
         ! Deaks with the optional args.
         nev = size(X)
         kdim_ = optval(kdim, 4*nev)
@@ -1470,6 +1480,7 @@ contains
         enddo
         
         info = k
+        !if (timeit()) call global_timer%stop('eighs_rsp')
         call logger%log_debug('end', module=this_module, procedure='eighs_rsp')
 
         return
@@ -1518,6 +1529,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='eighs_rdp')
+        !if (timeit()) call global_timer%start('eighs_rdp')
         ! Deaks with the optional args.
         nev = size(X)
         kdim_ = optval(kdim, 4*nev)
@@ -1581,6 +1593,7 @@ contains
         enddo
         
         info = k
+        !if (timeit()) call global_timer%stop('eighs_rdp')
         call logger%log_debug('end', module=this_module, procedure='eighs_rdp')
 
         return
@@ -1629,6 +1642,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='eighs_csp')
+        !if (timeit()) call global_timer%start('eighs_csp')
         ! Deaks with the optional args.
         nev = size(X)
         kdim_ = optval(kdim, 4*nev)
@@ -1692,6 +1706,7 @@ contains
         enddo
         
         info = k
+        !if (timeit()) call global_timer%stop('eighs_csp')
         call logger%log_debug('end', module=this_module, procedure='eighs_csp')
 
         return
@@ -1740,6 +1755,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='eighs_cdp')
+        !if (timeit()) call global_timer%start('eighs_cdp')
         ! Deaks with the optional args.
         nev = size(X)
         kdim_ = optval(kdim, 4*nev)
@@ -1803,6 +1819,7 @@ contains
         enddo
         
         info = k
+        !if (timeit()) call global_timer%stop('eighs_cdp')
         call logger%log_debug('end', module=this_module, procedure='eighs_cdp')
 
         return
@@ -1851,6 +1868,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='svds_rsp')
+        !if (timeit()) call global_timer%start('svds_rsp')
         ! Deals with the optional arguments.
         nsv = size(U)
         kdim_ = optval(kdim, 4*nsv)
@@ -1911,6 +1929,7 @@ contains
                 call V(i)%axpby(one_rsp, Vwrk(j), vmat(j, i))
             enddo
         enddo
+        !if (timeit()) call global_timer%stop('svds_rsp')
         call logger%log_debug('end', module=this_module, procedure='svds_rsp')
 
         return
@@ -1954,6 +1973,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='svds_rdp')
+        !if (timeit()) call global_timer%start('svds_rdp')
         ! Deals with the optional arguments.
         nsv = size(U)
         kdim_ = optval(kdim, 4*nsv)
@@ -2014,6 +2034,7 @@ contains
                 call V(i)%axpby(one_rdp, Vwrk(j), vmat(j, i))
             enddo
         enddo
+        !if (timeit()) call global_timer%stop('svds_rdp')
         call logger%log_debug('end', module=this_module, procedure='svds_rdp')
 
         return
@@ -2057,6 +2078,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='svds_csp')
+        !if (timeit()) call global_timer%start('svds_csp')
         ! Deals with the optional arguments.
         nsv = size(U)
         kdim_ = optval(kdim, 4*nsv)
@@ -2117,6 +2139,7 @@ contains
                 call V(i)%axpby(one_csp, Vwrk(j), vmat(j, i))
             enddo
         enddo
+        !if (timeit()) call global_timer%stop('svds_csp')
         call logger%log_debug('end', module=this_module, procedure='svds_csp')
 
         return
@@ -2160,6 +2183,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='svds_cdp')
+        !if (timeit()) call global_timer%start('svds_cdp')
         ! Deals with the optional arguments.
         nsv = size(U)
         kdim_ = optval(kdim, 4*nsv)
@@ -2220,6 +2244,7 @@ contains
                 call V(i)%axpby(one_cdp, Vwrk(j), vmat(j, i))
             enddo
         enddo
+        !if (timeit()) call global_timer%stop('svds_cdp')
         call logger%log_debug('end', module=this_module, procedure='svds_cdp')
 
         return
@@ -2281,6 +2306,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='gmres_rsp')
+        !if (timeit()) call global_timer%start('gmres_rsp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_sp)
         atol_ = optval(atol, atol_sp)
@@ -2423,6 +2449,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
+        !if (timeit()) call global_timer%stop('gmres_rsp')
         call logger%log_debug('end', module=this_module, procedure='gmres_rsp')
         
         return
@@ -2479,6 +2506,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='gmres_rdp')
+        !if (timeit()) call global_timer%start('gmres_rdp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_dp)
         atol_ = optval(atol, atol_dp)
@@ -2621,6 +2649,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
+        !if (timeit()) call global_timer%stop('gmres_rdp')
         call logger%log_debug('end', module=this_module, procedure='gmres_rdp')
         
         return
@@ -2677,6 +2706,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='gmres_csp')
+        !if (timeit()) call global_timer%start('gmres_csp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_sp)
         atol_ = optval(atol, atol_sp)
@@ -2819,6 +2849,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
+        !if (timeit()) call global_timer%stop('gmres_csp')
         call logger%log_debug('end', module=this_module, procedure='gmres_csp')
         
         return
@@ -2875,6 +2906,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='gmres_cdp')
+        !if (timeit()) call global_timer%start('gmres_cdp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_dp)
         atol_ = optval(atol, atol_dp)
@@ -3017,6 +3049,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
+        !if (timeit()) call global_timer%stop('gmres_cdp')
         call logger%log_debug('end', module=this_module, procedure='gmres_cdp')
         
         return
@@ -3083,6 +3116,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='fgmres_rsp')
+        !if (timeit()) call global_timer%start('fgmres_rsp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_sp)
         atol_ = optval(atol, atol_sp)
@@ -3224,6 +3258,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
+        !if (timeit()) call global_timer%stop('fgmres_rsp')
         call logger%log_debug('end', module=this_module, procedure='fgmres_rsp')
         
         return
@@ -3281,6 +3316,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='fgmres_rdp')
+        !if (timeit()) call global_timer%start('fgmres_rdp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_dp)
         atol_ = optval(atol, atol_dp)
@@ -3422,6 +3458,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
+        !if (timeit()) call global_timer%stop('fgmres_rdp')
         call logger%log_debug('end', module=this_module, procedure='fgmres_rdp')
         
         return
@@ -3479,6 +3516,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='fgmres_csp')
+        !if (timeit()) call global_timer%start('fgmres_csp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_sp)
         atol_ = optval(atol, atol_sp)
@@ -3620,6 +3658,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
+        !if (timeit()) call global_timer%stop('fgmres_csp')
         call logger%log_debug('end', module=this_module, procedure='fgmres_csp')
         
         return
@@ -3677,6 +3716,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='fgmres_cdp')
+        !if (timeit()) call global_timer%start('fgmres_cdp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_dp)
         atol_ = optval(atol, atol_dp)
@@ -3818,6 +3858,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
+        !if (timeit()) call global_timer%stop('fgmres_cdp')
         call logger%log_debug('end', module=this_module, procedure='fgmres_cdp')
         
         return
@@ -3870,6 +3911,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='cg_rsp')
+        !if (timeit()) call global_timer%start('cg_rsp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_sp)
         atol_ = optval(atol, atol_sp)
@@ -3952,6 +3994,7 @@ contains
         end if
 
         call A%reset_counter(.false., 'cg%post')
+        !if (timeit()) call global_timer%stop('cg_rsp')
         call logger%log_debug('end', module=this_module, procedure='cg_rsp')
 
         return
@@ -3997,6 +4040,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='cg_rdp')
+        !if (timeit()) call global_timer%start('cg_rdp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_dp)
         atol_ = optval(atol, atol_dp)
@@ -4079,6 +4123,7 @@ contains
         end if
 
         call A%reset_counter(.false., 'cg%post')
+        !if (timeit()) call global_timer%stop('cg_rdp')
         call logger%log_debug('end', module=this_module, procedure='cg_rdp')
 
         return
@@ -4124,6 +4169,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='cg_csp')
+        !if (timeit()) call global_timer%start('cg_csp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_sp)
         atol_ = optval(atol, atol_sp)
@@ -4206,6 +4252,7 @@ contains
         end if
 
         call A%reset_counter(.false., 'cg%post')
+        !if (timeit()) call global_timer%stop('cg_csp')
         call logger%log_debug('end', module=this_module, procedure='cg_csp')
 
         return
@@ -4251,6 +4298,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='cg_cdp')
+        !if (timeit()) call global_timer%start('cg_cdp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_dp)
         atol_ = optval(atol, atol_dp)
@@ -4333,6 +4381,7 @@ contains
         end if
 
         call A%reset_counter(.false., 'cg%post')
+        !if (timeit()) call global_timer%stop('cg_cdp')
         call logger%log_debug('end', module=this_module, procedure='cg_cdp')
 
         return

--- a/src/IterativeSolvers.f90
+++ b/src/IterativeSolvers.f90
@@ -31,7 +31,7 @@ module lightkrylov_IterativeSolvers
     use LightKrylov_Constants
     Use LightKrylov_Logger
     use LightKrylov_Utils
-    !use LightKrylov_Timer
+    use LightKrylov_Timing, only: timer => global_lightkrylov_timer, time_lightkrylov
     use LightKrylov_AbstractVectors
     use LightKrylov_AbstractLinops
     use LightKrylov_BaseKrylov
@@ -821,7 +821,7 @@ contains
         procedure(eigvals_select_sp), pointer :: select_
 
         call logger%log_debug('start', module=this_module, procedure='eigs_rsp')
-        !if (time_lightkrylov()) call global_timer%start('eigs_rsp')
+        if (time_lightkrylov()) call timer%start('eigs_rsp')
         ! Deals with optional parameters.
         nev = size(X)
         kdim_   = optval(kdim, 4*nev)
@@ -923,7 +923,7 @@ contains
         enddo
 
         info = niter
-        !if (time_lightkrylov()) call global_timer%stop('eigs_rsp')
+        if (time_lightkrylov()) call timer%stop('eigs_rsp')
         call logger%log_debug('end', module=this_module, procedure='eigs_rsp')
 
         return
@@ -974,7 +974,7 @@ contains
         procedure(eigvals_select_dp), pointer :: select_
 
         call logger%log_debug('start', module=this_module, procedure='eigs_rdp')
-        !if (time_lightkrylov()) call global_timer%start('eigs_rdp')
+        if (time_lightkrylov()) call timer%start('eigs_rdp')
         ! Deals with optional parameters.
         nev = size(X)
         kdim_   = optval(kdim, 4*nev)
@@ -1076,7 +1076,7 @@ contains
         enddo
 
         info = niter
-        !if (time_lightkrylov()) call global_timer%stop('eigs_rdp')
+        if (time_lightkrylov()) call timer%stop('eigs_rdp')
         call logger%log_debug('end', module=this_module, procedure='eigs_rdp')
 
         return
@@ -1126,7 +1126,7 @@ contains
         procedure(eigvals_select_sp), pointer :: select_
 
         call logger%log_debug('start', module=this_module, procedure='eigs_csp')
-        !if (time_lightkrylov()) call global_timer%start('eigs_csp')
+        if (time_lightkrylov()) call timer%start('eigs_csp')
         ! Deals with optional parameters.
         nev = size(X)
         kdim_   = optval(kdim, 4*nev)
@@ -1219,7 +1219,7 @@ contains
         enddo
 
         info = niter
-        !if (time_lightkrylov()) call global_timer%stop('eigs_csp')
+        if (time_lightkrylov()) call timer%stop('eigs_csp')
         call logger%log_debug('end', module=this_module, procedure='eigs_csp')
 
         return
@@ -1269,7 +1269,7 @@ contains
         procedure(eigvals_select_dp), pointer :: select_
 
         call logger%log_debug('start', module=this_module, procedure='eigs_cdp')
-        !if (time_lightkrylov()) call global_timer%start('eigs_cdp')
+        if (time_lightkrylov()) call timer%start('eigs_cdp')
         ! Deals with optional parameters.
         nev = size(X)
         kdim_   = optval(kdim, 4*nev)
@@ -1362,7 +1362,7 @@ contains
         enddo
 
         info = niter
-        !if (time_lightkrylov()) call global_timer%stop('eigs_cdp')
+        if (time_lightkrylov()) call timer%stop('eigs_cdp')
         call logger%log_debug('end', module=this_module, procedure='eigs_cdp')
 
         return
@@ -1416,7 +1416,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='eighs_rsp')
-        !if (time_lightkrylov()) call global_timer%start('eighs_rsp')
+        if (time_lightkrylov()) call timer%start('eighs_rsp')
         ! Deaks with the optional args.
         nev = size(X)
         kdim_ = optval(kdim, 4*nev)
@@ -1480,7 +1480,7 @@ contains
         enddo
         
         info = k
-        !if (time_lightkrylov()) call global_timer%stop('eighs_rsp')
+        if (time_lightkrylov()) call timer%stop('eighs_rsp')
         call logger%log_debug('end', module=this_module, procedure='eighs_rsp')
 
         return
@@ -1529,7 +1529,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='eighs_rdp')
-        !if (time_lightkrylov()) call global_timer%start('eighs_rdp')
+        if (time_lightkrylov()) call timer%start('eighs_rdp')
         ! Deaks with the optional args.
         nev = size(X)
         kdim_ = optval(kdim, 4*nev)
@@ -1593,7 +1593,7 @@ contains
         enddo
         
         info = k
-        !if (time_lightkrylov()) call global_timer%stop('eighs_rdp')
+        if (time_lightkrylov()) call timer%stop('eighs_rdp')
         call logger%log_debug('end', module=this_module, procedure='eighs_rdp')
 
         return
@@ -1642,7 +1642,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='eighs_csp')
-        !if (time_lightkrylov()) call global_timer%start('eighs_csp')
+        if (time_lightkrylov()) call timer%start('eighs_csp')
         ! Deaks with the optional args.
         nev = size(X)
         kdim_ = optval(kdim, 4*nev)
@@ -1706,7 +1706,7 @@ contains
         enddo
         
         info = k
-        !if (time_lightkrylov()) call global_timer%stop('eighs_csp')
+        if (time_lightkrylov()) call timer%stop('eighs_csp')
         call logger%log_debug('end', module=this_module, procedure='eighs_csp')
 
         return
@@ -1755,7 +1755,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='eighs_cdp')
-        !if (time_lightkrylov()) call global_timer%start('eighs_cdp')
+        if (time_lightkrylov()) call timer%start('eighs_cdp')
         ! Deaks with the optional args.
         nev = size(X)
         kdim_ = optval(kdim, 4*nev)
@@ -1819,7 +1819,7 @@ contains
         enddo
         
         info = k
-        !if (time_lightkrylov()) call global_timer%stop('eighs_cdp')
+        if (time_lightkrylov()) call timer%stop('eighs_cdp')
         call logger%log_debug('end', module=this_module, procedure='eighs_cdp')
 
         return
@@ -1868,7 +1868,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='svds_rsp')
-        !if (time_lightkrylov()) call global_timer%start('svds_rsp')
+        if (time_lightkrylov()) call timer%start('svds_rsp')
         ! Deals with the optional arguments.
         nsv = size(U)
         kdim_ = optval(kdim, 4*nsv)
@@ -1929,7 +1929,7 @@ contains
                 call V(i)%axpby(one_rsp, Vwrk(j), vmat(j, i))
             enddo
         enddo
-        !if (time_lightkrylov()) call global_timer%stop('svds_rsp')
+        if (time_lightkrylov()) call timer%stop('svds_rsp')
         call logger%log_debug('end', module=this_module, procedure='svds_rsp')
 
         return
@@ -1973,7 +1973,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='svds_rdp')
-        !if (time_lightkrylov()) call global_timer%start('svds_rdp')
+        if (time_lightkrylov()) call timer%start('svds_rdp')
         ! Deals with the optional arguments.
         nsv = size(U)
         kdim_ = optval(kdim, 4*nsv)
@@ -2034,7 +2034,7 @@ contains
                 call V(i)%axpby(one_rdp, Vwrk(j), vmat(j, i))
             enddo
         enddo
-        !if (time_lightkrylov()) call global_timer%stop('svds_rdp')
+        if (time_lightkrylov()) call timer%stop('svds_rdp')
         call logger%log_debug('end', module=this_module, procedure='svds_rdp')
 
         return
@@ -2078,7 +2078,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='svds_csp')
-        !if (time_lightkrylov()) call global_timer%start('svds_csp')
+        if (time_lightkrylov()) call timer%start('svds_csp')
         ! Deals with the optional arguments.
         nsv = size(U)
         kdim_ = optval(kdim, 4*nsv)
@@ -2139,7 +2139,7 @@ contains
                 call V(i)%axpby(one_csp, Vwrk(j), vmat(j, i))
             enddo
         enddo
-        !if (time_lightkrylov()) call global_timer%stop('svds_csp')
+        if (time_lightkrylov()) call timer%stop('svds_csp')
         call logger%log_debug('end', module=this_module, procedure='svds_csp')
 
         return
@@ -2183,7 +2183,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='svds_cdp')
-        !if (time_lightkrylov()) call global_timer%start('svds_cdp')
+        if (time_lightkrylov()) call timer%start('svds_cdp')
         ! Deals with the optional arguments.
         nsv = size(U)
         kdim_ = optval(kdim, 4*nsv)
@@ -2244,7 +2244,7 @@ contains
                 call V(i)%axpby(one_cdp, Vwrk(j), vmat(j, i))
             enddo
         enddo
-        !if (time_lightkrylov()) call global_timer%stop('svds_cdp')
+        if (time_lightkrylov()) call timer%stop('svds_cdp')
         call logger%log_debug('end', module=this_module, procedure='svds_cdp')
 
         return
@@ -2306,7 +2306,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='gmres_rsp')
-        !if (time_lightkrylov()) call global_timer%start('gmres_rsp')
+        if (time_lightkrylov()) call timer%start('gmres_rsp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_sp)
         atol_ = optval(atol, atol_sp)
@@ -2449,7 +2449,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
-        !if (time_lightkrylov()) call global_timer%stop('gmres_rsp')
+        if (time_lightkrylov()) call timer%stop('gmres_rsp')
         call logger%log_debug('end', module=this_module, procedure='gmres_rsp')
         
         return
@@ -2506,7 +2506,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='gmres_rdp')
-        !if (time_lightkrylov()) call global_timer%start('gmres_rdp')
+        if (time_lightkrylov()) call timer%start('gmres_rdp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_dp)
         atol_ = optval(atol, atol_dp)
@@ -2649,7 +2649,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
-        !if (time_lightkrylov()) call global_timer%stop('gmres_rdp')
+        if (time_lightkrylov()) call timer%stop('gmres_rdp')
         call logger%log_debug('end', module=this_module, procedure='gmres_rdp')
         
         return
@@ -2706,7 +2706,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='gmres_csp')
-        !if (time_lightkrylov()) call global_timer%start('gmres_csp')
+        if (time_lightkrylov()) call timer%start('gmres_csp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_sp)
         atol_ = optval(atol, atol_sp)
@@ -2849,7 +2849,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
-        !if (time_lightkrylov()) call global_timer%stop('gmres_csp')
+        if (time_lightkrylov()) call timer%stop('gmres_csp')
         call logger%log_debug('end', module=this_module, procedure='gmres_csp')
         
         return
@@ -2906,7 +2906,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='gmres_cdp')
-        !if (time_lightkrylov()) call global_timer%start('gmres_cdp')
+        if (time_lightkrylov()) call timer%start('gmres_cdp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_dp)
         atol_ = optval(atol, atol_dp)
@@ -3049,7 +3049,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
-        !if (time_lightkrylov()) call global_timer%stop('gmres_cdp')
+        if (time_lightkrylov()) call timer%stop('gmres_cdp')
         call logger%log_debug('end', module=this_module, procedure='gmres_cdp')
         
         return
@@ -3116,7 +3116,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='fgmres_rsp')
-        !if (time_lightkrylov()) call global_timer%start('fgmres_rsp')
+        if (time_lightkrylov()) call timer%start('fgmres_rsp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_sp)
         atol_ = optval(atol, atol_sp)
@@ -3258,7 +3258,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
-        !if (time_lightkrylov()) call global_timer%stop('fgmres_rsp')
+        if (time_lightkrylov()) call timer%stop('fgmres_rsp')
         call logger%log_debug('end', module=this_module, procedure='fgmres_rsp')
         
         return
@@ -3316,7 +3316,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='fgmres_rdp')
-        !if (time_lightkrylov()) call global_timer%start('fgmres_rdp')
+        if (time_lightkrylov()) call timer%start('fgmres_rdp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_dp)
         atol_ = optval(atol, atol_dp)
@@ -3458,7 +3458,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
-        !if (time_lightkrylov()) call global_timer%stop('fgmres_rdp')
+        if (time_lightkrylov()) call timer%stop('fgmres_rdp')
         call logger%log_debug('end', module=this_module, procedure='fgmres_rdp')
         
         return
@@ -3516,7 +3516,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='fgmres_csp')
-        !if (time_lightkrylov()) call global_timer%start('fgmres_csp')
+        if (time_lightkrylov()) call timer%start('fgmres_csp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_sp)
         atol_ = optval(atol, atol_sp)
@@ -3658,7 +3658,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
-        !if (time_lightkrylov()) call global_timer%stop('fgmres_csp')
+        if (time_lightkrylov()) call timer%stop('fgmres_csp')
         call logger%log_debug('end', module=this_module, procedure='fgmres_csp')
         
         return
@@ -3716,7 +3716,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='fgmres_cdp')
-        !if (time_lightkrylov()) call global_timer%start('fgmres_cdp')
+        if (time_lightkrylov()) call timer%start('fgmres_cdp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_dp)
         atol_ = optval(atol, atol_dp)
@@ -3858,7 +3858,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
-        !if (time_lightkrylov()) call global_timer%stop('fgmres_cdp')
+        if (time_lightkrylov()) call timer%stop('fgmres_cdp')
         call logger%log_debug('end', module=this_module, procedure='fgmres_cdp')
         
         return
@@ -3911,7 +3911,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='cg_rsp')
-        !if (time_lightkrylov()) call global_timer%start('cg_rsp')
+        if (time_lightkrylov()) call timer%start('cg_rsp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_sp)
         atol_ = optval(atol, atol_sp)
@@ -3994,7 +3994,7 @@ contains
         end if
 
         call A%reset_counter(.false., 'cg%post')
-        !if (time_lightkrylov()) call global_timer%stop('cg_rsp')
+        if (time_lightkrylov()) call timer%stop('cg_rsp')
         call logger%log_debug('end', module=this_module, procedure='cg_rsp')
 
         return
@@ -4040,7 +4040,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='cg_rdp')
-        !if (time_lightkrylov()) call global_timer%start('cg_rdp')
+        if (time_lightkrylov()) call timer%start('cg_rdp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_dp)
         atol_ = optval(atol, atol_dp)
@@ -4123,7 +4123,7 @@ contains
         end if
 
         call A%reset_counter(.false., 'cg%post')
-        !if (time_lightkrylov()) call global_timer%stop('cg_rdp')
+        if (time_lightkrylov()) call timer%stop('cg_rdp')
         call logger%log_debug('end', module=this_module, procedure='cg_rdp')
 
         return
@@ -4169,7 +4169,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='cg_csp')
-        !if (time_lightkrylov()) call global_timer%start('cg_csp')
+        if (time_lightkrylov()) call timer%start('cg_csp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_sp)
         atol_ = optval(atol, atol_sp)
@@ -4252,7 +4252,7 @@ contains
         end if
 
         call A%reset_counter(.false., 'cg%post')
-        !if (time_lightkrylov()) call global_timer%stop('cg_csp')
+        if (time_lightkrylov()) call timer%stop('cg_csp')
         call logger%log_debug('end', module=this_module, procedure='cg_csp')
 
         return
@@ -4298,7 +4298,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='cg_cdp')
-        !if (time_lightkrylov()) call global_timer%start('cg_cdp')
+        if (time_lightkrylov()) call timer%start('cg_cdp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_dp)
         atol_ = optval(atol, atol_dp)
@@ -4381,7 +4381,7 @@ contains
         end if
 
         call A%reset_counter(.false., 'cg%post')
-        !if (time_lightkrylov()) call global_timer%stop('cg_cdp')
+        if (time_lightkrylov()) call timer%stop('cg_cdp')
         call logger%log_debug('end', module=this_module, procedure='cg_cdp')
 
         return

--- a/src/IterativeSolvers.f90
+++ b/src/IterativeSolvers.f90
@@ -819,6 +819,7 @@ contains
         ! Eigenvalue selection.
         procedure(eigvals_select_sp), pointer :: select_
 
+        call logger%log_debug('start', module=this_module, procedure='eigs_rsp')
         ! Deals with optional parameters.
         nev = size(X)
         kdim_   = optval(kdim, 4*nev)
@@ -920,6 +921,7 @@ contains
         enddo
 
         info = niter
+        call logger%log_debug('end', module=this_module, procedure='eigs_rsp')
 
         return
     end subroutine eigs_rsp
@@ -968,6 +970,7 @@ contains
         ! Eigenvalue selection.
         procedure(eigvals_select_dp), pointer :: select_
 
+        call logger%log_debug('start', module=this_module, procedure='eigs_rdp')
         ! Deals with optional parameters.
         nev = size(X)
         kdim_   = optval(kdim, 4*nev)
@@ -1069,6 +1072,7 @@ contains
         enddo
 
         info = niter
+        call logger%log_debug('end', module=this_module, procedure='eigs_rdp')
 
         return
     end subroutine eigs_rdp
@@ -1116,6 +1120,7 @@ contains
         ! Eigenvalue selection.
         procedure(eigvals_select_sp), pointer :: select_
 
+        call logger%log_debug('start', module=this_module, procedure='eigs_csp')
         ! Deals with optional parameters.
         nev = size(X)
         kdim_   = optval(kdim, 4*nev)
@@ -1208,6 +1213,7 @@ contains
         enddo
 
         info = niter
+        call logger%log_debug('end', module=this_module, procedure='eigs_csp')
 
         return
     end subroutine eigs_csp
@@ -1255,6 +1261,7 @@ contains
         ! Eigenvalue selection.
         procedure(eigvals_select_dp), pointer :: select_
 
+        call logger%log_debug('start', module=this_module, procedure='eigs_cdp')
         ! Deals with optional parameters.
         nev = size(X)
         kdim_   = optval(kdim, 4*nev)
@@ -1347,6 +1354,7 @@ contains
         enddo
 
         info = niter
+        call logger%log_debug('end', module=this_module, procedure='eigs_cdp')
 
         return
     end subroutine eigs_cdp
@@ -1398,6 +1406,7 @@ contains
         real(sp) :: beta
         character(len=256) :: msg
 
+        call logger%log_debug('start', module=this_module, procedure='eighs_rsp')
         ! Deaks with the optional args.
         nev = size(X)
         kdim_ = optval(kdim, 4*nev)
@@ -1461,6 +1470,7 @@ contains
         enddo
         
         info = k
+        call logger%log_debug('end', module=this_module, procedure='eighs_rsp')
 
         return
     end subroutine eighs_rsp
@@ -1507,6 +1517,7 @@ contains
         real(dp) :: beta
         character(len=256) :: msg
 
+        call logger%log_debug('start', module=this_module, procedure='eighs_rdp')
         ! Deaks with the optional args.
         nev = size(X)
         kdim_ = optval(kdim, 4*nev)
@@ -1570,6 +1581,7 @@ contains
         enddo
         
         info = k
+        call logger%log_debug('end', module=this_module, procedure='eighs_rdp')
 
         return
     end subroutine eighs_rdp
@@ -1616,6 +1628,7 @@ contains
         complex(sp) :: beta
         character(len=256) :: msg
 
+        call logger%log_debug('start', module=this_module, procedure='eighs_csp')
         ! Deaks with the optional args.
         nev = size(X)
         kdim_ = optval(kdim, 4*nev)
@@ -1679,6 +1692,7 @@ contains
         enddo
         
         info = k
+        call logger%log_debug('end', module=this_module, procedure='eighs_csp')
 
         return
     end subroutine eighs_csp
@@ -1725,6 +1739,7 @@ contains
         complex(dp) :: beta
         character(len=256) :: msg
 
+        call logger%log_debug('start', module=this_module, procedure='eighs_cdp')
         ! Deaks with the optional args.
         nev = size(X)
         kdim_ = optval(kdim, 4*nev)
@@ -1788,6 +1803,7 @@ contains
         enddo
         
         info = k
+        call logger%log_debug('end', module=this_module, procedure='eighs_cdp')
 
         return
     end subroutine eighs_cdp
@@ -1834,6 +1850,7 @@ contains
         real(sp) :: tol, u0_norm
         character(len=256) :: msg
 
+        call logger%log_debug('start', module=this_module, procedure='svds_rsp')
         ! Deals with the optional arguments.
         nsv = size(U)
         kdim_ = optval(kdim, 4*nsv)
@@ -1894,6 +1911,7 @@ contains
                 call V(i)%axpby(one_rsp, Vwrk(j), vmat(j, i))
             enddo
         enddo
+        call logger%log_debug('end', module=this_module, procedure='svds_rsp')
 
         return
     end subroutine svds_rsp
@@ -1935,6 +1953,7 @@ contains
         real(dp) :: tol, u0_norm
         character(len=256) :: msg
 
+        call logger%log_debug('start', module=this_module, procedure='svds_rdp')
         ! Deals with the optional arguments.
         nsv = size(U)
         kdim_ = optval(kdim, 4*nsv)
@@ -1995,6 +2014,7 @@ contains
                 call V(i)%axpby(one_rdp, Vwrk(j), vmat(j, i))
             enddo
         enddo
+        call logger%log_debug('end', module=this_module, procedure='svds_rdp')
 
         return
     end subroutine svds_rdp
@@ -2036,6 +2056,7 @@ contains
         real(sp) :: tol, u0_norm
         character(len=256) :: msg
 
+        call logger%log_debug('start', module=this_module, procedure='svds_csp')
         ! Deals with the optional arguments.
         nsv = size(U)
         kdim_ = optval(kdim, 4*nsv)
@@ -2096,6 +2117,7 @@ contains
                 call V(i)%axpby(one_csp, Vwrk(j), vmat(j, i))
             enddo
         enddo
+        call logger%log_debug('end', module=this_module, procedure='svds_csp')
 
         return
     end subroutine svds_csp
@@ -2137,6 +2159,7 @@ contains
         real(dp) :: tol, u0_norm
         character(len=256) :: msg
 
+        call logger%log_debug('start', module=this_module, procedure='svds_cdp')
         ! Deals with the optional arguments.
         nsv = size(U)
         kdim_ = optval(kdim, 4*nsv)
@@ -2197,6 +2220,7 @@ contains
                 call V(i)%axpby(one_cdp, Vwrk(j), vmat(j, i))
             enddo
         enddo
+        call logger%log_debug('end', module=this_module, procedure='svds_cdp')
 
         return
     end subroutine svds_cdp
@@ -2256,6 +2280,7 @@ contains
         class(abstract_vector_rsp), allocatable :: dx, wrk
         character(len=256) :: msg
 
+        call logger%log_debug('start', module=this_module, procedure='gmres_rsp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_sp)
         atol_ = optval(atol, atol_sp)
@@ -2398,6 +2423,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
+        call logger%log_debug('end', module=this_module, procedure='gmres_rsp')
         
         return
     end subroutine gmres_rsp
@@ -2452,6 +2478,7 @@ contains
         class(abstract_vector_rdp), allocatable :: dx, wrk
         character(len=256) :: msg
 
+        call logger%log_debug('start', module=this_module, procedure='gmres_rdp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_dp)
         atol_ = optval(atol, atol_dp)
@@ -2594,6 +2621,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
+        call logger%log_debug('end', module=this_module, procedure='gmres_rdp')
         
         return
     end subroutine gmres_rdp
@@ -2648,6 +2676,7 @@ contains
         class(abstract_vector_csp), allocatable :: dx, wrk
         character(len=256) :: msg
 
+        call logger%log_debug('start', module=this_module, procedure='gmres_csp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_sp)
         atol_ = optval(atol, atol_sp)
@@ -2790,6 +2819,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
+        call logger%log_debug('end', module=this_module, procedure='gmres_csp')
         
         return
     end subroutine gmres_csp
@@ -2844,6 +2874,7 @@ contains
         class(abstract_vector_cdp), allocatable :: dx, wrk
         character(len=256) :: msg
 
+        call logger%log_debug('start', module=this_module, procedure='gmres_cdp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_dp)
         atol_ = optval(atol, atol_dp)
@@ -2986,6 +3017,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
+        call logger%log_debug('end', module=this_module, procedure='gmres_cdp')
         
         return
     end subroutine gmres_cdp
@@ -3050,6 +3082,7 @@ contains
         class(abstract_vector_rsp), allocatable :: dx
         character(len=256) :: msg
 
+        call logger%log_debug('start', module=this_module, procedure='fgmres_rsp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_sp)
         atol_ = optval(atol, atol_sp)
@@ -3191,6 +3224,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
+        call logger%log_debug('end', module=this_module, procedure='fgmres_rsp')
         
         return
     end subroutine fgmres_rsp
@@ -3246,6 +3280,7 @@ contains
         class(abstract_vector_rdp), allocatable :: dx
         character(len=256) :: msg
 
+        call logger%log_debug('start', module=this_module, procedure='fgmres_rdp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_dp)
         atol_ = optval(atol, atol_dp)
@@ -3387,6 +3422,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
+        call logger%log_debug('end', module=this_module, procedure='fgmres_rdp')
         
         return
     end subroutine fgmres_rdp
@@ -3442,6 +3478,7 @@ contains
         class(abstract_vector_csp), allocatable :: dx
         character(len=256) :: msg
 
+        call logger%log_debug('start', module=this_module, procedure='fgmres_csp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_sp)
         atol_ = optval(atol, atol_sp)
@@ -3583,6 +3620,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
+        call logger%log_debug('end', module=this_module, procedure='fgmres_csp')
         
         return
     end subroutine fgmres_csp
@@ -3638,6 +3676,7 @@ contains
         class(abstract_vector_cdp), allocatable :: dx
         character(len=256) :: msg
 
+        call logger%log_debug('start', module=this_module, procedure='fgmres_cdp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_dp)
         atol_ = optval(atol, atol_dp)
@@ -3779,6 +3818,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
+        call logger%log_debug('end', module=this_module, procedure='fgmres_cdp')
         
         return
     end subroutine fgmres_cdp
@@ -3829,6 +3869,7 @@ contains
         integer :: i
         character(len=256) :: msg
 
+        call logger%log_debug('start', module=this_module, procedure='cg_rsp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_sp)
         atol_ = optval(atol, atol_sp)
@@ -3911,6 +3952,7 @@ contains
         end if
 
         call A%reset_counter(.false., 'cg%post')
+        call logger%log_debug('end', module=this_module, procedure='cg_rsp')
 
         return
     end subroutine cg_rsp
@@ -3954,6 +3996,7 @@ contains
         integer :: i
         character(len=256) :: msg
 
+        call logger%log_debug('start', module=this_module, procedure='cg_rdp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_dp)
         atol_ = optval(atol, atol_dp)
@@ -4036,6 +4079,7 @@ contains
         end if
 
         call A%reset_counter(.false., 'cg%post')
+        call logger%log_debug('end', module=this_module, procedure='cg_rdp')
 
         return
     end subroutine cg_rdp
@@ -4079,6 +4123,7 @@ contains
         integer :: i
         character(len=256) :: msg
 
+        call logger%log_debug('start', module=this_module, procedure='cg_csp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_sp)
         atol_ = optval(atol, atol_sp)
@@ -4161,6 +4206,7 @@ contains
         end if
 
         call A%reset_counter(.false., 'cg%post')
+        call logger%log_debug('end', module=this_module, procedure='cg_csp')
 
         return
     end subroutine cg_csp
@@ -4204,6 +4250,7 @@ contains
         integer :: i
         character(len=256) :: msg
 
+        call logger%log_debug('start', module=this_module, procedure='cg_cdp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_dp)
         atol_ = optval(atol, atol_dp)
@@ -4286,6 +4333,7 @@ contains
         end if
 
         call A%reset_counter(.false., 'cg%post')
+        call logger%log_debug('end', module=this_module, procedure='cg_cdp')
 
         return
     end subroutine cg_cdp

--- a/src/IterativeSolvers.f90
+++ b/src/IterativeSolvers.f90
@@ -821,7 +821,7 @@ contains
         procedure(eigvals_select_sp), pointer :: select_
 
         call logger%log_debug('start', module=this_module, procedure='eigs_rsp')
-        !if (timeit()) call global_timer%start('eigs_rsp')
+        !if (time_lightkrylov()) call global_timer%start('eigs_rsp')
         ! Deals with optional parameters.
         nev = size(X)
         kdim_   = optval(kdim, 4*nev)
@@ -923,7 +923,7 @@ contains
         enddo
 
         info = niter
-        !if (timeit()) call global_timer%stop('eigs_rsp')
+        !if (time_lightkrylov()) call global_timer%stop('eigs_rsp')
         call logger%log_debug('end', module=this_module, procedure='eigs_rsp')
 
         return
@@ -974,7 +974,7 @@ contains
         procedure(eigvals_select_dp), pointer :: select_
 
         call logger%log_debug('start', module=this_module, procedure='eigs_rdp')
-        !if (timeit()) call global_timer%start('eigs_rdp')
+        !if (time_lightkrylov()) call global_timer%start('eigs_rdp')
         ! Deals with optional parameters.
         nev = size(X)
         kdim_   = optval(kdim, 4*nev)
@@ -1076,7 +1076,7 @@ contains
         enddo
 
         info = niter
-        !if (timeit()) call global_timer%stop('eigs_rdp')
+        !if (time_lightkrylov()) call global_timer%stop('eigs_rdp')
         call logger%log_debug('end', module=this_module, procedure='eigs_rdp')
 
         return
@@ -1126,7 +1126,7 @@ contains
         procedure(eigvals_select_sp), pointer :: select_
 
         call logger%log_debug('start', module=this_module, procedure='eigs_csp')
-        !if (timeit()) call global_timer%start('eigs_csp')
+        !if (time_lightkrylov()) call global_timer%start('eigs_csp')
         ! Deals with optional parameters.
         nev = size(X)
         kdim_   = optval(kdim, 4*nev)
@@ -1219,7 +1219,7 @@ contains
         enddo
 
         info = niter
-        !if (timeit()) call global_timer%stop('eigs_csp')
+        !if (time_lightkrylov()) call global_timer%stop('eigs_csp')
         call logger%log_debug('end', module=this_module, procedure='eigs_csp')
 
         return
@@ -1269,7 +1269,7 @@ contains
         procedure(eigvals_select_dp), pointer :: select_
 
         call logger%log_debug('start', module=this_module, procedure='eigs_cdp')
-        !if (timeit()) call global_timer%start('eigs_cdp')
+        !if (time_lightkrylov()) call global_timer%start('eigs_cdp')
         ! Deals with optional parameters.
         nev = size(X)
         kdim_   = optval(kdim, 4*nev)
@@ -1362,7 +1362,7 @@ contains
         enddo
 
         info = niter
-        !if (timeit()) call global_timer%stop('eigs_cdp')
+        !if (time_lightkrylov()) call global_timer%stop('eigs_cdp')
         call logger%log_debug('end', module=this_module, procedure='eigs_cdp')
 
         return
@@ -1416,7 +1416,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='eighs_rsp')
-        !if (timeit()) call global_timer%start('eighs_rsp')
+        !if (time_lightkrylov()) call global_timer%start('eighs_rsp')
         ! Deaks with the optional args.
         nev = size(X)
         kdim_ = optval(kdim, 4*nev)
@@ -1480,7 +1480,7 @@ contains
         enddo
         
         info = k
-        !if (timeit()) call global_timer%stop('eighs_rsp')
+        !if (time_lightkrylov()) call global_timer%stop('eighs_rsp')
         call logger%log_debug('end', module=this_module, procedure='eighs_rsp')
 
         return
@@ -1529,7 +1529,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='eighs_rdp')
-        !if (timeit()) call global_timer%start('eighs_rdp')
+        !if (time_lightkrylov()) call global_timer%start('eighs_rdp')
         ! Deaks with the optional args.
         nev = size(X)
         kdim_ = optval(kdim, 4*nev)
@@ -1593,7 +1593,7 @@ contains
         enddo
         
         info = k
-        !if (timeit()) call global_timer%stop('eighs_rdp')
+        !if (time_lightkrylov()) call global_timer%stop('eighs_rdp')
         call logger%log_debug('end', module=this_module, procedure='eighs_rdp')
 
         return
@@ -1642,7 +1642,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='eighs_csp')
-        !if (timeit()) call global_timer%start('eighs_csp')
+        !if (time_lightkrylov()) call global_timer%start('eighs_csp')
         ! Deaks with the optional args.
         nev = size(X)
         kdim_ = optval(kdim, 4*nev)
@@ -1706,7 +1706,7 @@ contains
         enddo
         
         info = k
-        !if (timeit()) call global_timer%stop('eighs_csp')
+        !if (time_lightkrylov()) call global_timer%stop('eighs_csp')
         call logger%log_debug('end', module=this_module, procedure='eighs_csp')
 
         return
@@ -1755,7 +1755,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='eighs_cdp')
-        !if (timeit()) call global_timer%start('eighs_cdp')
+        !if (time_lightkrylov()) call global_timer%start('eighs_cdp')
         ! Deaks with the optional args.
         nev = size(X)
         kdim_ = optval(kdim, 4*nev)
@@ -1819,7 +1819,7 @@ contains
         enddo
         
         info = k
-        !if (timeit()) call global_timer%stop('eighs_cdp')
+        !if (time_lightkrylov()) call global_timer%stop('eighs_cdp')
         call logger%log_debug('end', module=this_module, procedure='eighs_cdp')
 
         return
@@ -1868,7 +1868,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='svds_rsp')
-        !if (timeit()) call global_timer%start('svds_rsp')
+        !if (time_lightkrylov()) call global_timer%start('svds_rsp')
         ! Deals with the optional arguments.
         nsv = size(U)
         kdim_ = optval(kdim, 4*nsv)
@@ -1929,7 +1929,7 @@ contains
                 call V(i)%axpby(one_rsp, Vwrk(j), vmat(j, i))
             enddo
         enddo
-        !if (timeit()) call global_timer%stop('svds_rsp')
+        !if (time_lightkrylov()) call global_timer%stop('svds_rsp')
         call logger%log_debug('end', module=this_module, procedure='svds_rsp')
 
         return
@@ -1973,7 +1973,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='svds_rdp')
-        !if (timeit()) call global_timer%start('svds_rdp')
+        !if (time_lightkrylov()) call global_timer%start('svds_rdp')
         ! Deals with the optional arguments.
         nsv = size(U)
         kdim_ = optval(kdim, 4*nsv)
@@ -2034,7 +2034,7 @@ contains
                 call V(i)%axpby(one_rdp, Vwrk(j), vmat(j, i))
             enddo
         enddo
-        !if (timeit()) call global_timer%stop('svds_rdp')
+        !if (time_lightkrylov()) call global_timer%stop('svds_rdp')
         call logger%log_debug('end', module=this_module, procedure='svds_rdp')
 
         return
@@ -2078,7 +2078,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='svds_csp')
-        !if (timeit()) call global_timer%start('svds_csp')
+        !if (time_lightkrylov()) call global_timer%start('svds_csp')
         ! Deals with the optional arguments.
         nsv = size(U)
         kdim_ = optval(kdim, 4*nsv)
@@ -2139,7 +2139,7 @@ contains
                 call V(i)%axpby(one_csp, Vwrk(j), vmat(j, i))
             enddo
         enddo
-        !if (timeit()) call global_timer%stop('svds_csp')
+        !if (time_lightkrylov()) call global_timer%stop('svds_csp')
         call logger%log_debug('end', module=this_module, procedure='svds_csp')
 
         return
@@ -2183,7 +2183,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='svds_cdp')
-        !if (timeit()) call global_timer%start('svds_cdp')
+        !if (time_lightkrylov()) call global_timer%start('svds_cdp')
         ! Deals with the optional arguments.
         nsv = size(U)
         kdim_ = optval(kdim, 4*nsv)
@@ -2244,7 +2244,7 @@ contains
                 call V(i)%axpby(one_cdp, Vwrk(j), vmat(j, i))
             enddo
         enddo
-        !if (timeit()) call global_timer%stop('svds_cdp')
+        !if (time_lightkrylov()) call global_timer%stop('svds_cdp')
         call logger%log_debug('end', module=this_module, procedure='svds_cdp')
 
         return
@@ -2306,7 +2306,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='gmres_rsp')
-        !if (timeit()) call global_timer%start('gmres_rsp')
+        !if (time_lightkrylov()) call global_timer%start('gmres_rsp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_sp)
         atol_ = optval(atol, atol_sp)
@@ -2449,7 +2449,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
-        !if (timeit()) call global_timer%stop('gmres_rsp')
+        !if (time_lightkrylov()) call global_timer%stop('gmres_rsp')
         call logger%log_debug('end', module=this_module, procedure='gmres_rsp')
         
         return
@@ -2506,7 +2506,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='gmres_rdp')
-        !if (timeit()) call global_timer%start('gmres_rdp')
+        !if (time_lightkrylov()) call global_timer%start('gmres_rdp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_dp)
         atol_ = optval(atol, atol_dp)
@@ -2649,7 +2649,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
-        !if (timeit()) call global_timer%stop('gmres_rdp')
+        !if (time_lightkrylov()) call global_timer%stop('gmres_rdp')
         call logger%log_debug('end', module=this_module, procedure='gmres_rdp')
         
         return
@@ -2706,7 +2706,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='gmres_csp')
-        !if (timeit()) call global_timer%start('gmres_csp')
+        !if (time_lightkrylov()) call global_timer%start('gmres_csp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_sp)
         atol_ = optval(atol, atol_sp)
@@ -2849,7 +2849,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
-        !if (timeit()) call global_timer%stop('gmres_csp')
+        !if (time_lightkrylov()) call global_timer%stop('gmres_csp')
         call logger%log_debug('end', module=this_module, procedure='gmres_csp')
         
         return
@@ -2906,7 +2906,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='gmres_cdp')
-        !if (timeit()) call global_timer%start('gmres_cdp')
+        !if (time_lightkrylov()) call global_timer%start('gmres_cdp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_dp)
         atol_ = optval(atol, atol_dp)
@@ -3049,7 +3049,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
-        !if (timeit()) call global_timer%stop('gmres_cdp')
+        !if (time_lightkrylov()) call global_timer%stop('gmres_cdp')
         call logger%log_debug('end', module=this_module, procedure='gmres_cdp')
         
         return
@@ -3116,7 +3116,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='fgmres_rsp')
-        !if (timeit()) call global_timer%start('fgmres_rsp')
+        !if (time_lightkrylov()) call global_timer%start('fgmres_rsp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_sp)
         atol_ = optval(atol, atol_sp)
@@ -3258,7 +3258,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
-        !if (timeit()) call global_timer%stop('fgmres_rsp')
+        !if (time_lightkrylov()) call global_timer%stop('fgmres_rsp')
         call logger%log_debug('end', module=this_module, procedure='fgmres_rsp')
         
         return
@@ -3316,7 +3316,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='fgmres_rdp')
-        !if (timeit()) call global_timer%start('fgmres_rdp')
+        !if (time_lightkrylov()) call global_timer%start('fgmres_rdp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_dp)
         atol_ = optval(atol, atol_dp)
@@ -3458,7 +3458,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
-        !if (timeit()) call global_timer%stop('fgmres_rdp')
+        !if (time_lightkrylov()) call global_timer%stop('fgmres_rdp')
         call logger%log_debug('end', module=this_module, procedure='fgmres_rdp')
         
         return
@@ -3516,7 +3516,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='fgmres_csp')
-        !if (timeit()) call global_timer%start('fgmres_csp')
+        !if (time_lightkrylov()) call global_timer%start('fgmres_csp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_sp)
         atol_ = optval(atol, atol_sp)
@@ -3658,7 +3658,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
-        !if (timeit()) call global_timer%stop('fgmres_csp')
+        !if (time_lightkrylov()) call global_timer%stop('fgmres_csp')
         call logger%log_debug('end', module=this_module, procedure='fgmres_csp')
         
         return
@@ -3716,7 +3716,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='fgmres_cdp')
-        !if (timeit()) call global_timer%start('fgmres_cdp')
+        !if (time_lightkrylov()) call global_timer%start('fgmres_cdp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_dp)
         atol_ = optval(atol, atol_dp)
@@ -3858,7 +3858,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
-        !if (timeit()) call global_timer%stop('fgmres_cdp')
+        !if (time_lightkrylov()) call global_timer%stop('fgmres_cdp')
         call logger%log_debug('end', module=this_module, procedure='fgmres_cdp')
         
         return
@@ -3911,7 +3911,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='cg_rsp')
-        !if (timeit()) call global_timer%start('cg_rsp')
+        !if (time_lightkrylov()) call global_timer%start('cg_rsp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_sp)
         atol_ = optval(atol, atol_sp)
@@ -3994,7 +3994,7 @@ contains
         end if
 
         call A%reset_counter(.false., 'cg%post')
-        !if (timeit()) call global_timer%stop('cg_rsp')
+        !if (time_lightkrylov()) call global_timer%stop('cg_rsp')
         call logger%log_debug('end', module=this_module, procedure='cg_rsp')
 
         return
@@ -4040,7 +4040,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='cg_rdp')
-        !if (timeit()) call global_timer%start('cg_rdp')
+        !if (time_lightkrylov()) call global_timer%start('cg_rdp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_dp)
         atol_ = optval(atol, atol_dp)
@@ -4123,7 +4123,7 @@ contains
         end if
 
         call A%reset_counter(.false., 'cg%post')
-        !if (timeit()) call global_timer%stop('cg_rdp')
+        !if (time_lightkrylov()) call global_timer%stop('cg_rdp')
         call logger%log_debug('end', module=this_module, procedure='cg_rdp')
 
         return
@@ -4169,7 +4169,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='cg_csp')
-        !if (timeit()) call global_timer%start('cg_csp')
+        !if (time_lightkrylov()) call global_timer%start('cg_csp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_sp)
         atol_ = optval(atol, atol_sp)
@@ -4252,7 +4252,7 @@ contains
         end if
 
         call A%reset_counter(.false., 'cg%post')
-        !if (timeit()) call global_timer%stop('cg_csp')
+        !if (time_lightkrylov()) call global_timer%stop('cg_csp')
         call logger%log_debug('end', module=this_module, procedure='cg_csp')
 
         return
@@ -4298,7 +4298,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='cg_cdp')
-        !if (timeit()) call global_timer%start('cg_cdp')
+        !if (time_lightkrylov()) call global_timer%start('cg_cdp')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_dp)
         atol_ = optval(atol, atol_dp)
@@ -4381,7 +4381,7 @@ contains
         end if
 
         call A%reset_counter(.false., 'cg%post')
-        !if (timeit()) call global_timer%stop('cg_cdp')
+        !if (time_lightkrylov()) call global_timer%stop('cg_cdp')
         call logger%log_debug('end', module=this_module, procedure='cg_cdp')
 
         return

--- a/src/IterativeSolvers.fypp
+++ b/src/IterativeSolvers.fypp
@@ -624,7 +624,6 @@ contains
         ! Eigenvalue selection.
         procedure(eigvals_select_${kind}$), pointer :: select_
 
-        call logger%log_debug('start', module=this_module, procedure='eigs_${type[0]}$${kind}$')
         if (time_lightkrylov()) call timer%start('eigs_${type[0]}$${kind}$')
         ! Deals with optional parameters.
         nev = size(X)
@@ -732,8 +731,7 @@ contains
 
         info = niter
         if (time_lightkrylov()) call timer%stop('eigs_${type[0]}$${kind}$')
-        call logger%log_debug('end', module=this_module, procedure='eigs_${type[0]}$${kind}$')
-
+        
         return
     end subroutine eigs_${type[0]}$${kind}$
 
@@ -790,7 +788,6 @@ contains
         ${type}$ :: beta
         character(len=256) :: msg
 
-        call logger%log_debug('start', module=this_module, procedure='eighs_${type[0]}$${kind}$')
         if (time_lightkrylov()) call timer%start('eighs_${type[0]}$${kind}$')
         ! Deaks with the optional args.
         nev = size(X)
@@ -856,8 +853,7 @@ contains
         
         info = k
         if (time_lightkrylov()) call timer%stop('eighs_${type[0]}$${kind}$')
-        call logger%log_debug('end', module=this_module, procedure='eighs_${type[0]}$${kind}$')
-
+        
         return
     end subroutine eighs_${type[0]}$${kind}$
 
@@ -905,7 +901,6 @@ contains
         real(${kind}$) :: tol, u0_norm
         character(len=256) :: msg
 
-        call logger%log_debug('start', module=this_module, procedure='svds_${type[0]}$${kind}$')
         if (time_lightkrylov()) call timer%start('svds_${type[0]}$${kind}$')
         ! Deals with the optional arguments.
         nsv = size(U)
@@ -972,8 +967,7 @@ contains
             enddo
         enddo
         if (time_lightkrylov()) call timer%stop('svds_${type[0]}$${kind}$')
-        call logger%log_debug('end', module=this_module, procedure='svds_${type[0]}$${kind}$')
-
+        
         return
     end subroutine svds_${type[0]}$${kind}$
 
@@ -1034,7 +1028,6 @@ contains
         class(abstract_vector_${type[0]}$${kind}$), allocatable :: dx, wrk
         character(len=256) :: msg
 
-        call logger%log_debug('start', module=this_module, procedure='gmres_${type[0]}$${kind}$')
         if (time_lightkrylov()) call timer%start('gmres_${type[0]}$${kind}$')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_${kind}$)
@@ -1179,7 +1172,6 @@ contains
 
         call A%reset_counter(trans, 'gmres%post')
         if (time_lightkrylov()) call timer%stop('gmres_${type[0]}$${kind}$')
-        call logger%log_debug('end', module=this_module, procedure='gmres_${type[0]}$${kind}$')
         
         return
     end subroutine gmres_${type[0]}$${kind}$

--- a/src/IterativeSolvers.fypp
+++ b/src/IterativeSolvers.fypp
@@ -623,6 +623,7 @@ contains
         ! Eigenvalue selection.
         procedure(eigvals_select_${kind}$), pointer :: select_
 
+        call logger%log_debug('start', module=this_module, procedure='eigs_${type[0]}$${kind}$')
         ! Deals with optional parameters.
         nev = size(X)
         kdim_   = optval(kdim, 4*nev)
@@ -728,6 +729,7 @@ contains
         enddo
 
         info = niter
+        call logger%log_debug('end', module=this_module, procedure='eigs_${type[0]}$${kind}$')
 
         return
     end subroutine eigs_${type[0]}$${kind}$
@@ -785,6 +787,7 @@ contains
         ${type}$ :: beta
         character(len=256) :: msg
 
+        call logger%log_debug('start', module=this_module, procedure='eighs_${type[0]}$${kind}$')
         ! Deaks with the optional args.
         nev = size(X)
         kdim_ = optval(kdim, 4*nev)
@@ -848,6 +851,7 @@ contains
         enddo
         
         info = k
+        call logger%log_debug('end', module=this_module, procedure='eighs_${type[0]}$${kind}$')
 
         return
     end subroutine eighs_${type[0]}$${kind}$
@@ -896,6 +900,7 @@ contains
         real(${kind}$) :: tol, u0_norm
         character(len=256) :: msg
 
+        call logger%log_debug('start', module=this_module, procedure='svds_${type[0]}$${kind}$')
         ! Deals with the optional arguments.
         nsv = size(U)
         kdim_ = optval(kdim, 4*nsv)
@@ -960,6 +965,7 @@ contains
                 call V(i)%axpby(one_${type[0]}$${kind}$, Vwrk(j), vmat(j, i))
             enddo
         enddo
+        call logger%log_debug('end', module=this_module, procedure='svds_${type[0]}$${kind}$')
 
         return
     end subroutine svds_${type[0]}$${kind}$
@@ -1021,6 +1027,7 @@ contains
         class(abstract_vector_${type[0]}$${kind}$), allocatable :: dx, wrk
         character(len=256) :: msg
 
+        call logger%log_debug('start', module=this_module, procedure='gmres_${type[0]}$${kind}$')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_${kind}$)
         atol_ = optval(atol, atol_${kind}$)
@@ -1163,6 +1170,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
+        call logger%log_debug('end', module=this_module, procedure='gmres_${type[0]}$${kind}$')
         
         return
     end subroutine gmres_${type[0]}$${kind}$
@@ -1229,6 +1237,7 @@ contains
         class(abstract_vector_${type[0]}$${kind}$), allocatable :: dx
         character(len=256) :: msg
 
+        call logger%log_debug('start', module=this_module, procedure='fgmres_${type[0]}$${kind}$')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_${kind}$)
         atol_ = optval(atol, atol_${kind}$)
@@ -1370,6 +1379,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
+        call logger%log_debug('end', module=this_module, procedure='fgmres_${type[0]}$${kind}$')
         
         return
     end subroutine fgmres_${type[0]}$${kind}$
@@ -1426,6 +1436,7 @@ contains
         integer :: i
         character(len=256) :: msg
 
+        call logger%log_debug('start', module=this_module, procedure='cg_${type[0]}$${kind}$')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_${kind}$)
         atol_ = optval(atol, atol_${kind}$)
@@ -1512,6 +1523,7 @@ contains
         end if
 
         call A%reset_counter(.false., 'cg%post')
+        call logger%log_debug('end', module=this_module, procedure='cg_${type[0]}$${kind}$')
 
         return
     end subroutine cg_${type[0]}$${kind}$

--- a/src/IterativeSolvers.fypp
+++ b/src/IterativeSolvers.fypp
@@ -33,6 +33,7 @@ module lightkrylov_IterativeSolvers
     use LightKrylov_Constants
     Use LightKrylov_Logger
     use LightKrylov_Utils
+    !use LightKrylov_Timer
     use LightKrylov_AbstractVectors
     use LightKrylov_AbstractLinops
     use LightKrylov_BaseKrylov
@@ -624,6 +625,7 @@ contains
         procedure(eigvals_select_${kind}$), pointer :: select_
 
         call logger%log_debug('start', module=this_module, procedure='eigs_${type[0]}$${kind}$')
+        !if (timeit()) call global_timer%start('eigs_${type[0]}$${kind}$')
         ! Deals with optional parameters.
         nev = size(X)
         kdim_   = optval(kdim, 4*nev)
@@ -729,6 +731,7 @@ contains
         enddo
 
         info = niter
+        !if (timeit()) call global_timer%stop('eigs_${type[0]}$${kind}$')
         call logger%log_debug('end', module=this_module, procedure='eigs_${type[0]}$${kind}$')
 
         return
@@ -788,6 +791,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='eighs_${type[0]}$${kind}$')
+        !if (timeit()) call global_timer%start('eighs_${type[0]}$${kind}$')
         ! Deaks with the optional args.
         nev = size(X)
         kdim_ = optval(kdim, 4*nev)
@@ -851,6 +855,7 @@ contains
         enddo
         
         info = k
+        !if (timeit()) call global_timer%stop('eighs_${type[0]}$${kind}$')
         call logger%log_debug('end', module=this_module, procedure='eighs_${type[0]}$${kind}$')
 
         return
@@ -901,6 +906,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='svds_${type[0]}$${kind}$')
+        !if (timeit()) call global_timer%start('svds_${type[0]}$${kind}$')
         ! Deals with the optional arguments.
         nsv = size(U)
         kdim_ = optval(kdim, 4*nsv)
@@ -965,6 +971,7 @@ contains
                 call V(i)%axpby(one_${type[0]}$${kind}$, Vwrk(j), vmat(j, i))
             enddo
         enddo
+        !if (timeit()) call global_timer%stop('svds_${type[0]}$${kind}$')
         call logger%log_debug('end', module=this_module, procedure='svds_${type[0]}$${kind}$')
 
         return
@@ -1028,6 +1035,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='gmres_${type[0]}$${kind}$')
+        !if (timeit()) call global_timer%start('gmres_${type[0]}$${kind}$')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_${kind}$)
         atol_ = optval(atol, atol_${kind}$)
@@ -1170,6 +1178,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
+        !if (timeit()) call global_timer%stop('gmres_${type[0]}$${kind}$')
         call logger%log_debug('end', module=this_module, procedure='gmres_${type[0]}$${kind}$')
         
         return
@@ -1238,6 +1247,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='fgmres_${type[0]}$${kind}$')
+        !if (timeit()) call global_timer%start('fgmres_${type[0]}$${kind}$')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_${kind}$)
         atol_ = optval(atol, atol_${kind}$)
@@ -1379,6 +1389,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
+        !if (timeit()) call global_timer%stop('fgmres_${type[0]}$${kind}$')
         call logger%log_debug('end', module=this_module, procedure='fgmres_${type[0]}$${kind}$')
         
         return
@@ -1437,6 +1448,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='cg_${type[0]}$${kind}$')
+        !if (timeit()) call global_timer%start('cg_${type[0]}$${kind}$')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_${kind}$)
         atol_ = optval(atol, atol_${kind}$)
@@ -1523,6 +1535,7 @@ contains
         end if
 
         call A%reset_counter(.false., 'cg%post')
+        !if (timeit()) call global_timer%stop('cg_${type[0]}$${kind}$')
         call logger%log_debug('end', module=this_module, procedure='cg_${type[0]}$${kind}$')
 
         return

--- a/src/IterativeSolvers.fypp
+++ b/src/IterativeSolvers.fypp
@@ -33,7 +33,7 @@ module lightkrylov_IterativeSolvers
     use LightKrylov_Constants
     Use LightKrylov_Logger
     use LightKrylov_Utils
-    !use LightKrylov_Timer
+    use LightKrylov_Timing, only: timer => global_lightkrylov_timer, time_lightkrylov
     use LightKrylov_AbstractVectors
     use LightKrylov_AbstractLinops
     use LightKrylov_BaseKrylov
@@ -625,7 +625,7 @@ contains
         procedure(eigvals_select_${kind}$), pointer :: select_
 
         call logger%log_debug('start', module=this_module, procedure='eigs_${type[0]}$${kind}$')
-        !if (time_lightkrylov()) call global_timer%start('eigs_${type[0]}$${kind}$')
+        if (time_lightkrylov()) call timer%start('eigs_${type[0]}$${kind}$')
         ! Deals with optional parameters.
         nev = size(X)
         kdim_   = optval(kdim, 4*nev)
@@ -731,7 +731,7 @@ contains
         enddo
 
         info = niter
-        !if (time_lightkrylov()) call global_timer%stop('eigs_${type[0]}$${kind}$')
+        if (time_lightkrylov()) call timer%stop('eigs_${type[0]}$${kind}$')
         call logger%log_debug('end', module=this_module, procedure='eigs_${type[0]}$${kind}$')
 
         return
@@ -791,7 +791,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='eighs_${type[0]}$${kind}$')
-        !if (time_lightkrylov()) call global_timer%start('eighs_${type[0]}$${kind}$')
+        if (time_lightkrylov()) call timer%start('eighs_${type[0]}$${kind}$')
         ! Deaks with the optional args.
         nev = size(X)
         kdim_ = optval(kdim, 4*nev)
@@ -855,7 +855,7 @@ contains
         enddo
         
         info = k
-        !if (time_lightkrylov()) call global_timer%stop('eighs_${type[0]}$${kind}$')
+        if (time_lightkrylov()) call timer%stop('eighs_${type[0]}$${kind}$')
         call logger%log_debug('end', module=this_module, procedure='eighs_${type[0]}$${kind}$')
 
         return
@@ -906,7 +906,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='svds_${type[0]}$${kind}$')
-        !if (time_lightkrylov()) call global_timer%start('svds_${type[0]}$${kind}$')
+        if (time_lightkrylov()) call timer%start('svds_${type[0]}$${kind}$')
         ! Deals with the optional arguments.
         nsv = size(U)
         kdim_ = optval(kdim, 4*nsv)
@@ -971,7 +971,7 @@ contains
                 call V(i)%axpby(one_${type[0]}$${kind}$, Vwrk(j), vmat(j, i))
             enddo
         enddo
-        !if (time_lightkrylov()) call global_timer%stop('svds_${type[0]}$${kind}$')
+        if (time_lightkrylov()) call timer%stop('svds_${type[0]}$${kind}$')
         call logger%log_debug('end', module=this_module, procedure='svds_${type[0]}$${kind}$')
 
         return
@@ -1035,7 +1035,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='gmres_${type[0]}$${kind}$')
-        !if (time_lightkrylov()) call global_timer%start('gmres_${type[0]}$${kind}$')
+        if (time_lightkrylov()) call timer%start('gmres_${type[0]}$${kind}$')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_${kind}$)
         atol_ = optval(atol, atol_${kind}$)
@@ -1178,7 +1178,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
-        !if (time_lightkrylov()) call global_timer%stop('gmres_${type[0]}$${kind}$')
+        if (time_lightkrylov()) call timer%stop('gmres_${type[0]}$${kind}$')
         call logger%log_debug('end', module=this_module, procedure='gmres_${type[0]}$${kind}$')
         
         return
@@ -1247,7 +1247,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='fgmres_${type[0]}$${kind}$')
-        !if (time_lightkrylov()) call global_timer%start('fgmres_${type[0]}$${kind}$')
+        if (time_lightkrylov()) call timer%start('fgmres_${type[0]}$${kind}$')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_${kind}$)
         atol_ = optval(atol, atol_${kind}$)
@@ -1389,7 +1389,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
-        !if (time_lightkrylov()) call global_timer%stop('fgmres_${type[0]}$${kind}$')
+        if (time_lightkrylov()) call timer%stop('fgmres_${type[0]}$${kind}$')
         call logger%log_debug('end', module=this_module, procedure='fgmres_${type[0]}$${kind}$')
         
         return
@@ -1448,7 +1448,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='cg_${type[0]}$${kind}$')
-        !if (time_lightkrylov()) call global_timer%start('cg_${type[0]}$${kind}$')
+        if (time_lightkrylov()) call timer%start('cg_${type[0]}$${kind}$')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_${kind}$)
         atol_ = optval(atol, atol_${kind}$)
@@ -1535,7 +1535,7 @@ contains
         end if
 
         call A%reset_counter(.false., 'cg%post')
-        !if (time_lightkrylov()) call global_timer%stop('cg_${type[0]}$${kind}$')
+        if (time_lightkrylov()) call timer%stop('cg_${type[0]}$${kind}$')
         call logger%log_debug('end', module=this_module, procedure='cg_${type[0]}$${kind}$')
 
         return

--- a/src/IterativeSolvers.fypp
+++ b/src/IterativeSolvers.fypp
@@ -625,7 +625,7 @@ contains
         procedure(eigvals_select_${kind}$), pointer :: select_
 
         call logger%log_debug('start', module=this_module, procedure='eigs_${type[0]}$${kind}$')
-        !if (timeit()) call global_timer%start('eigs_${type[0]}$${kind}$')
+        !if (time_lightkrylov()) call global_timer%start('eigs_${type[0]}$${kind}$')
         ! Deals with optional parameters.
         nev = size(X)
         kdim_   = optval(kdim, 4*nev)
@@ -731,7 +731,7 @@ contains
         enddo
 
         info = niter
-        !if (timeit()) call global_timer%stop('eigs_${type[0]}$${kind}$')
+        !if (time_lightkrylov()) call global_timer%stop('eigs_${type[0]}$${kind}$')
         call logger%log_debug('end', module=this_module, procedure='eigs_${type[0]}$${kind}$')
 
         return
@@ -791,7 +791,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='eighs_${type[0]}$${kind}$')
-        !if (timeit()) call global_timer%start('eighs_${type[0]}$${kind}$')
+        !if (time_lightkrylov()) call global_timer%start('eighs_${type[0]}$${kind}$')
         ! Deaks with the optional args.
         nev = size(X)
         kdim_ = optval(kdim, 4*nev)
@@ -855,7 +855,7 @@ contains
         enddo
         
         info = k
-        !if (timeit()) call global_timer%stop('eighs_${type[0]}$${kind}$')
+        !if (time_lightkrylov()) call global_timer%stop('eighs_${type[0]}$${kind}$')
         call logger%log_debug('end', module=this_module, procedure='eighs_${type[0]}$${kind}$')
 
         return
@@ -906,7 +906,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='svds_${type[0]}$${kind}$')
-        !if (timeit()) call global_timer%start('svds_${type[0]}$${kind}$')
+        !if (time_lightkrylov()) call global_timer%start('svds_${type[0]}$${kind}$')
         ! Deals with the optional arguments.
         nsv = size(U)
         kdim_ = optval(kdim, 4*nsv)
@@ -971,7 +971,7 @@ contains
                 call V(i)%axpby(one_${type[0]}$${kind}$, Vwrk(j), vmat(j, i))
             enddo
         enddo
-        !if (timeit()) call global_timer%stop('svds_${type[0]}$${kind}$')
+        !if (time_lightkrylov()) call global_timer%stop('svds_${type[0]}$${kind}$')
         call logger%log_debug('end', module=this_module, procedure='svds_${type[0]}$${kind}$')
 
         return
@@ -1035,7 +1035,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='gmres_${type[0]}$${kind}$')
-        !if (timeit()) call global_timer%start('gmres_${type[0]}$${kind}$')
+        !if (time_lightkrylov()) call global_timer%start('gmres_${type[0]}$${kind}$')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_${kind}$)
         atol_ = optval(atol, atol_${kind}$)
@@ -1178,7 +1178,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
-        !if (timeit()) call global_timer%stop('gmres_${type[0]}$${kind}$')
+        !if (time_lightkrylov()) call global_timer%stop('gmres_${type[0]}$${kind}$')
         call logger%log_debug('end', module=this_module, procedure='gmres_${type[0]}$${kind}$')
         
         return
@@ -1247,7 +1247,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='fgmres_${type[0]}$${kind}$')
-        !if (timeit()) call global_timer%start('fgmres_${type[0]}$${kind}$')
+        !if (time_lightkrylov()) call global_timer%start('fgmres_${type[0]}$${kind}$')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_${kind}$)
         atol_ = optval(atol, atol_${kind}$)
@@ -1389,7 +1389,7 @@ contains
         end if
 
         call A%reset_counter(trans, 'gmres%post')
-        !if (timeit()) call global_timer%stop('fgmres_${type[0]}$${kind}$')
+        !if (time_lightkrylov()) call global_timer%stop('fgmres_${type[0]}$${kind}$')
         call logger%log_debug('end', module=this_module, procedure='fgmres_${type[0]}$${kind}$')
         
         return
@@ -1448,7 +1448,7 @@ contains
         character(len=256) :: msg
 
         call logger%log_debug('start', module=this_module, procedure='cg_${type[0]}$${kind}$')
-        !if (timeit()) call global_timer%start('cg_${type[0]}$${kind}$')
+        !if (time_lightkrylov()) call global_timer%start('cg_${type[0]}$${kind}$')
         ! Deals with the optional args.
         rtol_ = optval(rtol, rtol_${kind}$)
         atol_ = optval(atol, atol_${kind}$)
@@ -1535,7 +1535,7 @@ contains
         end if
 
         call A%reset_counter(.false., 'cg%post')
-        !if (timeit()) call global_timer%stop('cg_${type[0]}$${kind}$')
+        !if (time_lightkrylov()) call global_timer%stop('cg_${type[0]}$${kind}$')
         call logger%log_debug('end', module=this_module, procedure='cg_${type[0]}$${kind}$')
 
         return

--- a/src/LightKrylov.f90
+++ b/src/LightKrylov.f90
@@ -17,6 +17,8 @@ module LightKrylov
     use LightKrylov_IterativeSolvers
     ! --> Expmlib
     use LightKrylov_Expmlib
+    ! --> Timing utilities
+    use LightKrylov_Timing
     ! --> TestTypes
     implicit none
     private
@@ -139,6 +141,10 @@ module LightKrylov
     public :: expm
     public :: kexpm
     public :: k_exptA
+
+    ! Timer exports
+    public :: lightkrylov_timer
+    public :: abstract_watch
 
 contains
 

--- a/src/LightKrylov.fypp
+++ b/src/LightKrylov.fypp
@@ -19,6 +19,8 @@ module LightKrylov
     use LightKrylov_IterativeSolvers
     ! --> Expmlib
     use LightKrylov_Expmlib
+    ! --> Timing utilities
+    use LightKrylov_Timing
     ! --> TestTypes
     implicit none
     private
@@ -118,6 +120,10 @@ module LightKrylov
     public :: expm
     public :: kexpm
     public :: k_exptA
+
+    ! Timer exports
+    public :: lightkrylov_timer
+    public :: abstract_watch
 
 contains
 

--- a/src/Logger.f90
+++ b/src/Logger.f90
@@ -15,7 +15,7 @@ module LightKrylov_Logger
    implicit none
    private
 
-   character(len=128), parameter, private :: this_module = 'LightKrylov_Logger'
+   character(len=128), parameter :: this_module = 'LightKrylov_Logger'
 
    logical, parameter, private :: exit_on_error = .true.
    logical, parameter, private :: exit_on_test_error = .true.
@@ -94,6 +94,11 @@ contains
       if (present(iunit)) iunit = iunit_
       return
    end subroutine logger_setup
+
+   !subroutine flush_logger()
+
+
+   !end subroutine flush_logger
 
    subroutine comm_setup()
       ! internal

--- a/src/Logger.f90
+++ b/src/Logger.f90
@@ -33,7 +33,7 @@ module LightKrylov_Logger
 
 contains
 
-   subroutine logger_setup(logfile, nio, log_level, log_stdout, log_timestamp)
+   subroutine logger_setup(logfile, nio, log_level, log_stdout, log_timestamp, iunit)
       !! Wrapper to set up MPI if needed and initialize log files
       character(len=*), optional, intent(in) :: logfile
       !! name of the dedicated LightKrylov logfile
@@ -51,6 +51,8 @@ contains
       !! duplicate log messages to stdout?
       logical, optional, intent(in)          :: log_timestamp
       !! add timestamp to log messages
+      integer, optional, intent(out)         :: iunit
+      !! log unit identifier
 
       ! internals
       character(len=:), allocatable :: logfile_
@@ -58,8 +60,9 @@ contains
       integer                       :: log_level_
       logical                       :: log_stdout_
       logical                       :: log_timestamp_
+      integer                       :: iunit_
       ! misc
-      integer :: stat, iunit
+      integer :: stat
 
       logfile_       = optval(logfile, 'lightkrylov.log')
       nio_           = optval(nio, 0)
@@ -86,6 +89,9 @@ contains
          call logger%add_log_unit(6, stat=stat)
          if (stat /= 0) call stop_error('Unable to add stdout to logger.', module=this_module, procedure='logger_setup')
       end if
+
+      ! return unit if requested
+      if (present(iunit)) iunit = iunit_
       return
    end subroutine logger_setup
 

--- a/src/NewtonKrylov.f90
+++ b/src/NewtonKrylov.f90
@@ -2,7 +2,7 @@ module LightKrylov_NewtonKrylov
    use stdlib_optval, only: optval
    use LightKrylov_Constants
    use LightKrylov_Logger
-   use LightKrylov_Timer
+   use LightKrylov_Timing, only: timer => global_lightkrylov_timer, time_lightkrylov
    use LightKrylov_AbstractVectors
    use LightKrylov_AbstractLinops
    use LightKrylov_AbstractSystems
@@ -149,7 +149,7 @@ contains
       character(len=256) :: msg
       
       call logger%log_debug('start', module=this_module, procedure='newton_rsp')
-      !if (time_lightkrylov()) call global_timer%start('newton_rsp')
+      if (time_lightkrylov()) call timer%start('newton_rsp')
       
       ! Newton-solver tolerance
       target_tol = optval(tolerance, atol_sp)
@@ -268,7 +268,7 @@ contains
       end if
 
       call sys%reset_eval_counter('newton%post')
-      !if (time_lightkrylov()) call global_timer%stop('newton_rsp')
+      if (time_lightkrylov()) call timer%stop('newton_rsp')
       call logger%log_debug('end', module=this_module, procedure='newton_rsp')
 
       return
@@ -309,7 +309,7 @@ contains
       character(len=256) :: msg
       
       call logger%log_debug('start', module=this_module, procedure='newton_rdp')
-      !if (time_lightkrylov()) call global_timer%start('newton_rdp')
+      if (time_lightkrylov()) call timer%start('newton_rdp')
       
       ! Newton-solver tolerance
       target_tol = optval(tolerance, atol_dp)
@@ -428,7 +428,7 @@ contains
       end if
 
       call sys%reset_eval_counter('newton%post')
-      !if (time_lightkrylov()) call global_timer%stop('newton_rdp')
+      if (time_lightkrylov()) call timer%stop('newton_rdp')
       call logger%log_debug('end', module=this_module, procedure='newton_rdp')
 
       return
@@ -469,7 +469,7 @@ contains
       character(len=256) :: msg
       
       call logger%log_debug('start', module=this_module, procedure='newton_csp')
-      !if (time_lightkrylov()) call global_timer%start('newton_csp')
+      if (time_lightkrylov()) call timer%start('newton_csp')
       
       ! Newton-solver tolerance
       target_tol = optval(tolerance, atol_sp)
@@ -588,7 +588,7 @@ contains
       end if
 
       call sys%reset_eval_counter('newton%post')
-      !if (time_lightkrylov()) call global_timer%stop('newton_csp')
+      if (time_lightkrylov()) call timer%stop('newton_csp')
       call logger%log_debug('end', module=this_module, procedure='newton_csp')
 
       return
@@ -629,7 +629,7 @@ contains
       character(len=256) :: msg
       
       call logger%log_debug('start', module=this_module, procedure='newton_cdp')
-      !if (time_lightkrylov()) call global_timer%start('newton_cdp')
+      if (time_lightkrylov()) call timer%start('newton_cdp')
       
       ! Newton-solver tolerance
       target_tol = optval(tolerance, atol_dp)
@@ -748,7 +748,7 @@ contains
       end if
 
       call sys%reset_eval_counter('newton%post')
-      !if (time_lightkrylov()) call global_timer%stop('newton_cdp')
+      if (time_lightkrylov()) call timer%stop('newton_cdp')
       call logger%log_debug('end', module=this_module, procedure='newton_cdp')
 
       return

--- a/src/NewtonKrylov.f90
+++ b/src/NewtonKrylov.f90
@@ -148,7 +148,6 @@ contains
       type(newton_sp_metadata) :: newton_meta
       character(len=256) :: msg
       
-      call logger%log_debug('start', module=this_module, procedure='newton_rsp')
       if (time_lightkrylov()) call timer%start('newton_rsp')
       
       ! Newton-solver tolerance
@@ -269,8 +268,7 @@ contains
 
       call sys%reset_eval_counter('newton%post')
       if (time_lightkrylov()) call timer%stop('newton_rsp')
-      call logger%log_debug('end', module=this_module, procedure='newton_rsp')
-
+      
       return
    end subroutine newton_rsp
 
@@ -308,7 +306,6 @@ contains
       type(newton_dp_metadata) :: newton_meta
       character(len=256) :: msg
       
-      call logger%log_debug('start', module=this_module, procedure='newton_rdp')
       if (time_lightkrylov()) call timer%start('newton_rdp')
       
       ! Newton-solver tolerance
@@ -429,8 +426,7 @@ contains
 
       call sys%reset_eval_counter('newton%post')
       if (time_lightkrylov()) call timer%stop('newton_rdp')
-      call logger%log_debug('end', module=this_module, procedure='newton_rdp')
-
+      
       return
    end subroutine newton_rdp
 
@@ -468,7 +464,6 @@ contains
       type(newton_sp_metadata) :: newton_meta
       character(len=256) :: msg
       
-      call logger%log_debug('start', module=this_module, procedure='newton_csp')
       if (time_lightkrylov()) call timer%start('newton_csp')
       
       ! Newton-solver tolerance
@@ -589,8 +584,7 @@ contains
 
       call sys%reset_eval_counter('newton%post')
       if (time_lightkrylov()) call timer%stop('newton_csp')
-      call logger%log_debug('end', module=this_module, procedure='newton_csp')
-
+      
       return
    end subroutine newton_csp
 
@@ -628,7 +622,6 @@ contains
       type(newton_dp_metadata) :: newton_meta
       character(len=256) :: msg
       
-      call logger%log_debug('start', module=this_module, procedure='newton_cdp')
       if (time_lightkrylov()) call timer%start('newton_cdp')
       
       ! Newton-solver tolerance
@@ -749,8 +742,7 @@ contains
 
       call sys%reset_eval_counter('newton%post')
       if (time_lightkrylov()) call timer%stop('newton_cdp')
-      call logger%log_debug('end', module=this_module, procedure='newton_cdp')
-
+      
       return
    end subroutine newton_cdp
 

--- a/src/NewtonKrylov.f90
+++ b/src/NewtonKrylov.f90
@@ -2,6 +2,7 @@ module LightKrylov_NewtonKrylov
    use stdlib_optval, only: optval
    use LightKrylov_Constants
    use LightKrylov_Logger
+   !use LightKrylov_Timer
    use LightKrylov_AbstractVectors
    use LightKrylov_AbstractLinops
    use LightKrylov_AbstractSystems
@@ -109,7 +110,6 @@ module LightKrylov_NewtonKrylov
          !! Information flag
       end subroutine abstract_scheduler_dp
 
-
    end interface
 
 contains
@@ -149,6 +149,10 @@ contains
       character(len=256) :: msg
       
       call logger%log_debug('start', module=this_module, procedure='newton_rsp')
+      !if (timeit()) call global_timer%start('newton_rsp')
+      !print *, timeit()
+      !call initialize_timers()
+      
       ! Newton-solver tolerance
       target_tol = optval(tolerance, atol_sp)
       ! Newton-Krylov options
@@ -266,6 +270,7 @@ contains
       end if
 
       call sys%reset_eval_counter('newton%post')
+      !if (timeit()) call global_timer%stop('newton_rsp')
       call logger%log_debug('end', module=this_module, procedure='newton_rsp')
 
       return
@@ -306,6 +311,10 @@ contains
       character(len=256) :: msg
       
       call logger%log_debug('start', module=this_module, procedure='newton_rdp')
+      !if (timeit()) call global_timer%start('newton_rdp')
+      !print *, timeit()
+      !call initialize_timers()
+      
       ! Newton-solver tolerance
       target_tol = optval(tolerance, atol_dp)
       ! Newton-Krylov options
@@ -423,6 +432,7 @@ contains
       end if
 
       call sys%reset_eval_counter('newton%post')
+      !if (timeit()) call global_timer%stop('newton_rdp')
       call logger%log_debug('end', module=this_module, procedure='newton_rdp')
 
       return
@@ -463,6 +473,10 @@ contains
       character(len=256) :: msg
       
       call logger%log_debug('start', module=this_module, procedure='newton_csp')
+      !if (timeit()) call global_timer%start('newton_csp')
+      !print *, timeit()
+      !call initialize_timers()
+      
       ! Newton-solver tolerance
       target_tol = optval(tolerance, atol_sp)
       ! Newton-Krylov options
@@ -580,6 +594,7 @@ contains
       end if
 
       call sys%reset_eval_counter('newton%post')
+      !if (timeit()) call global_timer%stop('newton_csp')
       call logger%log_debug('end', module=this_module, procedure='newton_csp')
 
       return
@@ -620,6 +635,10 @@ contains
       character(len=256) :: msg
       
       call logger%log_debug('start', module=this_module, procedure='newton_cdp')
+      !if (timeit()) call global_timer%start('newton_cdp')
+      !print *, timeit()
+      !call initialize_timers()
+      
       ! Newton-solver tolerance
       target_tol = optval(tolerance, atol_dp)
       ! Newton-Krylov options
@@ -737,6 +756,7 @@ contains
       end if
 
       call sys%reset_eval_counter('newton%post')
+      !if (timeit()) call global_timer%stop('newton_cdp')
       call logger%log_debug('end', module=this_module, procedure='newton_cdp')
 
       return

--- a/src/NewtonKrylov.f90
+++ b/src/NewtonKrylov.f90
@@ -148,6 +148,7 @@ contains
       type(newton_sp_metadata) :: newton_meta
       character(len=256) :: msg
       
+      call logger%log_debug('start', module=this_module, procedure='newton_rsp')
       ! Newton-solver tolerance
       target_tol = optval(tolerance, atol_sp)
       ! Newton-Krylov options
@@ -265,6 +266,7 @@ contains
       end if
 
       call sys%reset_eval_counter('newton%post')
+      call logger%log_debug('end', module=this_module, procedure='newton_rsp')
 
       return
    end subroutine newton_rsp
@@ -303,6 +305,7 @@ contains
       type(newton_dp_metadata) :: newton_meta
       character(len=256) :: msg
       
+      call logger%log_debug('start', module=this_module, procedure='newton_rdp')
       ! Newton-solver tolerance
       target_tol = optval(tolerance, atol_dp)
       ! Newton-Krylov options
@@ -420,6 +423,7 @@ contains
       end if
 
       call sys%reset_eval_counter('newton%post')
+      call logger%log_debug('end', module=this_module, procedure='newton_rdp')
 
       return
    end subroutine newton_rdp
@@ -458,6 +462,7 @@ contains
       type(newton_sp_metadata) :: newton_meta
       character(len=256) :: msg
       
+      call logger%log_debug('start', module=this_module, procedure='newton_csp')
       ! Newton-solver tolerance
       target_tol = optval(tolerance, atol_sp)
       ! Newton-Krylov options
@@ -575,6 +580,7 @@ contains
       end if
 
       call sys%reset_eval_counter('newton%post')
+      call logger%log_debug('end', module=this_module, procedure='newton_csp')
 
       return
    end subroutine newton_csp
@@ -613,6 +619,7 @@ contains
       type(newton_dp_metadata) :: newton_meta
       character(len=256) :: msg
       
+      call logger%log_debug('start', module=this_module, procedure='newton_cdp')
       ! Newton-solver tolerance
       target_tol = optval(tolerance, atol_dp)
       ! Newton-Krylov options
@@ -730,6 +737,7 @@ contains
       end if
 
       call sys%reset_eval_counter('newton%post')
+      call logger%log_debug('end', module=this_module, procedure='newton_cdp')
 
       return
    end subroutine newton_cdp

--- a/src/NewtonKrylov.f90
+++ b/src/NewtonKrylov.f90
@@ -2,7 +2,7 @@ module LightKrylov_NewtonKrylov
    use stdlib_optval, only: optval
    use LightKrylov_Constants
    use LightKrylov_Logger
-   !use LightKrylov_Timer
+   use LightKrylov_Timer
    use LightKrylov_AbstractVectors
    use LightKrylov_AbstractLinops
    use LightKrylov_AbstractSystems
@@ -149,9 +149,7 @@ contains
       character(len=256) :: msg
       
       call logger%log_debug('start', module=this_module, procedure='newton_rsp')
-      !if (timeit()) call global_timer%start('newton_rsp')
-      !print *, timeit()
-      !call initialize_timers()
+      !if (time_lightkrylov()) call global_timer%start('newton_rsp')
       
       ! Newton-solver tolerance
       target_tol = optval(tolerance, atol_sp)
@@ -270,7 +268,7 @@ contains
       end if
 
       call sys%reset_eval_counter('newton%post')
-      !if (timeit()) call global_timer%stop('newton_rsp')
+      !if (time_lightkrylov()) call global_timer%stop('newton_rsp')
       call logger%log_debug('end', module=this_module, procedure='newton_rsp')
 
       return
@@ -311,9 +309,7 @@ contains
       character(len=256) :: msg
       
       call logger%log_debug('start', module=this_module, procedure='newton_rdp')
-      !if (timeit()) call global_timer%start('newton_rdp')
-      !print *, timeit()
-      !call initialize_timers()
+      !if (time_lightkrylov()) call global_timer%start('newton_rdp')
       
       ! Newton-solver tolerance
       target_tol = optval(tolerance, atol_dp)
@@ -432,7 +428,7 @@ contains
       end if
 
       call sys%reset_eval_counter('newton%post')
-      !if (timeit()) call global_timer%stop('newton_rdp')
+      !if (time_lightkrylov()) call global_timer%stop('newton_rdp')
       call logger%log_debug('end', module=this_module, procedure='newton_rdp')
 
       return
@@ -473,9 +469,7 @@ contains
       character(len=256) :: msg
       
       call logger%log_debug('start', module=this_module, procedure='newton_csp')
-      !if (timeit()) call global_timer%start('newton_csp')
-      !print *, timeit()
-      !call initialize_timers()
+      !if (time_lightkrylov()) call global_timer%start('newton_csp')
       
       ! Newton-solver tolerance
       target_tol = optval(tolerance, atol_sp)
@@ -594,7 +588,7 @@ contains
       end if
 
       call sys%reset_eval_counter('newton%post')
-      !if (timeit()) call global_timer%stop('newton_csp')
+      !if (time_lightkrylov()) call global_timer%stop('newton_csp')
       call logger%log_debug('end', module=this_module, procedure='newton_csp')
 
       return
@@ -635,9 +629,7 @@ contains
       character(len=256) :: msg
       
       call logger%log_debug('start', module=this_module, procedure='newton_cdp')
-      !if (timeit()) call global_timer%start('newton_cdp')
-      !print *, timeit()
-      !call initialize_timers()
+      !if (time_lightkrylov()) call global_timer%start('newton_cdp')
       
       ! Newton-solver tolerance
       target_tol = optval(tolerance, atol_dp)
@@ -756,7 +748,7 @@ contains
       end if
 
       call sys%reset_eval_counter('newton%post')
-      !if (timeit()) call global_timer%stop('newton_cdp')
+      !if (time_lightkrylov()) call global_timer%stop('newton_cdp')
       call logger%log_debug('end', module=this_module, procedure='newton_cdp')
 
       return

--- a/src/NewtonKrylov.fypp
+++ b/src/NewtonKrylov.fypp
@@ -137,7 +137,6 @@ contains
       type(newton_${kind}$_metadata) :: newton_meta
       character(len=256) :: msg
       
-      call logger%log_debug('start', module=this_module, procedure='newton_${type[0]}$${kind}$')
       if (time_lightkrylov()) call timer%start('newton_${type[0]}$${kind}$')
       
       ! Newton-solver tolerance
@@ -258,8 +257,7 @@ contains
 
       call sys%reset_eval_counter('newton%post')
       if (time_lightkrylov()) call timer%stop('newton_${type[0]}$${kind}$')
-      call logger%log_debug('end', module=this_module, procedure='newton_${type[0]}$${kind}$')
-
+      
       return
    end subroutine newton_${type[0]}$${kind}$
 

--- a/src/NewtonKrylov.fypp
+++ b/src/NewtonKrylov.fypp
@@ -137,6 +137,7 @@ contains
       type(newton_${kind}$_metadata) :: newton_meta
       character(len=256) :: msg
       
+      call logger%log_debug('start', module=this_module, procedure='newton_${type[0]}$${kind}$')
       ! Newton-solver tolerance
       target_tol = optval(tolerance, atol_${kind}$)
       ! Newton-Krylov options
@@ -254,6 +255,7 @@ contains
       end if
 
       call sys%reset_eval_counter('newton%post')
+      call logger%log_debug('end', module=this_module, procedure='newton_${type[0]}$${kind}$')
 
       return
    end subroutine newton_${type[0]}$${kind}$

--- a/src/NewtonKrylov.fypp
+++ b/src/NewtonKrylov.fypp
@@ -4,7 +4,7 @@ module LightKrylov_NewtonKrylov
    use stdlib_optval, only: optval
    use LightKrylov_Constants
    use LightKrylov_Logger
-   use LightKrylov_Timer
+   use LightKrylov_Timing, only: timer => global_lightkrylov_timer, time_lightkrylov
    use LightKrylov_AbstractVectors
    use LightKrylov_AbstractLinops
    use LightKrylov_AbstractSystems
@@ -138,7 +138,7 @@ contains
       character(len=256) :: msg
       
       call logger%log_debug('start', module=this_module, procedure='newton_${type[0]}$${kind}$')
-      !if (time_lightkrylov()) call global_timer%start('newton_${type[0]}$${kind}$')
+      if (time_lightkrylov()) call timer%start('newton_${type[0]}$${kind}$')
       
       ! Newton-solver tolerance
       target_tol = optval(tolerance, atol_${kind}$)
@@ -257,7 +257,7 @@ contains
       end if
 
       call sys%reset_eval_counter('newton%post')
-      !if (time_lightkrylov()) call global_timer%stop('newton_${type[0]}$${kind}$')
+      if (time_lightkrylov()) call timer%stop('newton_${type[0]}$${kind}$')
       call logger%log_debug('end', module=this_module, procedure='newton_${type[0]}$${kind}$')
 
       return

--- a/src/NewtonKrylov.fypp
+++ b/src/NewtonKrylov.fypp
@@ -4,7 +4,7 @@ module LightKrylov_NewtonKrylov
    use stdlib_optval, only: optval
    use LightKrylov_Constants
    use LightKrylov_Logger
-   !use LightKrylov_Timer
+   use LightKrylov_Timer
    use LightKrylov_AbstractVectors
    use LightKrylov_AbstractLinops
    use LightKrylov_AbstractSystems
@@ -138,9 +138,7 @@ contains
       character(len=256) :: msg
       
       call logger%log_debug('start', module=this_module, procedure='newton_${type[0]}$${kind}$')
-      !if (timeit()) call global_timer%start('newton_${type[0]}$${kind}$')
-      !print *, timeit()
-      !call initialize_timers()
+      !if (time_lightkrylov()) call global_timer%start('newton_${type[0]}$${kind}$')
       
       ! Newton-solver tolerance
       target_tol = optval(tolerance, atol_${kind}$)
@@ -259,7 +257,7 @@ contains
       end if
 
       call sys%reset_eval_counter('newton%post')
-      !if (timeit()) call global_timer%stop('newton_${type[0]}$${kind}$')
+      !if (time_lightkrylov()) call global_timer%stop('newton_${type[0]}$${kind}$')
       call logger%log_debug('end', module=this_module, procedure='newton_${type[0]}$${kind}$')
 
       return

--- a/src/NewtonKrylov.fypp
+++ b/src/NewtonKrylov.fypp
@@ -4,6 +4,7 @@ module LightKrylov_NewtonKrylov
    use stdlib_optval, only: optval
    use LightKrylov_Constants
    use LightKrylov_Logger
+   !use LightKrylov_Timer
    use LightKrylov_AbstractVectors
    use LightKrylov_AbstractLinops
    use LightKrylov_AbstractSystems
@@ -97,7 +98,6 @@ module LightKrylov_NewtonKrylov
       end subroutine abstract_scheduler_${kind}$
 
       #:endfor
-
    end interface
 
 contains
@@ -138,6 +138,10 @@ contains
       character(len=256) :: msg
       
       call logger%log_debug('start', module=this_module, procedure='newton_${type[0]}$${kind}$')
+      !if (timeit()) call global_timer%start('newton_${type[0]}$${kind}$')
+      !print *, timeit()
+      !call initialize_timers()
+      
       ! Newton-solver tolerance
       target_tol = optval(tolerance, atol_${kind}$)
       ! Newton-Krylov options
@@ -255,6 +259,7 @@ contains
       end if
 
       call sys%reset_eval_counter('newton%post')
+      !if (timeit()) call global_timer%stop('newton_${type[0]}$${kind}$')
       call logger%log_debug('end', module=this_module, procedure='newton_${type[0]}$${kind}$')
 
       return

--- a/src/TestUtils.f90
+++ b/src/TestUtils.f90
@@ -11,8 +11,8 @@ module LightKrylov_TestUtils
     
     private
 
-    character(len=*), parameter, private :: this_module      = 'LK_TUtils'
-    character(len=*), parameter, private :: this_module_long = 'LightKrylov_TestUtils'
+    character(len=*), parameter :: this_module      = 'LK_TUtils'
+    character(len=*), parameter :: this_module_long = 'LightKrylov_TestUtils'
 
     integer, parameter, public :: test_size = 128
 

--- a/src/TestUtils.fypp
+++ b/src/TestUtils.fypp
@@ -13,8 +13,8 @@ module LightKrylov_TestUtils
     
     private
 
-    character(len=*), parameter, private :: this_module      = 'LK_TUtils'
-    character(len=*), parameter, private :: this_module_long = 'LightKrylov_TestUtils'
+    character(len=*), parameter :: this_module      = 'LK_TUtils'
+    character(len=*), parameter :: this_module_long = 'LightKrylov_TestUtils'
 
     integer, parameter, public :: test_size = 128
 

--- a/src/Timer.f90
+++ b/src/Timer.f90
@@ -1,0 +1,322 @@
+module LightKrylov_Timer
+   use LightKrylov_Constants, only: dp
+   use LightKrylov_Logger
+   implicit none
+   private
+   character(len=128), parameter :: this_module = 'LightKrylov_Timer'
+   logical :: if_time = .false.
+
+   public :: initialize_timers, enumerate_timers, finalize_timers
+   public :: timeit
+
+   ! Timer type
+   type, public :: timer_type
+      private
+      character(len=128) :: name
+      real(dp) :: elapsed_time = 0.0_dp
+      real(dp) :: start_time = 0.0_dp
+      logical :: running = .false.
+      integer :: count = 0
+   contains
+      procedure, pass(self), public :: start => start_timer
+      procedure, pass(self), public :: stop => stop_timer
+      procedure, pass(self), public :: pause => pause_timer
+      procedure, pass(self), public :: reset => reset_timer
+      procedure, pass(self), public :: get_time => get_timer_time
+   end type timer_type
+
+   ! Watch type
+   type :: watch_type
+      private
+      type(timer_type), dimension(:), allocatable :: timers
+      integer :: timer_count = 0
+      integer :: private_count = 0
+   contains
+      procedure, pass(self), public :: add_timer
+      procedure, pass(self), public :: remove_timer
+      procedure, pass(self), public :: enumerate_timers
+      procedure, pass(self), public :: start => start_timer_by_name
+      procedure, pass(self), public :: stop => stop_timer_by_name
+      procedure, pass(self), public :: pause => pause_timer_by_name
+      procedure, pass(self), public :: reset => reset_timer_by_name
+   end type watch_type
+
+   type(watch_type), public :: global_timer
+
+contains
+
+   function timeit() result(if_time_lightkrylov)
+      logical :: if_time_lightkrylov
+      if_time_lightkrylov = if_time
+   end function timeit
+
+   subroutine initialize_timers()
+      ! timers for LightKrylov_BaseKrylov
+      ! rsp
+      !call global_timer%add_timer('QR_with_pivoting_rsp')
+      !call global_timer%add_timer('QR_no_pivoting_rsp')
+      !call global_timer%add_timer('Orthonormalize_basis_rsp')
+      !call global_timer%add_timer('Orthonormalize_vector_against_basis_rsp')
+      !call global_timer%add_timer('Orthonormalize_basis_against_basis_rsp')
+      !call global_timer%add_timer('DGS_vector_against_basis_rsp')
+      !call global_timer%add_timer('DGS_basis_against_basis_rsp')
+      !#:endfor
+      ! timers for LightKrylov_IterativeSolvers
+      !#:for kind, type in RC_KINDS_TYPES
+      ! rsp
+      !call global_timer%add_timer('eigs_rsp')
+      !call global_timer%add_timer('eighs_rsp')
+      call global_timer%add_timer('svds_rsp')
+      call global_timer%add_timer('gmres_rsp')
+      !call global_timer%add_timer('fgmres_rsp')
+      !call global_timer%add_timer('cg_rsp')
+      ! rdp
+      !call global_timer%add_timer('QR_with_pivoting_rdp')
+      !call global_timer%add_timer('QR_no_pivoting_rdp')
+      !call global_timer%add_timer('Orthonormalize_basis_rdp')
+      !call global_timer%add_timer('Orthonormalize_vector_against_basis_rdp')
+      !call global_timer%add_timer('Orthonormalize_basis_against_basis_rdp')
+      !call global_timer%add_timer('DGS_vector_against_basis_rdp')
+      !call global_timer%add_timer('DGS_basis_against_basis_rdp')
+      !#:endfor
+      ! timers for LightKrylov_IterativeSolvers
+      !#:for kind, type in RC_KINDS_TYPES
+      ! rdp
+      !call global_timer%add_timer('eigs_rdp')
+      !call global_timer%add_timer('eighs_rdp')
+      call global_timer%add_timer('svds_rdp')
+      call global_timer%add_timer('gmres_rdp')
+      !call global_timer%add_timer('fgmres_rdp')
+      !call global_timer%add_timer('cg_rdp')
+      ! csp
+      !call global_timer%add_timer('QR_with_pivoting_csp')
+      !call global_timer%add_timer('QR_no_pivoting_csp')
+      !call global_timer%add_timer('Orthonormalize_basis_csp')
+      !call global_timer%add_timer('Orthonormalize_vector_against_basis_csp')
+      !call global_timer%add_timer('Orthonormalize_basis_against_basis_csp')
+      !call global_timer%add_timer('DGS_vector_against_basis_csp')
+      !call global_timer%add_timer('DGS_basis_against_basis_csp')
+      !#:endfor
+      ! timers for LightKrylov_IterativeSolvers
+      !#:for kind, type in RC_KINDS_TYPES
+      ! csp
+      !call global_timer%add_timer('eigs_csp')
+      !call global_timer%add_timer('eighs_csp')
+      call global_timer%add_timer('svds_csp')
+      call global_timer%add_timer('gmres_csp')
+      !call global_timer%add_timer('fgmres_csp')
+      !call global_timer%add_timer('cg_csp')
+      ! cdp
+      !call global_timer%add_timer('QR_with_pivoting_cdp')
+      !call global_timer%add_timer('QR_no_pivoting_cdp')
+      !call global_timer%add_timer('Orthonormalize_basis_cdp')
+      !call global_timer%add_timer('Orthonormalize_vector_against_basis_cdp')
+      !call global_timer%add_timer('Orthonormalize_basis_against_basis_cdp')
+      !call global_timer%add_timer('DGS_vector_against_basis_cdp')
+      !call global_timer%add_timer('DGS_basis_against_basis_cdp')
+      !#:endfor
+      ! timers for LightKrylov_IterativeSolvers
+      !#:for kind, type in RC_KINDS_TYPES
+      ! cdp
+      !call global_timer%add_timer('eigs_cdp')
+      !call global_timer%add_timer('eighs_cdp')
+      call global_timer%add_timer('svds_cdp')
+      call global_timer%add_timer('gmres_cdp')
+      !call global_timer%add_timer('fgmres_cdp')
+      !call global_timer%add_timer('cg_cdp')
+      ! timers for LightKrylov_NewtonKrylov
+      ! rsp
+      call global_timer%add_timer('newton_rsp')
+      ! rdp
+      call global_timer%add_timer('newton_rdp')
+      ! csp
+      call global_timer%add_timer('newton_csp')
+      ! cdp
+      call global_timer%add_timer('newton_cdp')
+      global_timer%private_count = global_timer%timer_count
+      if_time = .true.
+   end subroutine initialize_timers
+
+   subroutine finalize_timers()
+      ! internal
+      integer :: i
+      do i = 1, global_timer%timer_count
+         call global_timer%timers(i)%stop()
+      end do
+      if_time = .false.
+      do i = 1, global_timer%timer_count
+         print *, trim(global_timer%timers(i)%name), ':', global_timer%timers(i)%count, global_timer%timers(i)%get_time()
+      end do
+   end subroutine finalize_timers
+
+   subroutine start_timer(self)
+      class(timer_type), intent(inout) :: self
+      if (.not. self%running) then
+         call cpu_time(self%start_time)
+         self%running = .true.
+      end if
+   end subroutine start_timer
+
+   subroutine stop_timer(self)
+      class(timer_type), intent(inout) :: self
+      ! internal
+      real(dp) :: t_now
+      call cpu_time(t_now)
+      if (self%running) then
+         self%elapsed_time = self%elapsed_time + (t_now - self%start_time)
+         self%count = self%count + 1
+         self%running = .false.
+      end if
+   end subroutine stop_timer
+
+   subroutine pause_timer(self)
+      class(timer_type), intent(inout) :: self
+      ! internal
+      real(dp) :: t_now
+      call cpu_time(t_now)
+      if (self%running) then
+         self%elapsed_time = self%elapsed_time + (t_now - self%start_time)
+         self%running = .false.
+      end if
+   end subroutine pause_timer
+
+   subroutine reset_timer(self)
+      class(timer_type), intent(inout) :: self
+      self%elapsed_time = 0.0_dp
+      self%start_time = 0.0_dp
+      self%running = .false.
+      self%count = 0
+   end subroutine reset_timer
+
+   real(dp) function get_timer_time(self) result(etime)
+      class(timer_type), intent(inout) :: self
+      if (self%running) then
+         call self%stop()
+      end if
+      etime = self%elapsed_time
+   end function
+
+   subroutine add_timer(self, name)
+      class(watch_type), intent(inout) :: self
+      character(len=*), intent(in) :: name
+      ! internal
+      integer :: i
+      if (self%timer_count == 0) then
+         allocate(self%timers(1))
+         self%timers(1) = timer_type(name)
+         self%timer_count = 1
+      else
+         do i = 1, self%timer_count
+            if (self%timers(i)%name == name) then
+               call stop_error('Timer "'//trim(name)//'" already defined!', module=this_module, procedure='add_timer')
+            end if
+         end do
+         self%timers = [ self%timers, timer_type(name) ]
+         self%timer_count = self%timer_count + 1
+      end if
+   end subroutine add_timer
+
+   subroutine remove_timer(self, name)
+      class(watch_type), intent(inout) :: self
+      character(len=*), intent(in) :: name
+      ! internal
+      type(timer_type), dimension(:), allocatable :: new_timers
+      integer :: i, i_rm
+      logical :: found
+      found = .false.
+      do i = 1, self%timer_count
+         if (self%timers(i)%name == name) then
+            i_rm = i
+            found = .true.
+         end if
+      end do
+      if (.not. found) then
+         call stop_error('Timer "'//trim(name)//'" not defined!', module=this_module, procedure='remove_timer')
+      else
+         if (i_rm <= self%private_count) then
+            call logger%log_message('Cannot remove private timer "'//trim(name)//'".', module=this_module, procedure='remove_timer')
+         else
+            self%timer_count = self%timer_count - 1
+            allocate(new_timers(self%timer_count))
+            new_timers(1:i_rm-1) = self%timers(1:i_rm-1)
+            new_timers(i_rm:)    = self%timers(i_rm+1:)
+            deallocate(self%timers)
+            self%timers = new_timers
+         end if
+      end if
+   end subroutine remove_timer
+
+   subroutine enumerate_timers(self)
+      class(watch_type), intent(in) :: self
+      ! internal
+      integer :: i
+      do i = 1, self%timer_count
+         print *, 'Timer', i, ':', trim(self%timers(i)%name)
+      end do
+   end subroutine
+   
+   subroutine start_timer_by_name(self, name)
+      class(watch_type), intent(inout) :: self
+      character(len=*), intent(in) :: name
+      ! internal
+      integer :: i
+      logical :: found
+      found = .false.
+      do i = 1, self%timer_count
+         if (self%timers(i)%name == name) then
+            call self%timers(i)%start()
+            found = .true.
+         end if
+      end do
+      if (.not. found) call stop_error('Timer "'//trim(name)//'" not found!', module=this_module, procedure='start_timer_by_name')
+   end subroutine start_timer_by_name
+
+   subroutine stop_timer_by_name(self, name)
+      class(watch_type), intent(inout) :: self
+      character(len=*), intent(in) :: name
+      ! internal
+      integer :: i
+      logical :: found
+      found = .false.
+      do i = 1, self%timer_count
+         if (self%timers(i)%name == name) then
+            call self%timers(i)%stop()
+            found = .true.
+         end if
+      end do
+      if (.not. found) call stop_error('Timer "'//trim(name)//'" not found!', module=this_module, procedure='stop_timer_by_name')
+   end subroutine stop_timer_by_name
+
+   subroutine pause_timer_by_name(self, name)
+      class(watch_type), intent(inout) :: self
+      character(len=*), intent(in) :: name
+      ! internal
+      integer :: i
+      logical :: found
+      found = .false.
+      do i = 1, self%timer_count
+         if (self%timers(i)%name == name) then
+            call self%timers(i)%pause()
+            found = .true.
+         end if
+      end do
+      if (.not. found) call stop_error('Timer "'//trim(name)//'" not found!', module=this_module, procedure='pause_timer_by_name')
+   end subroutine
+
+   subroutine reset_timer_by_name(self, name)
+      class(watch_type), intent(inout) :: self
+      character(len=*), intent(in) :: name
+      ! internal
+      integer :: i
+      logical :: found
+      found = .false.
+      do i = 1, self%timer_count
+         if (self%timers(i)%name == name) then
+            call self%timers(i)%reset()
+            found = .true.
+         end if
+      end do
+      if (.not. found) call stop_error('Timer "'//trim(name)//'" not found!', module=this_module, procedure='reset_timer_by_name')
+   end subroutine
+
+end module LightKrylov_Timer

--- a/src/Timer.f90
+++ b/src/Timer.f90
@@ -1,19 +1,21 @@
-module LightKrylov_Timer
+module LightKrylov_Timing
    use stdlib_optval, only: optval
+   use stdlib_ascii, only: to_lower
    use LightKrylov_Constants, only: dp
    use LightKrylov_Logger
    implicit none
    private
-   character(len=128), parameter :: this_module = 'LightKrylov_Timer'
+   character(len=*), parameter :: this_module      = 'LK_Timer'
+   character(len=*), parameter :: this_module_long = 'LightKrylov_Timer'
    logical :: if_time = .false.
 
    public :: time_lightkrylov
-   public :: global_timer
+   public :: global_lightkrylov_timer
 
    ! Timer type
-   type, public :: timer_type
+   type, public :: lightkrylov_timer
       private
-      character(len=128) :: name
+      character(len=128), public :: name = 'default_timer'
       real(dp) :: elapsed_time = 0.0_dp
       real(dp) :: start_time = 0.0_dp
       logical :: running = .false.
@@ -24,12 +26,13 @@ module LightKrylov_Timer
       procedure, pass(self), public :: pause => pause_timer
       procedure, pass(self), public :: reset => reset_timer
       procedure, pass(self), public :: get_time => get_timer_time
-   end type timer_type
+      procedure, pass(self), public :: print_info => print_timer_info
+   end type lightkrylov_timer
 
    ! Watch type
-   type :: watch_type
+   type :: lightkrylov_watch
       private
-      type(timer_type), dimension(:), allocatable :: timers
+      type(lightkrylov_timer), dimension(:), allocatable :: timers
       integer :: timer_count = 0
       integer :: basekrylov_count = 0
       integer :: iterativesolvers_count = 0
@@ -43,24 +46,31 @@ module LightKrylov_Timer
       procedure, pass(self), public :: get_timer_id
       procedure, pass(self), public :: initialize
       procedure, pass(self), public :: enumerate
-      procedure, pass(self), public :: finalize
+      procedure, pass(self), public :: finalize => finalize_watch
       procedure, pass(self), public :: start => start_timer_by_name
       procedure, pass(self), public :: stop => stop_timer_by_name
       procedure, pass(self), public :: pause => pause_timer_by_name
       procedure, pass(self), public :: reset => reset_timer_by_name
-   end type watch_type
+   end type lightkrylov_watch
 
-   type(watch_type) :: global_timer
+   type(lightkrylov_watch) :: global_lightkrylov_timer
 
 contains
 
-   function time_lightkrylov() result(if_time_lightkrylov)
-      logical :: if_time_lightkrylov
+   !--------------------------------------------------------------
+   !  Getter routine to determine whether timing is turned on/off
+   !--------------------------------------------------------------
+
+   logical function time_lightkrylov() result(if_time_lightkrylov)
       if_time_lightkrylov = if_time
    end function time_lightkrylov
 
+   !--------------------------------------------------------------
+   !  Type-bound procedures for lightkrylov_timer type
+   !--------------------------------------------------------------
+
    subroutine start_timer(self)
-      class(timer_type), intent(inout) :: self
+      class(lightkrylov_timer), intent(inout) :: self
       if (.not. self%running) then
          call cpu_time(self%start_time)
          self%running = .true.
@@ -69,7 +79,7 @@ contains
    end subroutine start_timer
 
    subroutine stop_timer(self)
-      class(timer_type), intent(inout) :: self
+      class(lightkrylov_timer), intent(inout) :: self
       ! internal
       real(dp) :: t_now
       call cpu_time(t_now)
@@ -80,7 +90,7 @@ contains
    end subroutine stop_timer
 
    subroutine pause_timer(self)
-      class(timer_type), intent(inout) :: self
+      class(lightkrylov_timer), intent(inout) :: self
       ! internal
       real(dp) :: t_now
       call cpu_time(t_now)
@@ -91,7 +101,7 @@ contains
    end subroutine pause_timer
 
    subroutine reset_timer(self)
-      class(timer_type), intent(inout) :: self
+      class(lightkrylov_timer), intent(inout) :: self
       self%elapsed_time = 0.0_dp
       self%start_time = 0.0_dp
       self%running = .false.
@@ -99,55 +109,79 @@ contains
    end subroutine reset_timer
 
    real(dp) function get_timer_time(self) result(etime)
-      class(timer_type), intent(inout) :: self
+      class(lightkrylov_timer), intent(inout) :: self
       if (self%running) then
          call self%stop()
       end if
       etime = self%elapsed_time
    end function
 
+   subroutine print_timer_info(self)
+      class(lightkrylov_timer), intent(inout) :: self
+      ! internal
+      integer :: i, j, icalled
+      integer :: ic_bk, ic_is, ic_nk, ic_user
+      character(len=128) :: msg
+      icalled = 0
+      call logger%log_message('###################        Timer summary        #################', module=this_module)
+      call logger%log_message('Name: '//trim(self%name), module=this_module)
+      call logger%log_message('________________________________________________', module=this_module)
+      write(msg,'(2X,A20,I8)') 'Count: ', self%count
+      call logger%log_message(msg, module=this_module)
+      write(msg,'(2X,A20,F12.8)') 'Total time (s): ', self%get_time()
+      call logger%log_message(msg, module=this_module)
+      write(msg,'(2X,A20,F12.8)') 'Average (s): ', self%get_time()/self%count
+      call logger%log_message(msg, module=this_module)
+      call logger%log_message('###################        Timer summary        #################', module=this_module)
+   end subroutine print_timer_info
+
+   !--------------------------------------------------------------
+   !  Type-bound procedures for lightkrylov_watch type
+   !--------------------------------------------------------------
+
    integer function get_timer_id(self, name) result(id)
-      class(watch_type) :: self
+      class(lightkrylov_watch) :: self
       character(len=*)  :: name
       ! internal
       integer :: i
       id = 0
       do i = 1, self%timer_count
-         if (self%timers(i)%name == name) then
+         if (self%timers(i)%name == to_lower(name)) then
             id = i
          end if
       end do
    end function get_timer_id
 
    subroutine add_timer(self, name)
-      class(watch_type), intent(inout) :: self
+      class(lightkrylov_watch), intent(inout) :: self
       character(len=*), intent(in) :: name
       if (self%timer_count == 0) then
          allocate(self%timers(1))
-         self%timers(1) = timer_type(name)
+         self%timers(1) = lightkrylov_timer(to_lower(name))
          self%timer_count = 1
       else
          if (self%get_timer_id(name) > 0) then
-            call stop_error('Timer "'//trim(name)//'" already defined!', module=this_module, procedure='add_timer')
+            call stop_error('Timer "'//to_lower(trim(name))//'" already defined!', module=this_module, procedure='add_timer')
          end if
-         self%timers = [ self%timers, timer_type(name) ]
+         self%timers = [ self%timers, lightkrylov_timer(name) ]
          self%timer_count = self%timer_count + 1
          if (self%user_mode) self%user_count = self%user_count + 1
       end if
+      call logger%log_debug('Timer "'//to_lower(trim(name))//'" added.', module=this_module)
    end subroutine add_timer
 
    subroutine remove_timer(self, name)
-      class(watch_type), intent(inout) :: self
+      class(lightkrylov_watch), intent(inout) :: self
       character(len=*), intent(in) :: name
       ! internal
-      type(timer_type), dimension(:), allocatable :: new_timers
+      type(lightkrylov_timer), dimension(:), allocatable :: new_timers
       integer :: id
       id = self%get_timer_id(name)
       if (id == 0) then
-         call stop_error('Timer "'//trim(name)//'" not defined!', module=this_module, procedure='remove_timer')
+         call stop_error('Timer "'//to_lower(trim(name))//'" not defined!', module=this_module, procedure='remove_timer')
       else
          if (id <= self%private_count) then
-            call logger%log_message('Cannot remove private timer "'//trim(name)//'".', module=this_module, procedure='remove_timer')
+            call logger%log_message('Cannot remove private timer "'//to_lower(trim(name))//'".', module=this_module, procedure='remove_timer')
          else
             self%timer_count = self%timer_count - 1
             allocate(new_timers(self%timer_count))
@@ -157,62 +191,66 @@ contains
             self%timers = new_timers
          end if
       end if
+      call logger%log_debug('Timer "'//to_lower(trim(name))//'" removed.', module=this_module)
    end subroutine remove_timer
    
    subroutine start_timer_by_name(self, name)
-      class(watch_type), intent(inout) :: self
+      class(lightkrylov_watch), intent(inout) :: self
       character(len=*), intent(in) :: name
       ! internal
       integer :: id
       id = self%get_timer_id(name)
       if (id == 0) then 
-         call stop_error('Timer "'//trim(name)//'" not found!', module=this_module, procedure='start_timer_by_name')
+         call stop_error('Timer "'//to_lower(trim(name))//'" not found!', module=this_module, procedure='start_timer_by_name')
       else
          call self%timers(id)%start()
       end if
+      call logger%log_debug('Timer "'//to_lower(trim(name))//'" started.', module=this_module)
    end subroutine start_timer_by_name
 
    subroutine stop_timer_by_name(self, name)
-      class(watch_type), intent(inout) :: self
+      class(lightkrylov_watch), intent(inout) :: self
       character(len=*), intent(in) :: name
       ! internal
       integer :: id
       id = self%get_timer_id(name)
       if (id == 0) then 
-         call stop_error('Timer "'//trim(name)//'" not found!', module=this_module, procedure='start_timer_by_name')
+         call stop_error('Timer "'//to_lower(trim(name))//'" not found!', module=this_module, procedure='start_timer_by_name')
       else
          call self%timers(id)%stop()
       end if
+      call logger%log_debug('Timer "'//to_lower(trim(name))//'" stopped.', module=this_module)
    end subroutine stop_timer_by_name
 
    subroutine pause_timer_by_name(self, name)
-      class(watch_type), intent(inout) :: self
+      class(lightkrylov_watch), intent(inout) :: self
       character(len=*), intent(in) :: name
       ! internal
       integer :: id
       id = self%get_timer_id(name)
       if (id == 0) then 
-         call stop_error('Timer "'//trim(name)//'" not found!', module=this_module, procedure='start_timer_by_name')
+         call stop_error('Timer "'//to_lower(trim(name))//'" not found!', module=this_module, procedure='start_timer_by_name')
       else
          call self%timers(id)%start()
       end if
+      call logger%log_debug('Timer "'//to_lower(trim(name))//'" paused.', module=this_module)
    end subroutine
 
    subroutine reset_timer_by_name(self, name)
-      class(watch_type), intent(inout) :: self
+      class(lightkrylov_watch), intent(inout) :: self
       character(len=*), intent(in) :: name
       ! internal
       integer :: id
       id = self%get_timer_id(name)
       if (id == 0) then 
-         call stop_error('Timer "'//trim(name)//'" not found!', module=this_module, procedure='start_timer_by_name')
+         call stop_error('Timer "'//to_lower(trim(name))//'" not found!', module=this_module, procedure='start_timer_by_name')
       else
          call self%timers(id)%start()
       end if
    end subroutine
 
    subroutine enumerate(self, only_user)
-      class(watch_type), intent(in) :: self
+      class(lightkrylov_watch), intent(in) :: self
       logical, optional, intent(in) :: only_user
       ! internal
       integer :: i
@@ -220,57 +258,59 @@ contains
       character(len=128) :: msg
       only_user_ = optval(only_user, .true.)
       if (.not. only_user_) then
-         call logger%log_message('Registered timers: default', module=this_module)
+         call logger%log_message('Registered timers: all', module=this_module)
          do i = 1, self%private_count
             write(msg,'(4X,I4,A,A)') i, ' : ', trim(self%timers(i)%name)
             call logger%log_message(msg, module=this_module)
          end do
       end if
-      call logger%log_message('Registered timers: user', module=this_module)
-      do i = self%private_count+1, self%timer_count
-         write(msg,'(4X,I4,A,A)') i, ' : ', trim(self%timers(i)%name)
-         call logger%log_message(msg, module=this_module)
-      end do
+      if (self%user_count > 0) then
+         call logger%log_message('Registered timers: user', module=this_module)
+         do i = self%private_count+1, self%timer_count
+            write(msg,'(4X,I4,A,A)') i, ' : ', trim(self%timers(i)%name)
+            call logger%log_message(msg, module=this_module)
+         end do
+      end if
    end subroutine enumerate
 
    subroutine initialize(self)
-      class(watch_type), intent(inout) :: self
+      class(lightkrylov_watch), intent(inout) :: self
       ! timers for LightKrylov_BaseKrylov
       ! rsp
-      call self%add_timer('QR_with_pivoting_rsp')
-      call self%add_timer('QR_no_pivoting_rsp')
-      call self%add_timer('Orthonormalize_basis_rsp')
-      call self%add_timer('Orthonormalize_vector_against_basis_rsp')
-      call self%add_timer('Orthonormalize_basis_against_basis_rsp')
-      call self%add_timer('DGS_vector_against_basis_rsp')
-      call self%add_timer('DGS_basis_against_basis_rsp')
+      call self%add_timer('qr_with_pivoting_rsp')
+      call self%add_timer('qr_no_pivoting_rsp')
+      call self%add_timer('orthonormalize_basis_rsp')
+      call self%add_timer('orthonormalize_vector_against_basis_rsp')
+      call self%add_timer('orthonormalize_basis_against_basis_rsp')
+      call self%add_timer('dgs_vector_against_basis_rsp')
+      call self%add_timer('dgs_basis_against_basis_rsp')
       self%basekrylov_count = self%timer_count
       ! rdp
-      call self%add_timer('QR_with_pivoting_rdp')
-      call self%add_timer('QR_no_pivoting_rdp')
-      call self%add_timer('Orthonormalize_basis_rdp')
-      call self%add_timer('Orthonormalize_vector_against_basis_rdp')
-      call self%add_timer('Orthonormalize_basis_against_basis_rdp')
-      call self%add_timer('DGS_vector_against_basis_rdp')
-      call self%add_timer('DGS_basis_against_basis_rdp')
+      call self%add_timer('qr_with_pivoting_rdp')
+      call self%add_timer('qr_no_pivoting_rdp')
+      call self%add_timer('orthonormalize_basis_rdp')
+      call self%add_timer('orthonormalize_vector_against_basis_rdp')
+      call self%add_timer('orthonormalize_basis_against_basis_rdp')
+      call self%add_timer('dgs_vector_against_basis_rdp')
+      call self%add_timer('dgs_basis_against_basis_rdp')
       self%basekrylov_count = self%timer_count
       ! csp
-      call self%add_timer('QR_with_pivoting_csp')
-      call self%add_timer('QR_no_pivoting_csp')
-      call self%add_timer('Orthonormalize_basis_csp')
-      call self%add_timer('Orthonormalize_vector_against_basis_csp')
-      call self%add_timer('Orthonormalize_basis_against_basis_csp')
-      call self%add_timer('DGS_vector_against_basis_csp')
-      call self%add_timer('DGS_basis_against_basis_csp')
+      call self%add_timer('qr_with_pivoting_csp')
+      call self%add_timer('qr_no_pivoting_csp')
+      call self%add_timer('orthonormalize_basis_csp')
+      call self%add_timer('orthonormalize_vector_against_basis_csp')
+      call self%add_timer('orthonormalize_basis_against_basis_csp')
+      call self%add_timer('dgs_vector_against_basis_csp')
+      call self%add_timer('dgs_basis_against_basis_csp')
       self%basekrylov_count = self%timer_count
       ! cdp
-      call self%add_timer('QR_with_pivoting_cdp')
-      call self%add_timer('QR_no_pivoting_cdp')
-      call self%add_timer('Orthonormalize_basis_cdp')
-      call self%add_timer('Orthonormalize_vector_against_basis_cdp')
-      call self%add_timer('Orthonormalize_basis_against_basis_cdp')
-      call self%add_timer('DGS_vector_against_basis_cdp')
-      call self%add_timer('DGS_basis_against_basis_cdp')
+      call self%add_timer('qr_with_pivoting_cdp')
+      call self%add_timer('qr_no_pivoting_cdp')
+      call self%add_timer('orthonormalize_basis_cdp')
+      call self%add_timer('orthonormalize_vector_against_basis_cdp')
+      call self%add_timer('orthonormalize_basis_against_basis_cdp')
+      call self%add_timer('dgs_vector_against_basis_cdp')
+      call self%add_timer('dgs_basis_against_basis_cdp')
       self%basekrylov_count = self%timer_count
       ! timers for LightKrylov_IterativeSolvers
       ! rsp
@@ -318,14 +358,17 @@ contains
       self%private_count = self%timer_count
       self%user_mode = .true.
       if_time = .true.
+      call logger%log_message('LightKrylov system timer initialization complete.', module=this_module)
+      print *, self%private_count
+      print *, self%user_count
    end subroutine initialize
 
-   subroutine finalize(self)
-      class(watch_type), intent(inout) :: self
+   subroutine finalize_watch(self)
+      class(lightkrylov_watch), intent(inout) :: self
       ! internal
       integer :: i, j, icalled
       integer :: ic_bk, ic_is, ic_nk, ic_user
-      character(len=128) :: msg
+      character(len=128) :: msg, timer_fmt
       icalled = 0
       ic_bk = 0
       do i = 1, self%timer_count
@@ -341,21 +384,27 @@ contains
       end do
       ic_user = icalled - ic_nk
       if_time = .false.
-      call logger%log_message('##############        Timer summary        ##############', module=this_module)
-      write(msg, '(2X,A20,I3)') 'Total active timers:', self%timer_count
+      call logger%log_message('###############        Global timer summary        ##############', module=this_module)
+      call logger%log_message('____________________', module=this_module)
+      call logger%log_message('Overview:', module=this_module)
+      call logger%log_message('_________________________________________________________________', module=this_module)
+      write(msg, '(2X,A20,I5)') 'Total active timers:', self%timer_count
       call logger%log_message(msg, module=this_module)
-      write(msg, '(2X,A20,I3)') 'User defined:', self%user_count
+      write(msg, '(2X,A20,I5)') 'User defined:', self%user_count
       call logger%log_message(msg, module=this_module)
-      write(msg, '(2X,A20,I3)') 'Called timers:', icalled
+      write(msg, '(2X,A20,I5)') 'Called timers:', icalled
       call logger%log_message(msg, module=this_module)
-      write(msg, '(A32,A5,2(1X,A10))') 'name', 'cnt', 'total', 'avg'
+      write(msg, '(A32,A7,2(1X,A12))') 'name', 'calls', 'total (s)', 'avg (s)'
       call logger%log_message(msg, module=this_module)
+      timer_fmt = '(2X,A30,I7,2(1X,F12.6))'
       if (ic_bk > 0) then
+         call logger%log_message('____________________', module=this_module)
          call logger%log_message('BaseKrylov:', module=this_module)
+         call logger%log_message('_________________________________________________________________', module=this_module)
          do i = 1, self%basekrylov_count
             associate(t => self%timers(i))
                if (t%count > 0) then
-                  write(msg,'(2X,A30,I5,2(1X,F10.6))') trim(t%name), t%count, t%get_time(), t%get_time()/t%count
+                  write(msg,timer_fmt) trim(t%name), t%count, t%get_time(), t%get_time()/t%count
                   call logger%log_message(msg, module=this_module)
                end if
             end associate
@@ -363,11 +412,13 @@ contains
       end if
       j = self%basekrylov_count
       if (ic_is > 0) then
+         call logger%log_message('____________________', module=this_module)
          call logger%log_message('IterativeSolvers:', module=this_module)
+         call logger%log_message('_________________________________________________________________', module=this_module)
          do i = j, self%iterativesolvers_count
             associate(t => self%timers(i))
                if (t%count > 0) then
-                  write(msg,'(2X,A30,I5,2(1X,F10.6))') trim(t%name), t%count, t%get_time(), t%get_time()/t%count
+                  write(msg,timer_fmt) trim(t%name), t%count, t%get_time(), t%get_time()/t%count
                   call logger%log_message(msg, module=this_module)
                end if
             end associate
@@ -375,11 +426,13 @@ contains
       end if
       j = self%iterativesolvers_count
       if (ic_nk > 0) then
+         call logger%log_message('____________________', module=this_module)
          call logger%log_message('NewtonKrylov:', module=this_module)
+         call logger%log_message('_________________________________________________________________', module=this_module)
          do i = j, self%newtonkrylov_count
             associate(t => self%timers(i))
                if (t%count > 0) then
-                  write(msg,'(2X,A30,I5,2(1X,F10.6))') trim(t%name), t%count, t%get_time(), t%get_time()/t%count
+                  write(msg,timer_fmt) trim(t%name), t%count, t%get_time(), t%get_time()/t%count
                   call logger%log_message(msg, module=this_module)
                end if
             end associate
@@ -387,17 +440,19 @@ contains
       end if
       if (self%user_count > 0 .and. ic_user > 0) then
          j = self%private_count
+         call logger%log_message('____________________', module=this_module)
          call logger%log_message('User-defined:', module=this_module)
+         call logger%log_message('_________________________________________________________________', module=this_module)
          do i = j, self%timer_count
             associate(t => self%timers(i))
                if (t%count > 0) then
-                  write(msg,'(2X,A30,I5,2(1X,F10.6))') trim(t%name), t%count, t%get_time(), t%get_time()/t%count
+                  write(msg,timer_fmt) trim(t%name), t%count, t%get_time(), t%get_time()/t%count
                   call logger%log_message(msg, module=this_module)
                end if
             end associate
          end do
       end if
-      call logger%log_message('##############        Timer summary        ##############', module=this_module)
-   end subroutine finalize
+      call logger%log_message('###############        Global timer summary        ##############', module=this_module)
+   end subroutine finalize_watch
 
-end module LightKrylov_Timer
+end module LightKrylov_Timing

--- a/src/Timer.f90
+++ b/src/Timer.f90
@@ -152,7 +152,8 @@ contains
       real(dp) :: etime, etavg
       character(len=128) :: msg, timer_fmt
       timer_fmt       = '(2X,A30," : ",I7,2(1X,F12.6))'
-      call logger%log_message('###        Timer info                  #######################################', module=this_module)
+      call logger%log_message('###        Timer info                  #######################################', & 
+                              & module=this_module)
       write(msg, '(A32," : ",A7,2(1X,A12))') 'name', 'calls', 'total (s)', 'avg (s)'
       call logger%log_message(msg, module=this_module)
       etime = 0.0_dp
@@ -161,7 +162,8 @@ contains
       if (self%count > 0) etavg = etime/self%count
       write(msg,timer_fmt) trim(self%name), self%count, etime, etavg
       call logger%log_message(msg, module=this_module)
-      call logger%log_message('###        Timer info                  #######################################', module=this_module)
+      call logger%log_message('###        Timer info                  #######################################', & 
+                              & module=this_module)
    end subroutine print_timer_info
 
    subroutine finalize_timer(self)
@@ -174,10 +176,12 @@ contains
       timer_fmt       = '(2X,A30," : ",A6,1X,I7,2(1X,F12.6))'
       timer_fmt_reset = '(2X,33X,A6,I3,1X,I7,2(1X,F12.6))'
       icalled = 0
-      call logger%log_message('###        Timer summary               #######################################', module=this_module)
+      call logger%log_message('###        Timer summary               #######################################', & 
+                              & module=this_module)
       write(msg, '(A32," : ",7X,A7,2(1X,A12))') 'name', 'calls', 'total (s)', 'avg (s)'
       call logger%log_message(msg, module=this_module)
-      call logger%log_message('______________________________________________________________________________', module=this_module)
+      call logger%log_message('______________________________________________________________________________', & 
+                              & module=this_module)
       etavg = 0.0_dp
       if (self%count > 0 .or. self%reset_counter > 0) then
          if (self%reset_counter == 0) call self%save_timer_history()
@@ -196,7 +200,8 @@ contains
             end do
          end if
       end if
-      call logger%log_message('###        Timer summary               #######################################', module=this_module)
+      call logger%log_message('###        Timer summary               #######################################', & 
+                              & module=this_module)
    end subroutine finalize_timer
 
    !--------------------------------------------------------------
@@ -225,7 +230,8 @@ contains
          self%timer_count = 1
       else
          if (self%get_timer_id(name) > 0) then
-            call stop_error('Timer "'//to_lower(trim(name))//'" already defined!', module=this_module, procedure='add_timer')
+            call stop_error('Timer "'//to_lower(trim(name))//'" already defined!', & 
+                              & module=this_module, procedure='add_timer')
          end if
          self%timers = [ self%timers, lightkrylov_timer(name) ]
          self%timer_count = self%timer_count + 1
@@ -242,10 +248,12 @@ contains
       integer :: id
       id = self%get_timer_id(name)
       if (id == 0) then
-         call stop_error('Timer "'//to_lower(trim(name))//'" not defined!', module=this_module, procedure='remove_timer')
+         call stop_error('Timer "'//to_lower(trim(name))//'" not defined!', & 
+                              & module=this_module, procedure='remove_timer')
       else
          if (id <= self%private_count) then
-            call logger%log_message('Cannot remove private timer "'//to_lower(trim(name))//'".', module=this_module, procedure='remove_timer')
+            call logger%log_message('Cannot remove private timer "'//to_lower(trim(name))//'".', & 
+                              & module=this_module, procedure='remove_timer')
          else
             self%timer_count = self%timer_count - 1
             allocate(new_timers(self%timer_count))
@@ -265,7 +273,8 @@ contains
       integer :: id
       id = self%get_timer_id(name)
       if (id == 0) then 
-         call stop_error('Timer "'//to_lower(trim(name))//'" not found!', module=this_module, procedure='start_timer_by_name')
+         call stop_error('Timer "'//to_lower(trim(name))//'" not found!', & 
+                              & module=this_module, procedure='start_timer_by_name')
       else
          call self%timers(id)%start()
       end if
@@ -279,7 +288,8 @@ contains
       integer :: id
       id = self%get_timer_id(name)
       if (id == 0) then 
-         call stop_error('Timer "'//to_lower(trim(name))//'" not found!', module=this_module, procedure='start_timer_by_name')
+         call stop_error('Timer "'//to_lower(trim(name))//'" not found!', & 
+                              & module=this_module, procedure='start_timer_by_name')
       else
          call self%timers(id)%stop()
       end if
@@ -293,7 +303,8 @@ contains
       integer :: id
       id = self%get_timer_id(name)
       if (id == 0) then 
-         call stop_error('Timer "'//to_lower(trim(name))//'" not found!', module=this_module, procedure='start_timer_by_name')
+         call stop_error('Timer "'//to_lower(trim(name))//'" not found!', & 
+                              & module=this_module, procedure='start_timer_by_name')
       else
          call self%timers(id)%pause()
       end if
@@ -308,7 +319,8 @@ contains
       integer :: id
       id = self%get_timer_id(name)
       if (id == 0) then 
-         call stop_error('Timer "'//to_lower(trim(name))//'" not found!', module=this_module, procedure='start_timer_by_name')
+         call stop_error('Timer "'//to_lower(trim(name))//'" not found!', & 
+                              & module=this_module, procedure='start_timer_by_name')
       else
          call self%timers(id)%reset(save_history)
       end if
@@ -474,7 +486,8 @@ contains
       end do
       ic_user = icalled - ic_nk - ic_is - ic_bk
       if_time = .false.
-      call logger%log_message('###        Global timer summary        #######################################', module=this_module)
+      call logger%log_message('###        Global timer summary        #######################################', & 
+                              & module=this_module)
       call logger%log_message('____________________', module=this_module)
       call logger%log_message('Overview:', module=this_module)
       write(msg, '(2X,A40,I5)') 'Total active timers:', self%timer_count
@@ -490,7 +503,8 @@ contains
          call logger%log_message('BaseKrylov:', module=this_module)
          write(msg, '(A32," : ",7X,A7,2(1X,A12))') 'name', 'calls', 'total (s)', 'avg (s)'
          call logger%log_message(msg, module=this_module)
-         call logger%log_message('______________________________________________________________________________', module=this_module)
+         call logger%log_message('______________________________________________________________________________', & 
+                              & module=this_module)
          do i = 1, self%basekrylov_count
             associate(t => self%timers(i))
                rcount = t%reset_counter
@@ -519,7 +533,8 @@ contains
          call logger%log_message('IterativeSolvers:', module=this_module)
          write(msg, '(A32," : ",7X,A7,2(1X,A12))') 'name', 'calls', 'total (s)', 'avg (s)'
          call logger%log_message(msg, module=this_module)
-         call logger%log_message('______________________________________________________________________________', module=this_module)
+         call logger%log_message('______________________________________________________________________________', & 
+                              & module=this_module)
          do i = j, self%iterativesolvers_count
             associate(t => self%timers(i))
                rcount = t%reset_counter
@@ -548,7 +563,8 @@ contains
          call logger%log_message('NewtonKrylov:', module=this_module)
          write(msg, '(A32," : ",7X,A7,2(1X,A12))') 'name', 'calls', 'total (s)', 'avg (s)'
          call logger%log_message(msg, module=this_module)
-         call logger%log_message('_________________________________________________________________', module=this_module)
+         call logger%log_message('______________________________________________________________________________', & 
+                              & module=this_module)
          do i = j, self%newtonkrylov_count
             associate(t => self%timers(i))
                rcount = t%reset_counter
@@ -577,7 +593,8 @@ contains
          call logger%log_message('User-defined:', module=this_module)
          write(msg, '(A32," : ",7X,A7,2(1X,A12))') 'name', 'calls', 'total (s)', 'avg (s)'
          call logger%log_message(msg, module=this_module)
-         call logger%log_message('_________________________________________________________________', module=this_module)
+         call logger%log_message('______________________________________________________________________________', & 
+                              & module=this_module)
          do i = j, self%timer_count
             associate(t => self%timers(i))
                rcount = t%reset_counter

--- a/src/Timer.f90
+++ b/src/Timer.f90
@@ -1,4 +1,5 @@
 module LightKrylov_Timer
+   use stdlib_optval, only: optval
    use LightKrylov_Constants, only: dp
    use LightKrylov_Logger
    implicit none
@@ -6,8 +7,8 @@ module LightKrylov_Timer
    character(len=128), parameter :: this_module = 'LightKrylov_Timer'
    logical :: if_time = .false.
 
-   public :: initialize_timers, enumerate_timers, finalize_timers
-   public :: timeit
+   public :: time_lightkrylov
+   public :: global_timer
 
    ! Timer type
    type, public :: timer_type
@@ -30,130 +31,40 @@ module LightKrylov_Timer
       private
       type(timer_type), dimension(:), allocatable :: timers
       integer :: timer_count = 0
+      integer :: basekrylov_count = 0
+      integer :: iterativesolvers_count = 0
+      integer :: newtonkrylov_count = 0
       integer :: private_count = 0
+      logical :: user_mode = .false.
+      integer :: user_count = 0
    contains
       procedure, pass(self), public :: add_timer
       procedure, pass(self), public :: remove_timer
-      procedure, pass(self), public :: enumerate_timers
+      procedure, pass(self), public :: get_timer_id
+      procedure, pass(self), public :: initialize
+      procedure, pass(self), public :: enumerate
+      procedure, pass(self), public :: finalize
       procedure, pass(self), public :: start => start_timer_by_name
       procedure, pass(self), public :: stop => stop_timer_by_name
       procedure, pass(self), public :: pause => pause_timer_by_name
       procedure, pass(self), public :: reset => reset_timer_by_name
    end type watch_type
 
-   type(watch_type), public :: global_timer
+   type(watch_type) :: global_timer
 
 contains
 
-   function timeit() result(if_time_lightkrylov)
+   function time_lightkrylov() result(if_time_lightkrylov)
       logical :: if_time_lightkrylov
       if_time_lightkrylov = if_time
-   end function timeit
-
-   subroutine initialize_timers()
-      ! timers for LightKrylov_BaseKrylov
-      ! rsp
-      !call global_timer%add_timer('QR_with_pivoting_rsp')
-      !call global_timer%add_timer('QR_no_pivoting_rsp')
-      !call global_timer%add_timer('Orthonormalize_basis_rsp')
-      !call global_timer%add_timer('Orthonormalize_vector_against_basis_rsp')
-      !call global_timer%add_timer('Orthonormalize_basis_against_basis_rsp')
-      !call global_timer%add_timer('DGS_vector_against_basis_rsp')
-      !call global_timer%add_timer('DGS_basis_against_basis_rsp')
-      !#:endfor
-      ! timers for LightKrylov_IterativeSolvers
-      !#:for kind, type in RC_KINDS_TYPES
-      ! rsp
-      !call global_timer%add_timer('eigs_rsp')
-      !call global_timer%add_timer('eighs_rsp')
-      call global_timer%add_timer('svds_rsp')
-      call global_timer%add_timer('gmres_rsp')
-      !call global_timer%add_timer('fgmres_rsp')
-      !call global_timer%add_timer('cg_rsp')
-      ! rdp
-      !call global_timer%add_timer('QR_with_pivoting_rdp')
-      !call global_timer%add_timer('QR_no_pivoting_rdp')
-      !call global_timer%add_timer('Orthonormalize_basis_rdp')
-      !call global_timer%add_timer('Orthonormalize_vector_against_basis_rdp')
-      !call global_timer%add_timer('Orthonormalize_basis_against_basis_rdp')
-      !call global_timer%add_timer('DGS_vector_against_basis_rdp')
-      !call global_timer%add_timer('DGS_basis_against_basis_rdp')
-      !#:endfor
-      ! timers for LightKrylov_IterativeSolvers
-      !#:for kind, type in RC_KINDS_TYPES
-      ! rdp
-      !call global_timer%add_timer('eigs_rdp')
-      !call global_timer%add_timer('eighs_rdp')
-      call global_timer%add_timer('svds_rdp')
-      call global_timer%add_timer('gmres_rdp')
-      !call global_timer%add_timer('fgmres_rdp')
-      !call global_timer%add_timer('cg_rdp')
-      ! csp
-      !call global_timer%add_timer('QR_with_pivoting_csp')
-      !call global_timer%add_timer('QR_no_pivoting_csp')
-      !call global_timer%add_timer('Orthonormalize_basis_csp')
-      !call global_timer%add_timer('Orthonormalize_vector_against_basis_csp')
-      !call global_timer%add_timer('Orthonormalize_basis_against_basis_csp')
-      !call global_timer%add_timer('DGS_vector_against_basis_csp')
-      !call global_timer%add_timer('DGS_basis_against_basis_csp')
-      !#:endfor
-      ! timers for LightKrylov_IterativeSolvers
-      !#:for kind, type in RC_KINDS_TYPES
-      ! csp
-      !call global_timer%add_timer('eigs_csp')
-      !call global_timer%add_timer('eighs_csp')
-      call global_timer%add_timer('svds_csp')
-      call global_timer%add_timer('gmres_csp')
-      !call global_timer%add_timer('fgmres_csp')
-      !call global_timer%add_timer('cg_csp')
-      ! cdp
-      !call global_timer%add_timer('QR_with_pivoting_cdp')
-      !call global_timer%add_timer('QR_no_pivoting_cdp')
-      !call global_timer%add_timer('Orthonormalize_basis_cdp')
-      !call global_timer%add_timer('Orthonormalize_vector_against_basis_cdp')
-      !call global_timer%add_timer('Orthonormalize_basis_against_basis_cdp')
-      !call global_timer%add_timer('DGS_vector_against_basis_cdp')
-      !call global_timer%add_timer('DGS_basis_against_basis_cdp')
-      !#:endfor
-      ! timers for LightKrylov_IterativeSolvers
-      !#:for kind, type in RC_KINDS_TYPES
-      ! cdp
-      !call global_timer%add_timer('eigs_cdp')
-      !call global_timer%add_timer('eighs_cdp')
-      call global_timer%add_timer('svds_cdp')
-      call global_timer%add_timer('gmres_cdp')
-      !call global_timer%add_timer('fgmres_cdp')
-      !call global_timer%add_timer('cg_cdp')
-      ! timers for LightKrylov_NewtonKrylov
-      ! rsp
-      call global_timer%add_timer('newton_rsp')
-      ! rdp
-      call global_timer%add_timer('newton_rdp')
-      ! csp
-      call global_timer%add_timer('newton_csp')
-      ! cdp
-      call global_timer%add_timer('newton_cdp')
-      global_timer%private_count = global_timer%timer_count
-      if_time = .true.
-   end subroutine initialize_timers
-
-   subroutine finalize_timers()
-      ! internal
-      integer :: i
-      do i = 1, global_timer%timer_count
-         call global_timer%timers(i)%stop()
-      end do
-      if_time = .false.
-      do i = 1, global_timer%timer_count
-         print *, trim(global_timer%timers(i)%name), ':', global_timer%timers(i)%count, global_timer%timers(i)%get_time()
-      end do
-   end subroutine finalize_timers
+   end function time_lightkrylov
 
    subroutine start_timer(self)
       class(timer_type), intent(inout) :: self
       if (.not. self%running) then
          call cpu_time(self%start_time)
          self%running = .true.
+         self%count = self%count + 1
       end if
    end subroutine start_timer
 
@@ -164,7 +75,6 @@ contains
       call cpu_time(t_now)
       if (self%running) then
          self%elapsed_time = self%elapsed_time + (t_now - self%start_time)
-         self%count = self%count + 1
          self%running = .false.
       end if
    end subroutine stop_timer
@@ -196,23 +106,33 @@ contains
       etime = self%elapsed_time
    end function
 
+   integer function get_timer_id(self, name) result(id)
+      class(watch_type) :: self
+      character(len=*)  :: name
+      ! internal
+      integer :: i
+      id = 0
+      do i = 1, self%timer_count
+         if (self%timers(i)%name == name) then
+            id = i
+         end if
+      end do
+   end function get_timer_id
+
    subroutine add_timer(self, name)
       class(watch_type), intent(inout) :: self
       character(len=*), intent(in) :: name
-      ! internal
-      integer :: i
       if (self%timer_count == 0) then
          allocate(self%timers(1))
          self%timers(1) = timer_type(name)
          self%timer_count = 1
       else
-         do i = 1, self%timer_count
-            if (self%timers(i)%name == name) then
-               call stop_error('Timer "'//trim(name)//'" already defined!', module=this_module, procedure='add_timer')
-            end if
-         end do
+         if (self%get_timer_id(name) > 0) then
+            call stop_error('Timer "'//trim(name)//'" already defined!', module=this_module, procedure='add_timer')
+         end if
          self%timers = [ self%timers, timer_type(name) ]
          self%timer_count = self%timer_count + 1
+         if (self%user_mode) self%user_count = self%user_count + 1
       end if
    end subroutine add_timer
 
@@ -221,102 +141,263 @@ contains
       character(len=*), intent(in) :: name
       ! internal
       type(timer_type), dimension(:), allocatable :: new_timers
-      integer :: i, i_rm
-      logical :: found
-      found = .false.
-      do i = 1, self%timer_count
-         if (self%timers(i)%name == name) then
-            i_rm = i
-            found = .true.
-         end if
-      end do
-      if (.not. found) then
+      integer :: id
+      id = self%get_timer_id(name)
+      if (id == 0) then
          call stop_error('Timer "'//trim(name)//'" not defined!', module=this_module, procedure='remove_timer')
       else
-         if (i_rm <= self%private_count) then
+         if (id <= self%private_count) then
             call logger%log_message('Cannot remove private timer "'//trim(name)//'".', module=this_module, procedure='remove_timer')
          else
             self%timer_count = self%timer_count - 1
             allocate(new_timers(self%timer_count))
-            new_timers(1:i_rm-1) = self%timers(1:i_rm-1)
-            new_timers(i_rm:)    = self%timers(i_rm+1:)
+            new_timers(1:id-1) = self%timers(1:id-1)
+            new_timers(id:)    = self%timers(id+1:)
             deallocate(self%timers)
             self%timers = new_timers
          end if
       end if
    end subroutine remove_timer
-
-   subroutine enumerate_timers(self)
-      class(watch_type), intent(in) :: self
-      ! internal
-      integer :: i
-      do i = 1, self%timer_count
-         print *, 'Timer', i, ':', trim(self%timers(i)%name)
-      end do
-   end subroutine
    
    subroutine start_timer_by_name(self, name)
       class(watch_type), intent(inout) :: self
       character(len=*), intent(in) :: name
       ! internal
-      integer :: i
-      logical :: found
-      found = .false.
-      do i = 1, self%timer_count
-         if (self%timers(i)%name == name) then
-            call self%timers(i)%start()
-            found = .true.
-         end if
-      end do
-      if (.not. found) call stop_error('Timer "'//trim(name)//'" not found!', module=this_module, procedure='start_timer_by_name')
+      integer :: id
+      id = self%get_timer_id(name)
+      if (id == 0) then 
+         call stop_error('Timer "'//trim(name)//'" not found!', module=this_module, procedure='start_timer_by_name')
+      else
+         call self%timers(id)%start()
+      end if
    end subroutine start_timer_by_name
 
    subroutine stop_timer_by_name(self, name)
       class(watch_type), intent(inout) :: self
       character(len=*), intent(in) :: name
       ! internal
-      integer :: i
-      logical :: found
-      found = .false.
-      do i = 1, self%timer_count
-         if (self%timers(i)%name == name) then
-            call self%timers(i)%stop()
-            found = .true.
-         end if
-      end do
-      if (.not. found) call stop_error('Timer "'//trim(name)//'" not found!', module=this_module, procedure='stop_timer_by_name')
+      integer :: id
+      id = self%get_timer_id(name)
+      if (id == 0) then 
+         call stop_error('Timer "'//trim(name)//'" not found!', module=this_module, procedure='start_timer_by_name')
+      else
+         call self%timers(id)%stop()
+      end if
    end subroutine stop_timer_by_name
 
    subroutine pause_timer_by_name(self, name)
       class(watch_type), intent(inout) :: self
       character(len=*), intent(in) :: name
       ! internal
-      integer :: i
-      logical :: found
-      found = .false.
-      do i = 1, self%timer_count
-         if (self%timers(i)%name == name) then
-            call self%timers(i)%pause()
-            found = .true.
-         end if
-      end do
-      if (.not. found) call stop_error('Timer "'//trim(name)//'" not found!', module=this_module, procedure='pause_timer_by_name')
+      integer :: id
+      id = self%get_timer_id(name)
+      if (id == 0) then 
+         call stop_error('Timer "'//trim(name)//'" not found!', module=this_module, procedure='start_timer_by_name')
+      else
+         call self%timers(id)%start()
+      end if
    end subroutine
 
    subroutine reset_timer_by_name(self, name)
       class(watch_type), intent(inout) :: self
       character(len=*), intent(in) :: name
       ! internal
+      integer :: id
+      id = self%get_timer_id(name)
+      if (id == 0) then 
+         call stop_error('Timer "'//trim(name)//'" not found!', module=this_module, procedure='start_timer_by_name')
+      else
+         call self%timers(id)%start()
+      end if
+   end subroutine
+
+   subroutine enumerate(self, only_user)
+      class(watch_type), intent(in) :: self
+      logical, optional, intent(in) :: only_user
+      ! internal
       integer :: i
-      logical :: found
-      found = .false.
+      logical :: only_user_
+      character(len=128) :: msg
+      only_user_ = optval(only_user, .true.)
+      if (.not. only_user_) then
+         call logger%log_message('Registered timers: default', module=this_module)
+         do i = 1, self%private_count
+            write(msg,'(4X,I4,A,A)') i, ' : ', trim(self%timers(i)%name)
+            call logger%log_message(msg, module=this_module)
+         end do
+      end if
+      call logger%log_message('Registered timers: user', module=this_module)
+      do i = self%private_count+1, self%timer_count
+         write(msg,'(4X,I4,A,A)') i, ' : ', trim(self%timers(i)%name)
+         call logger%log_message(msg, module=this_module)
+      end do
+   end subroutine enumerate
+
+   subroutine initialize(self)
+      class(watch_type), intent(inout) :: self
+      ! timers for LightKrylov_BaseKrylov
+      ! rsp
+      call self%add_timer('QR_with_pivoting_rsp')
+      call self%add_timer('QR_no_pivoting_rsp')
+      call self%add_timer('Orthonormalize_basis_rsp')
+      call self%add_timer('Orthonormalize_vector_against_basis_rsp')
+      call self%add_timer('Orthonormalize_basis_against_basis_rsp')
+      call self%add_timer('DGS_vector_against_basis_rsp')
+      call self%add_timer('DGS_basis_against_basis_rsp')
+      self%basekrylov_count = self%timer_count
+      ! rdp
+      call self%add_timer('QR_with_pivoting_rdp')
+      call self%add_timer('QR_no_pivoting_rdp')
+      call self%add_timer('Orthonormalize_basis_rdp')
+      call self%add_timer('Orthonormalize_vector_against_basis_rdp')
+      call self%add_timer('Orthonormalize_basis_against_basis_rdp')
+      call self%add_timer('DGS_vector_against_basis_rdp')
+      call self%add_timer('DGS_basis_against_basis_rdp')
+      self%basekrylov_count = self%timer_count
+      ! csp
+      call self%add_timer('QR_with_pivoting_csp')
+      call self%add_timer('QR_no_pivoting_csp')
+      call self%add_timer('Orthonormalize_basis_csp')
+      call self%add_timer('Orthonormalize_vector_against_basis_csp')
+      call self%add_timer('Orthonormalize_basis_against_basis_csp')
+      call self%add_timer('DGS_vector_against_basis_csp')
+      call self%add_timer('DGS_basis_against_basis_csp')
+      self%basekrylov_count = self%timer_count
+      ! cdp
+      call self%add_timer('QR_with_pivoting_cdp')
+      call self%add_timer('QR_no_pivoting_cdp')
+      call self%add_timer('Orthonormalize_basis_cdp')
+      call self%add_timer('Orthonormalize_vector_against_basis_cdp')
+      call self%add_timer('Orthonormalize_basis_against_basis_cdp')
+      call self%add_timer('DGS_vector_against_basis_cdp')
+      call self%add_timer('DGS_basis_against_basis_cdp')
+      self%basekrylov_count = self%timer_count
+      ! timers for LightKrylov_IterativeSolvers
+      ! rsp
+      call self%add_timer('eigs_rsp')
+      call self%add_timer('eighs_rsp')
+      call self%add_timer('svds_rsp')
+      call self%add_timer('gmres_rsp')
+      call self%add_timer('fgmres_rsp')
+      call self%add_timer('cg_rsp')
+      self%iterativesolvers_count = self%timer_count
+      ! rdp
+      call self%add_timer('eigs_rdp')
+      call self%add_timer('eighs_rdp')
+      call self%add_timer('svds_rdp')
+      call self%add_timer('gmres_rdp')
+      call self%add_timer('fgmres_rdp')
+      call self%add_timer('cg_rdp')
+      self%iterativesolvers_count = self%timer_count
+      ! csp
+      call self%add_timer('eigs_csp')
+      call self%add_timer('eighs_csp')
+      call self%add_timer('svds_csp')
+      call self%add_timer('gmres_csp')
+      call self%add_timer('fgmres_csp')
+      call self%add_timer('cg_csp')
+      self%iterativesolvers_count = self%timer_count
+      ! cdp
+      call self%add_timer('eigs_cdp')
+      call self%add_timer('eighs_cdp')
+      call self%add_timer('svds_cdp')
+      call self%add_timer('gmres_cdp')
+      call self%add_timer('fgmres_cdp')
+      call self%add_timer('cg_cdp')
+      self%iterativesolvers_count = self%timer_count
+      ! timers for LightKrylov_NewtonKrylov
+      ! rsp
+      call self%add_timer('newton_rsp')
+      ! rdp
+      call self%add_timer('newton_rdp')
+      ! csp
+      call self%add_timer('newton_csp')
+      ! cdp
+      call self%add_timer('newton_cdp')
+      self%newtonkrylov_count = self%timer_count
+      self%private_count = self%timer_count
+      self%user_mode = .true.
+      if_time = .true.
+   end subroutine initialize
+
+   subroutine finalize(self)
+      class(watch_type), intent(inout) :: self
+      ! internal
+      integer :: i, j, icalled
+      integer :: ic_bk, ic_is, ic_nk, ic_user
+      character(len=128) :: msg
+      icalled = 0
+      ic_bk = 0
       do i = 1, self%timer_count
-         if (self%timers(i)%name == name) then
-            call self%timers(i)%reset()
-            found = .true.
+         call self%timers(i)%stop()
+         if (self%timers(i)%count > 0) icalled = icalled + 1
+         if (i == self%basekrylov_count) then
+            ic_bk = icalled
+         else if (i == self%iterativesolvers_count) then
+            ic_is = icalled - ic_bk
+         else if (i == self%newtonkrylov_count) then
+            ic_nk = icalled - ic_is
          end if
       end do
-      if (.not. found) call stop_error('Timer "'//trim(name)//'" not found!', module=this_module, procedure='reset_timer_by_name')
-   end subroutine
+      ic_user = icalled - ic_nk
+      if_time = .false.
+      call logger%log_message('##############        Timer summary        ##############', module=this_module)
+      write(msg, '(2X,A20,I3)') 'Total active timers:', self%timer_count
+      call logger%log_message(msg, module=this_module)
+      write(msg, '(2X,A20,I3)') 'User defined:', self%user_count
+      call logger%log_message(msg, module=this_module)
+      write(msg, '(2X,A20,I3)') 'Called timers:', icalled
+      call logger%log_message(msg, module=this_module)
+      write(msg, '(A32,A5,2(1X,A10))') 'name', 'cnt', 'total', 'avg'
+      call logger%log_message(msg, module=this_module)
+      if (ic_bk > 0) then
+         call logger%log_message('BaseKrylov:', module=this_module)
+         do i = 1, self%basekrylov_count
+            associate(t => self%timers(i))
+               if (t%count > 0) then
+                  write(msg,'(2X,A30,I5,2(1X,F10.6))') trim(t%name), t%count, t%get_time(), t%get_time()/t%count
+                  call logger%log_message(msg, module=this_module)
+               end if
+            end associate
+         end do
+      end if
+      j = self%basekrylov_count
+      if (ic_is > 0) then
+         call logger%log_message('IterativeSolvers:', module=this_module)
+         do i = j, self%iterativesolvers_count
+            associate(t => self%timers(i))
+               if (t%count > 0) then
+                  write(msg,'(2X,A30,I5,2(1X,F10.6))') trim(t%name), t%count, t%get_time(), t%get_time()/t%count
+                  call logger%log_message(msg, module=this_module)
+               end if
+            end associate
+         end do
+      end if
+      j = self%iterativesolvers_count
+      if (ic_nk > 0) then
+         call logger%log_message('NewtonKrylov:', module=this_module)
+         do i = j, self%newtonkrylov_count
+            associate(t => self%timers(i))
+               if (t%count > 0) then
+                  write(msg,'(2X,A30,I5,2(1X,F10.6))') trim(t%name), t%count, t%get_time(), t%get_time()/t%count
+                  call logger%log_message(msg, module=this_module)
+               end if
+            end associate
+         end do
+      end if
+      if (self%user_count > 0 .and. ic_user > 0) then
+         j = self%private_count
+         call logger%log_message('User-defined:', module=this_module)
+         do i = j, self%timer_count
+            associate(t => self%timers(i))
+               if (t%count > 0) then
+                  write(msg,'(2X,A30,I5,2(1X,F10.6))') trim(t%name), t%count, t%get_time(), t%get_time()/t%count
+                  call logger%log_message(msg, module=this_module)
+               end if
+            end associate
+         end do
+      end if
+      call logger%log_message('##############        Timer summary        ##############', module=this_module)
+   end subroutine finalize
 
 end module LightKrylov_Timer

--- a/src/Timer.f90
+++ b/src/Timer.f90
@@ -57,10 +57,6 @@ module LightKrylov_Timing
 
 contains
 
-   !--------------------------------------------------------------
-   !  Getter routine to determine whether timing is turned on/off
-   !--------------------------------------------------------------
-
    logical function time_lightkrylov() result(if_time_lightkrylov)
       if_time_lightkrylov = if_time
    end function time_lightkrylov
@@ -284,6 +280,9 @@ contains
       call self%add_timer('orthonormalize_basis_against_basis_rsp')
       call self%add_timer('dgs_vector_against_basis_rsp')
       call self%add_timer('dgs_basis_against_basis_rsp')
+      call self%add_timer('arnoldi_rsp')
+      call self%add_timer('lanczos_bidiagonalization_rsp')
+      call self%add_timer('lanczos_tridiagonalization_rsp')
       self%basekrylov_count = self%timer_count
       ! rdp
       call self%add_timer('qr_with_pivoting_rdp')
@@ -293,6 +292,9 @@ contains
       call self%add_timer('orthonormalize_basis_against_basis_rdp')
       call self%add_timer('dgs_vector_against_basis_rdp')
       call self%add_timer('dgs_basis_against_basis_rdp')
+      call self%add_timer('arnoldi_rdp')
+      call self%add_timer('lanczos_bidiagonalization_rdp')
+      call self%add_timer('lanczos_tridiagonalization_rdp')
       self%basekrylov_count = self%timer_count
       ! csp
       call self%add_timer('qr_with_pivoting_csp')
@@ -302,6 +304,9 @@ contains
       call self%add_timer('orthonormalize_basis_against_basis_csp')
       call self%add_timer('dgs_vector_against_basis_csp')
       call self%add_timer('dgs_basis_against_basis_csp')
+      call self%add_timer('arnoldi_csp')
+      call self%add_timer('lanczos_bidiagonalization_csp')
+      call self%add_timer('lanczos_tridiagonalization_csp')
       self%basekrylov_count = self%timer_count
       ! cdp
       call self%add_timer('qr_with_pivoting_cdp')
@@ -311,6 +316,9 @@ contains
       call self%add_timer('orthonormalize_basis_against_basis_cdp')
       call self%add_timer('dgs_vector_against_basis_cdp')
       call self%add_timer('dgs_basis_against_basis_cdp')
+      call self%add_timer('arnoldi_cdp')
+      call self%add_timer('lanczos_bidiagonalization_cdp')
+      call self%add_timer('lanczos_tridiagonalization_cdp')
       self%basekrylov_count = self%timer_count
       ! timers for LightKrylov_IterativeSolvers
       ! rsp

--- a/src/Timer.f90
+++ b/src/Timer.f90
@@ -25,6 +25,7 @@ module LightKrylov_Timing
       integer :: count = 0
       integer :: reset_counter = 0
    contains
+      private
       procedure, pass(self), public :: start => start_timer
       procedure, pass(self), public :: stop => stop_timer
       procedure, pass(self), public :: pause => pause_timer
@@ -35,33 +36,57 @@ module LightKrylov_Timing
       procedure, pass(self), public :: save_timer_history
    end type lightkrylov_timer
 
-   ! Watch type
-   type :: lightkrylov_watch
+   ! Abstract watch type
+   type, abstract, public :: abstract_watch
+      !! Base type to define a global timer.
       private
       type(lightkrylov_timer), dimension(:), allocatable :: timers
       integer :: timer_count = 0
-      integer :: basekrylov_count = 0
-      integer :: iterativesolvers_count = 0
-      integer :: newtonkrylov_count = 0
       integer :: private_count = 0
       logical :: user_mode = .false.
       integer :: user_count = 0
    contains
+      private
       procedure, pass(self), public :: add_timer
       procedure, pass(self), public :: remove_timer
       procedure, pass(self), public :: get_timer_id
-      procedure, pass(self), public :: initialize
       procedure, pass(self), public :: enumerate
       procedure, pass(self), public :: reset_all
-      procedure, pass(self), public :: finalize => finalize_watch
       procedure, pass(self), public :: start => start_timer_by_name
       procedure, pass(self), public :: stop => stop_timer_by_name
       procedure, pass(self), public :: pause => pause_timer_by_name
       procedure, pass(self), public :: reset => reset_timer_by_name
+      procedure(abstract_watch_init), pass(self), deferred, public :: initialize
+      procedure(abstract_watch_exit), pass(self), deferred, public :: finalize
+   end type abstract_watch
+
+   abstract interface
+      subroutine abstract_watch_init(self)
+         !! Interface for the initialization of the structure.
+         import abstract_watch
+         class(abstract_watch), intent(inout) :: self
+      end subroutine abstract_watch_init
+      subroutine abstract_watch_exit(self)
+         !! Interface for the finalization of the structure including the printing of the results
+         import abstract_watch
+         class(abstract_watch), intent(inout) :: self
+      end subroutine abstract_watch_exit
+   end interface
+
+   ! LightKrylov_watch type
+   type, extends(abstract_watch), public :: lightkrylov_watch
+      !! Global timing structure to contain all timers within Lightkrylov
+      character(len=128) :: name = 'lightkrylov_timer'
+      integer :: basekrylov_count = 0
+      integer :: iterativesolvers_count = 0
+      integer :: newtonkrylov_count = 0
+   contains
+      private
+      procedure, pass(self), public :: initialize => initialize_lightkrylov_watch
+      procedure, pass(self), public :: finalize => finalize_lightkrylov_watch
    end type lightkrylov_watch
 
    type(lightkrylov_watch) :: global_lightkrylov_timer
-
 contains
 
    logical function time_lightkrylov() result(if_time_lightkrylov)
@@ -215,11 +240,11 @@ contains
    end subroutine finalize_timer
 
    !--------------------------------------------------------------
-   !  Type-bound procedures for lightkrylov_watch type
+   !  Type-bound procedures for abstract_watch type
    !--------------------------------------------------------------
 
    integer function get_timer_id(self, name) result(id)
-      class(lightkrylov_watch) :: self
+      class(abstract_watch) :: self
       character(len=*)  :: name
       ! internal
       integer :: i
@@ -232,7 +257,7 @@ contains
    end function get_timer_id
 
    subroutine add_timer(self, name)
-      class(lightkrylov_watch), intent(inout) :: self
+      class(abstract_watch), intent(inout) :: self
       character(len=*), intent(in) :: name
       if (self%timer_count == 0) then
          allocate(self%timers(1))
@@ -251,7 +276,7 @@ contains
    end subroutine add_timer
 
    subroutine remove_timer(self, name)
-      class(lightkrylov_watch), intent(inout) :: self
+      class(abstract_watch), intent(inout) :: self
       character(len=*), intent(in) :: name
       ! internal
       type(lightkrylov_timer), dimension(:), allocatable :: new_timers
@@ -277,7 +302,7 @@ contains
    end subroutine remove_timer
    
    subroutine start_timer_by_name(self, name)
-      class(lightkrylov_watch), intent(inout) :: self
+      class(abstract_watch), intent(inout) :: self
       character(len=*), intent(in) :: name
       ! internal
       integer :: id
@@ -292,7 +317,7 @@ contains
    end subroutine start_timer_by_name
 
    subroutine stop_timer_by_name(self, name)
-      class(lightkrylov_watch), intent(inout) :: self
+      class(abstract_watch), intent(inout) :: self
       character(len=*), intent(in) :: name
       ! internal
       integer :: id
@@ -307,7 +332,7 @@ contains
    end subroutine stop_timer_by_name
 
    subroutine pause_timer_by_name(self, name)
-      class(lightkrylov_watch), intent(inout) :: self
+      class(abstract_watch), intent(inout) :: self
       character(len=*), intent(in) :: name
       ! internal
       integer :: id
@@ -322,7 +347,7 @@ contains
    end subroutine
 
    subroutine reset_timer_by_name(self, name, save_history)
-      class(lightkrylov_watch), intent(inout) :: self
+      class(abstract_watch), intent(inout) :: self
       character(len=*), intent(in) :: name
       logical, optional, intent(in) :: save_history
       ! internal
@@ -337,7 +362,7 @@ contains
    end subroutine
 
    subroutine enumerate(self, only_user)
-      class(lightkrylov_watch), intent(in) :: self
+      class(abstract_watch), intent(in) :: self
       logical, optional, intent(in) :: only_user
       ! internal
       integer :: i
@@ -361,7 +386,7 @@ contains
    end subroutine enumerate
 
    subroutine reset_all(self, save_history)
-      class(lightkrylov_watch), intent(inout) :: self
+      class(abstract_watch), intent(inout) :: self
       logical, optional, intent(in) :: save_history
       ! internal
       integer :: i
@@ -371,7 +396,11 @@ contains
       end do
    end subroutine reset_all
 
-   subroutine initialize(self)
+   !--------------------------------------------------------------
+   !  Concrete implementations for the lightkrylov_watch type
+   !--------------------------------------------------------------
+
+   subroutine initialize_lightkrylov_watch(self)
       class(lightkrylov_watch), intent(inout) :: self
       ! timers for LightKrylov_BaseKrylov
       ! rsp
@@ -469,9 +498,9 @@ contains
       self%user_mode = .true.
       if_time = .true.
       call logger%log_message('LightKrylov system timer initialization complete.', module=this_module)
-   end subroutine initialize
+   end subroutine initialize_lightkrylov_watch
 
-   subroutine finalize_watch(self)
+   subroutine finalize_lightkrylov_watch(self)
       class(lightkrylov_watch), intent(inout) :: self
       ! internal
       integer :: i, j, icalled
@@ -627,6 +656,6 @@ contains
       end if
       call logger%log_message('###        Global timer summary        #######################################',  & 
                               & module=this_module)
-   end subroutine finalize_watch
+   end subroutine finalize_lightkrylov_watch
 
 end module LightKrylov_Timing

--- a/src/Timer.f90
+++ b/src/Timer.f90
@@ -18,15 +18,21 @@ module LightKrylov_Timing
       character(len=128), public :: name = 'default_timer'
       real(dp) :: elapsed_time = 0.0_dp
       real(dp) :: start_time = 0.0_dp
+      real(dp), dimension(:), allocatable :: etime_history
+      real(dp), dimension(:), allocatable :: etavg_history
+      integer,  dimension(:), allocatable :: count_history
       logical :: running = .false.
       integer :: count = 0
+      integer :: reset_counter = 0
    contains
       procedure, pass(self), public :: start => start_timer
       procedure, pass(self), public :: stop => stop_timer
       procedure, pass(self), public :: pause => pause_timer
       procedure, pass(self), public :: reset => reset_timer
+      procedure, pass(self), public :: finalize => finalize_timer
       procedure, pass(self), public :: get_time => get_timer_time
       procedure, pass(self), public :: print_info => print_timer_info
+      procedure, pass(self), public :: save_timer_history
    end type lightkrylov_timer
 
    ! Watch type
@@ -43,9 +49,11 @@ module LightKrylov_Timing
    contains
       procedure, pass(self), public :: add_timer
       procedure, pass(self), public :: remove_timer
+
       procedure, pass(self), public :: get_timer_id
       procedure, pass(self), public :: initialize
       procedure, pass(self), public :: enumerate
+      procedure, pass(self), public :: reset_all
       procedure, pass(self), public :: finalize => finalize_watch
       procedure, pass(self), public :: start => start_timer_by_name
       procedure, pass(self), public :: stop => stop_timer_by_name
@@ -96,12 +104,37 @@ contains
       end if
    end subroutine pause_timer
 
-   subroutine reset_timer(self)
+   subroutine save_timer_history(self)
       class(lightkrylov_timer), intent(inout) :: self
-      self%elapsed_time = 0.0_dp
-      self%start_time = 0.0_dp
-      self%running = .false.
-      self%count = 0
+      if (self%reset_counter == 0) then
+         allocate(self%etime_history(1))
+         allocate(self%etavg_history(1))
+         allocate(self%count_history(1))
+         self%etime_history(1) = self%elapsed_time
+         self%etavg_history(1) = self%elapsed_time/self%count
+         self%count_history(1) = self%count
+         self%reset_counter = 1
+      else
+         self%etime_history = [ self%etime_history, self%elapsed_time ]
+         self%etavg_history = [ self%etavg_history, self%elapsed_time/self%count ]
+         self%count_history = [ self%count_history, self%count ]
+         self%reset_counter = self%reset_counter + 1
+      end if
+   end subroutine save_timer_history
+
+   subroutine reset_timer(self, save_history)
+      class(lightkrylov_timer), intent(inout) :: self
+      logical, optional, intent(in) :: save_history
+      ! internal
+      logical :: ifsave
+      ifsave = optval(save_history, .true.)
+      if (self%count > 0) then
+         if (ifsave) call self%save_timer_history()
+         self%elapsed_time = 0.0_dp
+         self%start_time = 0.0_dp
+         self%running = .false.
+         self%count = 0
+      end if
    end subroutine reset_timer
 
    real(dp) function get_timer_time(self) result(etime)
@@ -115,21 +148,56 @@ contains
    subroutine print_timer_info(self)
       class(lightkrylov_timer), intent(inout) :: self
       ! internal
-      integer :: i, j, icalled
-      integer :: ic_bk, ic_is, ic_nk, ic_user
-      character(len=128) :: msg
-      icalled = 0
-      call logger%log_message('###################        Timer summary        #################', module=this_module)
-      call logger%log_message('Name: '//trim(self%name), module=this_module)
-      call logger%log_message('________________________________________________', module=this_module)
-      write(msg,'(2X,A20,I8)') 'Count: ', self%count
+      integer :: i
+      real(dp) :: etime, etavg
+      character(len=128) :: msg, timer_fmt
+      timer_fmt       = '(2X,A30," : ",I7,2(1X,F12.6))'
+      call logger%log_message('###        Timer info                  #######################################', module=this_module)
+      write(msg, '(A32," : ",A7,2(1X,A12))') 'name', 'calls', 'total (s)', 'avg (s)'
       call logger%log_message(msg, module=this_module)
-      write(msg,'(2X,A20,F12.8)') 'Total time (s): ', self%get_time()
+      etime = 0.0_dp
+      etavg = 0.0_dp
+      etime = self%get_time()
+      if (self%count > 0) etavg = etime/self%count
+      write(msg,timer_fmt) trim(self%name), self%count, etime, etavg
       call logger%log_message(msg, module=this_module)
-      write(msg,'(2X,A20,F12.8)') 'Average (s): ', self%get_time()/self%count
-      call logger%log_message(msg, module=this_module)
-      call logger%log_message('###################        Timer summary        #################', module=this_module)
+      call logger%log_message('###        Timer info                  #######################################', module=this_module)
    end subroutine print_timer_info
+
+   subroutine finalize_timer(self)
+      class(lightkrylov_timer), intent(inout) :: self
+      ! internal
+      integer :: i, j, icalled
+      integer :: ic_bk, ic_is, ic_nk, ic_user, count
+      real(dp) :: etime, etavg
+      character(len=128) :: msg, timer_fmt, timer_fmt_reset
+      timer_fmt       = '(2X,A30," : ",A6,1X,I7,2(1X,F12.6))'
+      timer_fmt_reset = '(2X,33X,A6,I3,1X,I7,2(1X,F12.6))'
+      icalled = 0
+      call logger%log_message('###        Timer summary               #######################################', module=this_module)
+      write(msg, '(A32," : ",7X,A7,2(1X,A12))') 'name', 'calls', 'total (s)', 'avg (s)'
+      call logger%log_message(msg, module=this_module)
+      call logger%log_message('______________________________________________________________________________', module=this_module)
+      etavg = 0.0_dp
+      if (self%count > 0 .or. self%reset_counter > 0) then
+         if (self%reset_counter == 0) call self%save_timer_history()
+         etime = sum(self%etime_history)
+         count = sum(self%count_history)
+         etavg = sum(self%etavg_history)/self%reset_counter
+         write(msg,timer_fmt) trim(self%name), 'total', count, etime, etavg
+         call logger%log_message(msg, module=this_module)
+         if (self%reset_counter > 1) then
+            do j = 1, self%reset_counter
+               etime = self%etime_history(j)
+               etavg = self%etavg_history(j)
+               count = self%count_history(j)
+               write(msg,timer_fmt_reset) 'reset', j, count, etime, etavg
+               call logger%log_message(msg, module=this_module)
+            end do
+         end if
+      end if
+      call logger%log_message('###        Timer summary               #######################################', module=this_module)
+   end subroutine finalize_timer
 
    !--------------------------------------------------------------
    !  Type-bound procedures for lightkrylov_watch type
@@ -227,21 +295,22 @@ contains
       if (id == 0) then 
          call stop_error('Timer "'//to_lower(trim(name))//'" not found!', module=this_module, procedure='start_timer_by_name')
       else
-         call self%timers(id)%start()
+         call self%timers(id)%pause()
       end if
       call logger%log_debug('Timer "'//to_lower(trim(name))//'" paused.', module=this_module)
    end subroutine
 
-   subroutine reset_timer_by_name(self, name)
+   subroutine reset_timer_by_name(self, name, save_history)
       class(lightkrylov_watch), intent(inout) :: self
       character(len=*), intent(in) :: name
+      logical, optional, intent(in) :: save_history
       ! internal
       integer :: id
       id = self%get_timer_id(name)
       if (id == 0) then 
          call stop_error('Timer "'//to_lower(trim(name))//'" not found!', module=this_module, procedure='start_timer_by_name')
       else
-         call self%timers(id)%start()
+         call self%timers(id)%reset(save_history)
       end if
    end subroutine
 
@@ -268,6 +337,17 @@ contains
          end do
       end if
    end subroutine enumerate
+
+   subroutine reset_all(self, save_history)
+      class(lightkrylov_watch), intent(inout) :: self
+      logical, optional, intent(in) :: save_history
+      ! internal
+      integer :: i
+      character(len=128) :: msg
+      do i = 1, self%timer_count
+         call self%timers(i)%reset(save_history)
+      end do
+   end subroutine reset_all
 
    subroutine initialize(self)
       class(lightkrylov_watch), intent(inout) :: self
@@ -375,45 +455,60 @@ contains
       class(lightkrylov_watch), intent(inout) :: self
       ! internal
       integer :: i, j, icalled
-      integer :: ic_bk, ic_is, ic_nk, ic_user
-      character(len=128) :: msg, timer_fmt
+      integer :: ic_bk, ic_is, ic_nk, ic_user, count, rcount
+      real(dp) :: etime, etavg
+      character(len=128) :: msg, timer_fmt, timer_fmt_reset
       icalled = 0
       ic_bk = 0
       do i = 1, self%timer_count
          call self%timers(i)%stop()
          if (self%timers(i)%count > 0) icalled = icalled + 1
+         call self%timers(i)%save_timer_history()
          if (i == self%basekrylov_count) then
             ic_bk = icalled
          else if (i == self%iterativesolvers_count) then
             ic_is = icalled - ic_bk
          else if (i == self%newtonkrylov_count) then
-            ic_nk = icalled - ic_is
+            ic_nk = icalled - ic_is - ic_bk
          end if
       end do
-      ic_user = icalled - ic_nk
+      ic_user = icalled - ic_nk - ic_is - ic_bk
       if_time = .false.
-      call logger%log_message('###############        Global timer summary        ##############', module=this_module)
+      call logger%log_message('###        Global timer summary        #######################################', module=this_module)
       call logger%log_message('____________________', module=this_module)
       call logger%log_message('Overview:', module=this_module)
-      call logger%log_message('_________________________________________________________________', module=this_module)
-      write(msg, '(2X,A20,I5)') 'Total active timers:', self%timer_count
+      write(msg, '(2X,A40,I5)') 'Total active timers:', self%timer_count
       call logger%log_message(msg, module=this_module)
-      write(msg, '(2X,A20,I5)') 'User defined:', self%user_count
+      write(msg, '(2X,A40,I5)') 'User defined:', self%user_count
       call logger%log_message(msg, module=this_module)
-      write(msg, '(2X,A20,I5)') 'Called timers:', icalled
+      write(msg, '(2X,A40,I5)') 'Called timers:', icalled
       call logger%log_message(msg, module=this_module)
-      write(msg, '(A32,A7,2(1X,A12))') 'name', 'calls', 'total (s)', 'avg (s)'
-      call logger%log_message(msg, module=this_module)
-      timer_fmt = '(2X,A30,I7,2(1X,F12.6))'
+      timer_fmt = '(2X,A30," : ",A6,1X,I7,2(1X,F12.6))'
+      timer_fmt_reset = '(2X,33X,A6,I3,1X,I7,2(1X,F12.6))'
       if (ic_bk > 0) then
          call logger%log_message('____________________', module=this_module)
          call logger%log_message('BaseKrylov:', module=this_module)
-         call logger%log_message('_________________________________________________________________', module=this_module)
+         write(msg, '(A32," : ",7X,A7,2(1X,A12))') 'name', 'calls', 'total (s)', 'avg (s)'
+         call logger%log_message(msg, module=this_module)
+         call logger%log_message('______________________________________________________________________________', module=this_module)
          do i = 1, self%basekrylov_count
             associate(t => self%timers(i))
-               if (t%count > 0) then
-                  write(msg,timer_fmt) trim(t%name), t%count, t%get_time(), t%get_time()/t%count
+               rcount = t%reset_counter
+               if (t%count_history(rcount) > 0) then
+                  etime = sum(t%etime_history)
+                  etavg = sum(t%etavg_history)/rcount
+                  count = sum(t%count_history)
+                  write(msg,timer_fmt) trim(t%name), 'total', count, etime, etavg
                   call logger%log_message(msg, module=this_module)
+                  if (rcount > 1) then
+                     do j = 1, rcount
+                        etime = t%etime_history(j)
+                        etavg = t%etavg_history(j)
+                        count = t%count_history(j)
+                        write(msg,timer_fmt_reset) 'reset', j, count, etime, etavg
+                        call logger%log_message(msg, module=this_module)
+                     end do
+                  end if
                end if
             end associate
          end do
@@ -422,12 +517,27 @@ contains
       if (ic_is > 0) then
          call logger%log_message('____________________', module=this_module)
          call logger%log_message('IterativeSolvers:', module=this_module)
-         call logger%log_message('_________________________________________________________________', module=this_module)
+         write(msg, '(A32," : ",7X,A7,2(1X,A12))') 'name', 'calls', 'total (s)', 'avg (s)'
+         call logger%log_message(msg, module=this_module)
+         call logger%log_message('______________________________________________________________________________', module=this_module)
          do i = j, self%iterativesolvers_count
             associate(t => self%timers(i))
-               if (t%count > 0) then
-                  write(msg,timer_fmt) trim(t%name), t%count, t%get_time(), t%get_time()/t%count
+               rcount = t%reset_counter
+               if (t%count_history(rcount) > 0) then
+                  etime = sum(t%etime_history)
+                  etavg = sum(t%etavg_history)/rcount
+                  count = sum(t%count_history)
+                  write(msg,timer_fmt) trim(t%name), 'total', count, etime, etavg
                   call logger%log_message(msg, module=this_module)
+                  if (rcount > 1) then
+                     do j = 1, rcount
+                        etime = t%etime_history(j)
+                        etavg = t%etavg_history(j)
+                        count = t%count_history(j)
+                        write(msg,timer_fmt_reset) 'reset', j, count, etime, etavg
+                        call logger%log_message(msg, module=this_module)
+                     end do
+                  end if
                end if
             end associate
          end do
@@ -436,12 +546,27 @@ contains
       if (ic_nk > 0) then
          call logger%log_message('____________________', module=this_module)
          call logger%log_message('NewtonKrylov:', module=this_module)
+         write(msg, '(A32," : ",7X,A7,2(1X,A12))') 'name', 'calls', 'total (s)', 'avg (s)'
+         call logger%log_message(msg, module=this_module)
          call logger%log_message('_________________________________________________________________', module=this_module)
          do i = j, self%newtonkrylov_count
             associate(t => self%timers(i))
-               if (t%count > 0) then
-                  write(msg,timer_fmt) trim(t%name), t%count, t%get_time(), t%get_time()/t%count
+               rcount = t%reset_counter
+               if (t%count_history(rcount) > 0) then
+                  etime = sum(t%etime_history)
+                  etavg = sum(t%etavg_history)/rcount
+                  count = sum(t%count_history)
+                  write(msg,timer_fmt) trim(t%name), 'total', count, etime, etavg
                   call logger%log_message(msg, module=this_module)
+                  if (rcount > 1) then
+                     do j = 1, rcount
+                        etime = t%etime_history(j)
+                        etavg = t%etavg_history(j)
+                        count = t%count_history(j)
+                        write(msg,timer_fmt_reset) 'reset', j, count, etime, etavg
+                        call logger%log_message(msg, module=this_module)
+                     end do
+                  end if
                end if
             end associate
          end do
@@ -450,17 +575,32 @@ contains
          j = self%private_count
          call logger%log_message('____________________', module=this_module)
          call logger%log_message('User-defined:', module=this_module)
+         write(msg, '(A32," : ",7X,A7,2(1X,A12))') 'name', 'calls', 'total (s)', 'avg (s)'
+         call logger%log_message(msg, module=this_module)
          call logger%log_message('_________________________________________________________________', module=this_module)
          do i = j, self%timer_count
             associate(t => self%timers(i))
-               if (t%count > 0) then
-                  write(msg,timer_fmt) trim(t%name), t%count, t%get_time(), t%get_time()/t%count
+               rcount = t%reset_counter
+               if (t%count_history(rcount) > 0) then
+                  etime = sum(t%etime_history)
+                  etavg = sum(t%etavg_history)/rcount
+                  count = sum(t%count_history)
+                  write(msg,timer_fmt) trim(t%name), 'total', count, etime, etavg
                   call logger%log_message(msg, module=this_module)
+                  if (rcount > 1) then
+                     do j = 1, rcount
+                        etime = t%etime_history(j)
+                        etavg = t%etavg_history(j)
+                        count = t%count_history(j)
+                        write(msg,timer_fmt_reset) 'reset', j, count, etime, etavg
+                        call logger%log_message(msg, module=this_module)
+                     end do
+                  end if
                end if
             end associate
          end do
       end if
-      call logger%log_message('###############        Global timer summary        ##############', module=this_module)
+      call logger%log_message('###        Global timer summary        #######################################', module=this_module)
    end subroutine finalize_watch
 
 end module LightKrylov_Timing

--- a/src/Timer.f90
+++ b/src/Timer.f90
@@ -49,7 +49,6 @@ module LightKrylov_Timing
    contains
       procedure, pass(self), public :: add_timer
       procedure, pass(self), public :: remove_timer
-
       procedure, pass(self), public :: get_timer_id
       procedure, pass(self), public :: initialize
       procedure, pass(self), public :: enumerate

--- a/src/Timer.fypp
+++ b/src/Timer.fypp
@@ -27,6 +27,7 @@ module LightKrylov_Timing
       integer :: count = 0
       integer :: reset_counter = 0
    contains
+      private
       procedure, pass(self), public :: start => start_timer
       procedure, pass(self), public :: stop => stop_timer
       procedure, pass(self), public :: pause => pause_timer
@@ -37,33 +38,57 @@ module LightKrylov_Timing
       procedure, pass(self), public :: save_timer_history
    end type lightkrylov_timer
 
-   ! Watch type
-   type :: lightkrylov_watch
+   ! Abstract watch type
+   type, abstract, public :: abstract_watch
+      !! Base type to define a global timer.
       private
       type(lightkrylov_timer), dimension(:), allocatable :: timers
       integer :: timer_count = 0
-      integer :: basekrylov_count = 0
-      integer :: iterativesolvers_count = 0
-      integer :: newtonkrylov_count = 0
       integer :: private_count = 0
       logical :: user_mode = .false.
       integer :: user_count = 0
    contains
+      private
       procedure, pass(self), public :: add_timer
       procedure, pass(self), public :: remove_timer
       procedure, pass(self), public :: get_timer_id
-      procedure, pass(self), public :: initialize
       procedure, pass(self), public :: enumerate
       procedure, pass(self), public :: reset_all
-      procedure, pass(self), public :: finalize => finalize_watch
       procedure, pass(self), public :: start => start_timer_by_name
       procedure, pass(self), public :: stop => stop_timer_by_name
       procedure, pass(self), public :: pause => pause_timer_by_name
       procedure, pass(self), public :: reset => reset_timer_by_name
+      procedure(abstract_watch_init), pass(self), deferred, public :: initialize
+      procedure(abstract_watch_exit), pass(self), deferred, public :: finalize
+   end type abstract_watch
+
+   abstract interface
+      subroutine abstract_watch_init(self)
+         !! Interface for the initialization of the structure.
+         import abstract_watch
+         class(abstract_watch), intent(inout) :: self
+      end subroutine abstract_watch_init
+      subroutine abstract_watch_exit(self)
+         !! Interface for the finalization of the structure including the printing of the results
+         import abstract_watch
+         class(abstract_watch), intent(inout) :: self
+      end subroutine abstract_watch_exit
+   end interface
+
+   ! LightKrylov_watch type
+   type, extends(abstract_watch), public :: lightkrylov_watch
+      !! Global timing structure to contain all timers within Lightkrylov
+      character(len=128) :: name = 'lightkrylov_timer'
+      integer :: basekrylov_count = 0
+      integer :: iterativesolvers_count = 0
+      integer :: newtonkrylov_count = 0
+   contains
+      private
+      procedure, pass(self), public :: initialize => initialize_lightkrylov_watch
+      procedure, pass(self), public :: finalize => finalize_lightkrylov_watch
    end type lightkrylov_watch
 
    type(lightkrylov_watch) :: global_lightkrylov_timer
-
 contains
 
    logical function time_lightkrylov() result(if_time_lightkrylov)
@@ -217,11 +242,11 @@ contains
    end subroutine finalize_timer
 
    !--------------------------------------------------------------
-   !  Type-bound procedures for lightkrylov_watch type
+   !  Type-bound procedures for abstract_watch type
    !--------------------------------------------------------------
 
    integer function get_timer_id(self, name) result(id)
-      class(lightkrylov_watch) :: self
+      class(abstract_watch) :: self
       character(len=*)  :: name
       ! internal
       integer :: i
@@ -234,7 +259,7 @@ contains
    end function get_timer_id
 
    subroutine add_timer(self, name)
-      class(lightkrylov_watch), intent(inout) :: self
+      class(abstract_watch), intent(inout) :: self
       character(len=*), intent(in) :: name
       if (self%timer_count == 0) then
          allocate(self%timers(1))
@@ -253,7 +278,7 @@ contains
    end subroutine add_timer
 
    subroutine remove_timer(self, name)
-      class(lightkrylov_watch), intent(inout) :: self
+      class(abstract_watch), intent(inout) :: self
       character(len=*), intent(in) :: name
       ! internal
       type(lightkrylov_timer), dimension(:), allocatable :: new_timers
@@ -279,7 +304,7 @@ contains
    end subroutine remove_timer
    
    subroutine start_timer_by_name(self, name)
-      class(lightkrylov_watch), intent(inout) :: self
+      class(abstract_watch), intent(inout) :: self
       character(len=*), intent(in) :: name
       ! internal
       integer :: id
@@ -294,7 +319,7 @@ contains
    end subroutine start_timer_by_name
 
    subroutine stop_timer_by_name(self, name)
-      class(lightkrylov_watch), intent(inout) :: self
+      class(abstract_watch), intent(inout) :: self
       character(len=*), intent(in) :: name
       ! internal
       integer :: id
@@ -309,7 +334,7 @@ contains
    end subroutine stop_timer_by_name
 
    subroutine pause_timer_by_name(self, name)
-      class(lightkrylov_watch), intent(inout) :: self
+      class(abstract_watch), intent(inout) :: self
       character(len=*), intent(in) :: name
       ! internal
       integer :: id
@@ -324,7 +349,7 @@ contains
    end subroutine
 
    subroutine reset_timer_by_name(self, name, save_history)
-      class(lightkrylov_watch), intent(inout) :: self
+      class(abstract_watch), intent(inout) :: self
       character(len=*), intent(in) :: name
       logical, optional, intent(in) :: save_history
       ! internal
@@ -339,7 +364,7 @@ contains
    end subroutine
 
    subroutine enumerate(self, only_user)
-      class(lightkrylov_watch), intent(in) :: self
+      class(abstract_watch), intent(in) :: self
       logical, optional, intent(in) :: only_user
       ! internal
       integer :: i
@@ -363,7 +388,7 @@ contains
    end subroutine enumerate
 
    subroutine reset_all(self, save_history)
-      class(lightkrylov_watch), intent(inout) :: self
+      class(abstract_watch), intent(inout) :: self
       logical, optional, intent(in) :: save_history
       ! internal
       integer :: i
@@ -373,7 +398,11 @@ contains
       end do
    end subroutine reset_all
 
-   subroutine initialize(self)
+   !--------------------------------------------------------------
+   !  Concrete implementations for the lightkrylov_watch type
+   !--------------------------------------------------------------
+
+   subroutine initialize_lightkrylov_watch(self)
       class(lightkrylov_watch), intent(inout) :: self
       ! timers for LightKrylov_BaseKrylov
       #:for kind, type in RC_KINDS_TYPES
@@ -411,9 +440,9 @@ contains
       self%user_mode = .true.
       if_time = .true.
       call logger%log_message('LightKrylov system timer initialization complete.', module=this_module)
-   end subroutine initialize
+   end subroutine initialize_lightkrylov_watch
 
-   subroutine finalize_watch(self)
+   subroutine finalize_lightkrylov_watch(self)
       class(lightkrylov_watch), intent(inout) :: self
       ! internal
       integer :: i, j, icalled
@@ -569,6 +598,6 @@ contains
       end if
       call logger%log_message('###        Global timer summary        #######################################',  & 
                               & module=this_module)
-   end subroutine finalize_watch
+   end subroutine finalize_lightkrylov_watch
 
 end module LightKrylov_Timing

--- a/src/Timer.fypp
+++ b/src/Timer.fypp
@@ -283,6 +283,9 @@ contains
       call self%add_timer('orthonormalize_basis_against_basis_${type[0]}$${kind}$')
       call self%add_timer('dgs_vector_against_basis_${type[0]}$${kind}$')
       call self%add_timer('dgs_basis_against_basis_${type[0]}$${kind}$')
+      call self%add_timer('arnoldi_${type[0]}$${kind}$')
+      call self%add_timer('lanczos_bidiagonalization_${type[0]}$${kind}$')
+      call self%add_timer('lanczos_tridiagonalization_${type[0]}$${kind}$')
       self%basekrylov_count = self%timer_count
       #:endfor
       ! timers for LightKrylov_IterativeSolvers

--- a/src/Timer.fypp
+++ b/src/Timer.fypp
@@ -20,15 +20,21 @@ module LightKrylov_Timing
       character(len=128), public :: name = 'default_timer'
       real(dp) :: elapsed_time = 0.0_dp
       real(dp) :: start_time = 0.0_dp
+      real(dp), dimension(:), allocatable :: etime_history
+      real(dp), dimension(:), allocatable :: etavg_history
+      integer,  dimension(:), allocatable :: count_history
       logical :: running = .false.
       integer :: count = 0
+      integer :: reset_counter = 0
    contains
       procedure, pass(self), public :: start => start_timer
       procedure, pass(self), public :: stop => stop_timer
       procedure, pass(self), public :: pause => pause_timer
       procedure, pass(self), public :: reset => reset_timer
+      procedure, pass(self), public :: finalize => finalize_timer
       procedure, pass(self), public :: get_time => get_timer_time
       procedure, pass(self), public :: print_info => print_timer_info
+      procedure, pass(self), public :: save_timer_history
    end type lightkrylov_timer
 
    ! Watch type
@@ -45,9 +51,11 @@ module LightKrylov_Timing
    contains
       procedure, pass(self), public :: add_timer
       procedure, pass(self), public :: remove_timer
+
       procedure, pass(self), public :: get_timer_id
       procedure, pass(self), public :: initialize
       procedure, pass(self), public :: enumerate
+      procedure, pass(self), public :: reset_all
       procedure, pass(self), public :: finalize => finalize_watch
       procedure, pass(self), public :: start => start_timer_by_name
       procedure, pass(self), public :: stop => stop_timer_by_name
@@ -98,12 +106,37 @@ contains
       end if
    end subroutine pause_timer
 
-   subroutine reset_timer(self)
+   subroutine save_timer_history(self)
       class(lightkrylov_timer), intent(inout) :: self
-      self%elapsed_time = 0.0_dp
-      self%start_time = 0.0_dp
-      self%running = .false.
-      self%count = 0
+      if (self%reset_counter == 0) then
+         allocate(self%etime_history(1))
+         allocate(self%etavg_history(1))
+         allocate(self%count_history(1))
+         self%etime_history(1) = self%elapsed_time
+         self%etavg_history(1) = self%elapsed_time/self%count
+         self%count_history(1) = self%count
+         self%reset_counter = 1
+      else
+         self%etime_history = [ self%etime_history, self%elapsed_time ]
+         self%etavg_history = [ self%etavg_history, self%elapsed_time/self%count ]
+         self%count_history = [ self%count_history, self%count ]
+         self%reset_counter = self%reset_counter + 1
+      end if
+   end subroutine save_timer_history
+
+   subroutine reset_timer(self, save_history)
+      class(lightkrylov_timer), intent(inout) :: self
+      logical, optional, intent(in) :: save_history
+      ! internal
+      logical :: ifsave
+      ifsave = optval(save_history, .true.)
+      if (self%count > 0) then
+         if (ifsave) call self%save_timer_history()
+         self%elapsed_time = 0.0_dp
+         self%start_time = 0.0_dp
+         self%running = .false.
+         self%count = 0
+      end if
    end subroutine reset_timer
 
    real(dp) function get_timer_time(self) result(etime)
@@ -117,21 +150,56 @@ contains
    subroutine print_timer_info(self)
       class(lightkrylov_timer), intent(inout) :: self
       ! internal
-      integer :: i, j, icalled
-      integer :: ic_bk, ic_is, ic_nk, ic_user
-      character(len=128) :: msg
-      icalled = 0
-      call logger%log_message('###################        Timer summary        #################', module=this_module)
-      call logger%log_message('Name: '//trim(self%name), module=this_module)
-      call logger%log_message('________________________________________________', module=this_module)
-      write(msg,'(2X,A20,I8)') 'Count: ', self%count
+      integer :: i
+      real(dp) :: etime, etavg
+      character(len=128) :: msg, timer_fmt
+      timer_fmt       = '(2X,A30," : ",I7,2(1X,F12.6))'
+      call logger%log_message('###        Timer info                  #######################################', module=this_module)
+      write(msg, '(A32," : ",A7,2(1X,A12))') 'name', 'calls', 'total (s)', 'avg (s)'
       call logger%log_message(msg, module=this_module)
-      write(msg,'(2X,A20,F12.8)') 'Total time (s): ', self%get_time()
+      etime = 0.0_dp
+      etavg = 0.0_dp
+      etime = self%get_time()
+      if (self%count > 0) etavg = etime/self%count
+      write(msg,timer_fmt) trim(self%name), self%count, etime, etavg
       call logger%log_message(msg, module=this_module)
-      write(msg,'(2X,A20,F12.8)') 'Average (s): ', self%get_time()/self%count
-      call logger%log_message(msg, module=this_module)
-      call logger%log_message('###################        Timer summary        #################', module=this_module)
+      call logger%log_message('###        Timer info                  #######################################', module=this_module)
    end subroutine print_timer_info
+
+   subroutine finalize_timer(self)
+      class(lightkrylov_timer), intent(inout) :: self
+      ! internal
+      integer :: i, j, icalled
+      integer :: ic_bk, ic_is, ic_nk, ic_user, count
+      real(dp) :: etime, etavg
+      character(len=128) :: msg, timer_fmt, timer_fmt_reset
+      timer_fmt       = '(2X,A30," : ",A6,1X,I7,2(1X,F12.6))'
+      timer_fmt_reset = '(2X,33X,A6,I3,1X,I7,2(1X,F12.6))'
+      icalled = 0
+      call logger%log_message('###        Timer summary               #######################################', module=this_module)
+      write(msg, '(A32," : ",7X,A7,2(1X,A12))') 'name', 'calls', 'total (s)', 'avg (s)'
+      call logger%log_message(msg, module=this_module)
+      call logger%log_message('______________________________________________________________________________', module=this_module)
+      etavg = 0.0_dp
+      if (self%count > 0 .or. self%reset_counter > 0) then
+         if (self%reset_counter == 0) call self%save_timer_history()
+         etime = sum(self%etime_history)
+         count = sum(self%count_history)
+         etavg = sum(self%etavg_history)/self%reset_counter
+         write(msg,timer_fmt) trim(self%name), 'total', count, etime, etavg
+         call logger%log_message(msg, module=this_module)
+         if (self%reset_counter > 1) then
+            do j = 1, self%reset_counter
+               etime = self%etime_history(j)
+               etavg = self%etavg_history(j)
+               count = self%count_history(j)
+               write(msg,timer_fmt_reset) 'reset', j, count, etime, etavg
+               call logger%log_message(msg, module=this_module)
+            end do
+         end if
+      end if
+      call logger%log_message('###        Timer summary               #######################################', module=this_module)
+   end subroutine finalize_timer
 
    !--------------------------------------------------------------
    !  Type-bound procedures for lightkrylov_watch type
@@ -229,21 +297,22 @@ contains
       if (id == 0) then 
          call stop_error('Timer "'//to_lower(trim(name))//'" not found!', module=this_module, procedure='start_timer_by_name')
       else
-         call self%timers(id)%start()
+         call self%timers(id)%pause()
       end if
       call logger%log_debug('Timer "'//to_lower(trim(name))//'" paused.', module=this_module)
    end subroutine
 
-   subroutine reset_timer_by_name(self, name)
+   subroutine reset_timer_by_name(self, name, save_history)
       class(lightkrylov_watch), intent(inout) :: self
       character(len=*), intent(in) :: name
+      logical, optional, intent(in) :: save_history
       ! internal
       integer :: id
       id = self%get_timer_id(name)
       if (id == 0) then 
          call stop_error('Timer "'//to_lower(trim(name))//'" not found!', module=this_module, procedure='start_timer_by_name')
       else
-         call self%timers(id)%start()
+         call self%timers(id)%reset(save_history)
       end if
    end subroutine
 
@@ -270,6 +339,17 @@ contains
          end do
       end if
    end subroutine enumerate
+
+   subroutine reset_all(self, save_history)
+      class(lightkrylov_watch), intent(inout) :: self
+      logical, optional, intent(in) :: save_history
+      ! internal
+      integer :: i
+      character(len=128) :: msg
+      do i = 1, self%timer_count
+         call self%timers(i)%reset(save_history)
+      end do
+   end subroutine reset_all
 
    subroutine initialize(self)
       class(lightkrylov_watch), intent(inout) :: self
@@ -317,45 +397,60 @@ contains
       class(lightkrylov_watch), intent(inout) :: self
       ! internal
       integer :: i, j, icalled
-      integer :: ic_bk, ic_is, ic_nk, ic_user
-      character(len=128) :: msg, timer_fmt
+      integer :: ic_bk, ic_is, ic_nk, ic_user, count, rcount
+      real(dp) :: etime, etavg
+      character(len=128) :: msg, timer_fmt, timer_fmt_reset
       icalled = 0
       ic_bk = 0
       do i = 1, self%timer_count
          call self%timers(i)%stop()
          if (self%timers(i)%count > 0) icalled = icalled + 1
+         call self%timers(i)%save_timer_history()
          if (i == self%basekrylov_count) then
             ic_bk = icalled
          else if (i == self%iterativesolvers_count) then
             ic_is = icalled - ic_bk
          else if (i == self%newtonkrylov_count) then
-            ic_nk = icalled - ic_is
+            ic_nk = icalled - ic_is - ic_bk
          end if
       end do
-      ic_user = icalled - ic_nk
+      ic_user = icalled - ic_nk - ic_is - ic_bk
       if_time = .false.
-      call logger%log_message('###############        Global timer summary        ##############', module=this_module)
+      call logger%log_message('###        Global timer summary        #######################################', module=this_module)
       call logger%log_message('____________________', module=this_module)
       call logger%log_message('Overview:', module=this_module)
-      call logger%log_message('_________________________________________________________________', module=this_module)
-      write(msg, '(2X,A20,I5)') 'Total active timers:', self%timer_count
+      write(msg, '(2X,A40,I5)') 'Total active timers:', self%timer_count
       call logger%log_message(msg, module=this_module)
-      write(msg, '(2X,A20,I5)') 'User defined:', self%user_count
+      write(msg, '(2X,A40,I5)') 'User defined:', self%user_count
       call logger%log_message(msg, module=this_module)
-      write(msg, '(2X,A20,I5)') 'Called timers:', icalled
+      write(msg, '(2X,A40,I5)') 'Called timers:', icalled
       call logger%log_message(msg, module=this_module)
-      write(msg, '(A32,A7,2(1X,A12))') 'name', 'calls', 'total (s)', 'avg (s)'
-      call logger%log_message(msg, module=this_module)
-      timer_fmt = '(2X,A30,I7,2(1X,F12.6))'
+      timer_fmt = '(2X,A30," : ",A6,1X,I7,2(1X,F12.6))'
+      timer_fmt_reset = '(2X,33X,A6,I3,1X,I7,2(1X,F12.6))'
       if (ic_bk > 0) then
          call logger%log_message('____________________', module=this_module)
          call logger%log_message('BaseKrylov:', module=this_module)
-         call logger%log_message('_________________________________________________________________', module=this_module)
+         write(msg, '(A32," : ",7X,A7,2(1X,A12))') 'name', 'calls', 'total (s)', 'avg (s)'
+         call logger%log_message(msg, module=this_module)
+         call logger%log_message('______________________________________________________________________________', module=this_module)
          do i = 1, self%basekrylov_count
             associate(t => self%timers(i))
-               if (t%count > 0) then
-                  write(msg,timer_fmt) trim(t%name), t%count, t%get_time(), t%get_time()/t%count
+               rcount = t%reset_counter
+               if (t%count_history(rcount) > 0) then
+                  etime = sum(t%etime_history)
+                  etavg = sum(t%etavg_history)/rcount
+                  count = sum(t%count_history)
+                  write(msg,timer_fmt) trim(t%name), 'total', count, etime, etavg
                   call logger%log_message(msg, module=this_module)
+                  if (rcount > 1) then
+                     do j = 1, rcount
+                        etime = t%etime_history(j)
+                        etavg = t%etavg_history(j)
+                        count = t%count_history(j)
+                        write(msg,timer_fmt_reset) 'reset', j, count, etime, etavg
+                        call logger%log_message(msg, module=this_module)
+                     end do
+                  end if
                end if
             end associate
          end do
@@ -364,12 +459,27 @@ contains
       if (ic_is > 0) then
          call logger%log_message('____________________', module=this_module)
          call logger%log_message('IterativeSolvers:', module=this_module)
-         call logger%log_message('_________________________________________________________________', module=this_module)
+         write(msg, '(A32," : ",7X,A7,2(1X,A12))') 'name', 'calls', 'total (s)', 'avg (s)'
+         call logger%log_message(msg, module=this_module)
+         call logger%log_message('______________________________________________________________________________', module=this_module)
          do i = j, self%iterativesolvers_count
             associate(t => self%timers(i))
-               if (t%count > 0) then
-                  write(msg,timer_fmt) trim(t%name), t%count, t%get_time(), t%get_time()/t%count
+               rcount = t%reset_counter
+               if (t%count_history(rcount) > 0) then
+                  etime = sum(t%etime_history)
+                  etavg = sum(t%etavg_history)/rcount
+                  count = sum(t%count_history)
+                  write(msg,timer_fmt) trim(t%name), 'total', count, etime, etavg
                   call logger%log_message(msg, module=this_module)
+                  if (rcount > 1) then
+                     do j = 1, rcount
+                        etime = t%etime_history(j)
+                        etavg = t%etavg_history(j)
+                        count = t%count_history(j)
+                        write(msg,timer_fmt_reset) 'reset', j, count, etime, etavg
+                        call logger%log_message(msg, module=this_module)
+                     end do
+                  end if
                end if
             end associate
          end do
@@ -378,12 +488,27 @@ contains
       if (ic_nk > 0) then
          call logger%log_message('____________________', module=this_module)
          call logger%log_message('NewtonKrylov:', module=this_module)
+         write(msg, '(A32," : ",7X,A7,2(1X,A12))') 'name', 'calls', 'total (s)', 'avg (s)'
+         call logger%log_message(msg, module=this_module)
          call logger%log_message('_________________________________________________________________', module=this_module)
          do i = j, self%newtonkrylov_count
             associate(t => self%timers(i))
-               if (t%count > 0) then
-                  write(msg,timer_fmt) trim(t%name), t%count, t%get_time(), t%get_time()/t%count
+               rcount = t%reset_counter
+               if (t%count_history(rcount) > 0) then
+                  etime = sum(t%etime_history)
+                  etavg = sum(t%etavg_history)/rcount
+                  count = sum(t%count_history)
+                  write(msg,timer_fmt) trim(t%name), 'total', count, etime, etavg
                   call logger%log_message(msg, module=this_module)
+                  if (rcount > 1) then
+                     do j = 1, rcount
+                        etime = t%etime_history(j)
+                        etavg = t%etavg_history(j)
+                        count = t%count_history(j)
+                        write(msg,timer_fmt_reset) 'reset', j, count, etime, etavg
+                        call logger%log_message(msg, module=this_module)
+                     end do
+                  end if
                end if
             end associate
          end do
@@ -392,17 +517,32 @@ contains
          j = self%private_count
          call logger%log_message('____________________', module=this_module)
          call logger%log_message('User-defined:', module=this_module)
+         write(msg, '(A32," : ",7X,A7,2(1X,A12))') 'name', 'calls', 'total (s)', 'avg (s)'
+         call logger%log_message(msg, module=this_module)
          call logger%log_message('_________________________________________________________________', module=this_module)
          do i = j, self%timer_count
             associate(t => self%timers(i))
-               if (t%count > 0) then
-                  write(msg,timer_fmt) trim(t%name), t%count, t%get_time(), t%get_time()/t%count
+               rcount = t%reset_counter
+               if (t%count_history(rcount) > 0) then
+                  etime = sum(t%etime_history)
+                  etavg = sum(t%etavg_history)/rcount
+                  count = sum(t%count_history)
+                  write(msg,timer_fmt) trim(t%name), 'total', count, etime, etavg
                   call logger%log_message(msg, module=this_module)
+                  if (rcount > 1) then
+                     do j = 1, rcount
+                        etime = t%etime_history(j)
+                        etavg = t%etavg_history(j)
+                        count = t%count_history(j)
+                        write(msg,timer_fmt_reset) 'reset', j, count, etime, etavg
+                        call logger%log_message(msg, module=this_module)
+                     end do
+                  end if
                end if
             end associate
          end do
       end if
-      call logger%log_message('###############        Global timer summary        ##############', module=this_module)
+      call logger%log_message('###        Global timer summary        #######################################', module=this_module)
    end subroutine finalize_watch
 
 end module LightKrylov_Timing

--- a/src/Timer.fypp
+++ b/src/Timer.fypp
@@ -51,7 +51,6 @@ module LightKrylov_Timing
    contains
       procedure, pass(self), public :: add_timer
       procedure, pass(self), public :: remove_timer
-
       procedure, pass(self), public :: get_timer_id
       procedure, pass(self), public :: initialize
       procedure, pass(self), public :: enumerate

--- a/src/Timer.fypp
+++ b/src/Timer.fypp
@@ -1,21 +1,23 @@
 #:include "../include/common.fypp"
 #:set RC_KINDS_TYPES = REAL_KINDS_TYPES + CMPLX_KINDS_TYPES
-module LightKrylov_Timer
+module LightKrylov_Timing
    use stdlib_optval, only: optval
+   use stdlib_ascii, only: to_lower
    use LightKrylov_Constants, only: dp
    use LightKrylov_Logger
    implicit none
    private
-   character(len=128), parameter :: this_module = 'LightKrylov_Timer'
+   character(len=*), parameter :: this_module      = 'LK_Timer'
+   character(len=*), parameter :: this_module_long = 'LightKrylov_Timer'
    logical :: if_time = .false.
 
    public :: time_lightkrylov
-   public :: global_timer
+   public :: global_lightkrylov_timer
 
    ! Timer type
-   type, public :: timer_type
+   type, public :: lightkrylov_timer
       private
-      character(len=128) :: name
+      character(len=128), public :: name = 'default_timer'
       real(dp) :: elapsed_time = 0.0_dp
       real(dp) :: start_time = 0.0_dp
       logical :: running = .false.
@@ -26,12 +28,13 @@ module LightKrylov_Timer
       procedure, pass(self), public :: pause => pause_timer
       procedure, pass(self), public :: reset => reset_timer
       procedure, pass(self), public :: get_time => get_timer_time
-   end type timer_type
+      procedure, pass(self), public :: print_info => print_timer_info
+   end type lightkrylov_timer
 
    ! Watch type
-   type :: watch_type
+   type :: lightkrylov_watch
       private
-      type(timer_type), dimension(:), allocatable :: timers
+      type(lightkrylov_timer), dimension(:), allocatable :: timers
       integer :: timer_count = 0
       integer :: basekrylov_count = 0
       integer :: iterativesolvers_count = 0
@@ -45,24 +48,27 @@ module LightKrylov_Timer
       procedure, pass(self), public :: get_timer_id
       procedure, pass(self), public :: initialize
       procedure, pass(self), public :: enumerate
-      procedure, pass(self), public :: finalize
+      procedure, pass(self), public :: finalize => finalize_watch
       procedure, pass(self), public :: start => start_timer_by_name
       procedure, pass(self), public :: stop => stop_timer_by_name
       procedure, pass(self), public :: pause => pause_timer_by_name
       procedure, pass(self), public :: reset => reset_timer_by_name
-   end type watch_type
+   end type lightkrylov_watch
 
-   type(watch_type) :: global_timer
+   type(lightkrylov_watch) :: global_lightkrylov_timer
 
 contains
 
-   function time_lightkrylov() result(if_time_lightkrylov)
-      logical :: if_time_lightkrylov
+   logical function time_lightkrylov() result(if_time_lightkrylov)
       if_time_lightkrylov = if_time
    end function time_lightkrylov
 
+   !--------------------------------------------------------------
+   !  Type-bound procedures for lightkrylov_timer type
+   !--------------------------------------------------------------
+
    subroutine start_timer(self)
-      class(timer_type), intent(inout) :: self
+      class(lightkrylov_timer), intent(inout) :: self
       if (.not. self%running) then
          call cpu_time(self%start_time)
          self%running = .true.
@@ -71,7 +77,7 @@ contains
    end subroutine start_timer
 
    subroutine stop_timer(self)
-      class(timer_type), intent(inout) :: self
+      class(lightkrylov_timer), intent(inout) :: self
       ! internal
       real(dp) :: t_now
       call cpu_time(t_now)
@@ -82,7 +88,7 @@ contains
    end subroutine stop_timer
 
    subroutine pause_timer(self)
-      class(timer_type), intent(inout) :: self
+      class(lightkrylov_timer), intent(inout) :: self
       ! internal
       real(dp) :: t_now
       call cpu_time(t_now)
@@ -93,7 +99,7 @@ contains
    end subroutine pause_timer
 
    subroutine reset_timer(self)
-      class(timer_type), intent(inout) :: self
+      class(lightkrylov_timer), intent(inout) :: self
       self%elapsed_time = 0.0_dp
       self%start_time = 0.0_dp
       self%running = .false.
@@ -101,55 +107,79 @@ contains
    end subroutine reset_timer
 
    real(dp) function get_timer_time(self) result(etime)
-      class(timer_type), intent(inout) :: self
+      class(lightkrylov_timer), intent(inout) :: self
       if (self%running) then
          call self%stop()
       end if
       etime = self%elapsed_time
    end function
 
+   subroutine print_timer_info(self)
+      class(lightkrylov_timer), intent(inout) :: self
+      ! internal
+      integer :: i, j, icalled
+      integer :: ic_bk, ic_is, ic_nk, ic_user
+      character(len=128) :: msg
+      icalled = 0
+      call logger%log_message('###################        Timer summary        #################', module=this_module)
+      call logger%log_message('Name: '//trim(self%name), module=this_module)
+      call logger%log_message('________________________________________________', module=this_module)
+      write(msg,'(2X,A20,I8)') 'Count: ', self%count
+      call logger%log_message(msg, module=this_module)
+      write(msg,'(2X,A20,F12.8)') 'Total time (s): ', self%get_time()
+      call logger%log_message(msg, module=this_module)
+      write(msg,'(2X,A20,F12.8)') 'Average (s): ', self%get_time()/self%count
+      call logger%log_message(msg, module=this_module)
+      call logger%log_message('###################        Timer summary        #################', module=this_module)
+   end subroutine print_timer_info
+
+   !--------------------------------------------------------------
+   !  Type-bound procedures for lightkrylov_watch type
+   !--------------------------------------------------------------
+
    integer function get_timer_id(self, name) result(id)
-      class(watch_type) :: self
+      class(lightkrylov_watch) :: self
       character(len=*)  :: name
       ! internal
       integer :: i
       id = 0
       do i = 1, self%timer_count
-         if (self%timers(i)%name == name) then
+         if (self%timers(i)%name == to_lower(name)) then
             id = i
          end if
       end do
    end function get_timer_id
 
    subroutine add_timer(self, name)
-      class(watch_type), intent(inout) :: self
+      class(lightkrylov_watch), intent(inout) :: self
       character(len=*), intent(in) :: name
       if (self%timer_count == 0) then
          allocate(self%timers(1))
-         self%timers(1) = timer_type(name)
+         self%timers(1) = lightkrylov_timer(to_lower(name))
          self%timer_count = 1
       else
          if (self%get_timer_id(name) > 0) then
-            call stop_error('Timer "'//trim(name)//'" already defined!', module=this_module, procedure='add_timer')
+            call stop_error('Timer "'//to_lower(trim(name))//'" already defined!', module=this_module, procedure='add_timer')
          end if
-         self%timers = [ self%timers, timer_type(name) ]
+         self%timers = [ self%timers, lightkrylov_timer(name) ]
          self%timer_count = self%timer_count + 1
          if (self%user_mode) self%user_count = self%user_count + 1
       end if
+      call logger%log_debug('Timer "'//to_lower(trim(name))//'" added.', module=this_module)
    end subroutine add_timer
 
    subroutine remove_timer(self, name)
-      class(watch_type), intent(inout) :: self
+      class(lightkrylov_watch), intent(inout) :: self
       character(len=*), intent(in) :: name
       ! internal
-      type(timer_type), dimension(:), allocatable :: new_timers
+      type(lightkrylov_timer), dimension(:), allocatable :: new_timers
       integer :: id
       id = self%get_timer_id(name)
       if (id == 0) then
-         call stop_error('Timer "'//trim(name)//'" not defined!', module=this_module, procedure='remove_timer')
+         call stop_error('Timer "'//to_lower(trim(name))//'" not defined!', module=this_module, procedure='remove_timer')
       else
          if (id <= self%private_count) then
-            call logger%log_message('Cannot remove private timer "'//trim(name)//'".', module=this_module, procedure='remove_timer')
+            call logger%log_message('Cannot remove private timer "'//to_lower(trim(name))//'".', module=this_module, procedure='remove_timer')
          else
             self%timer_count = self%timer_count - 1
             allocate(new_timers(self%timer_count))
@@ -159,62 +189,66 @@ contains
             self%timers = new_timers
          end if
       end if
+      call logger%log_debug('Timer "'//to_lower(trim(name))//'" removed.', module=this_module)
    end subroutine remove_timer
    
    subroutine start_timer_by_name(self, name)
-      class(watch_type), intent(inout) :: self
+      class(lightkrylov_watch), intent(inout) :: self
       character(len=*), intent(in) :: name
       ! internal
       integer :: id
       id = self%get_timer_id(name)
       if (id == 0) then 
-         call stop_error('Timer "'//trim(name)//'" not found!', module=this_module, procedure='start_timer_by_name')
+         call stop_error('Timer "'//to_lower(trim(name))//'" not found!', module=this_module, procedure='start_timer_by_name')
       else
          call self%timers(id)%start()
       end if
+      call logger%log_debug('Timer "'//to_lower(trim(name))//'" started.', module=this_module)
    end subroutine start_timer_by_name
 
    subroutine stop_timer_by_name(self, name)
-      class(watch_type), intent(inout) :: self
+      class(lightkrylov_watch), intent(inout) :: self
       character(len=*), intent(in) :: name
       ! internal
       integer :: id
       id = self%get_timer_id(name)
       if (id == 0) then 
-         call stop_error('Timer "'//trim(name)//'" not found!', module=this_module, procedure='start_timer_by_name')
+         call stop_error('Timer "'//to_lower(trim(name))//'" not found!', module=this_module, procedure='start_timer_by_name')
       else
          call self%timers(id)%stop()
       end if
+      call logger%log_debug('Timer "'//to_lower(trim(name))//'" stopped.', module=this_module)
    end subroutine stop_timer_by_name
 
    subroutine pause_timer_by_name(self, name)
-      class(watch_type), intent(inout) :: self
+      class(lightkrylov_watch), intent(inout) :: self
       character(len=*), intent(in) :: name
       ! internal
       integer :: id
       id = self%get_timer_id(name)
       if (id == 0) then 
-         call stop_error('Timer "'//trim(name)//'" not found!', module=this_module, procedure='start_timer_by_name')
+         call stop_error('Timer "'//to_lower(trim(name))//'" not found!', module=this_module, procedure='start_timer_by_name')
       else
          call self%timers(id)%start()
       end if
+      call logger%log_debug('Timer "'//to_lower(trim(name))//'" paused.', module=this_module)
    end subroutine
 
    subroutine reset_timer_by_name(self, name)
-      class(watch_type), intent(inout) :: self
+      class(lightkrylov_watch), intent(inout) :: self
       character(len=*), intent(in) :: name
       ! internal
       integer :: id
       id = self%get_timer_id(name)
       if (id == 0) then 
-         call stop_error('Timer "'//trim(name)//'" not found!', module=this_module, procedure='start_timer_by_name')
+         call stop_error('Timer "'//to_lower(trim(name))//'" not found!', module=this_module, procedure='start_timer_by_name')
       else
          call self%timers(id)%start()
       end if
    end subroutine
 
    subroutine enumerate(self, only_user)
-      class(watch_type), intent(in) :: self
+      class(lightkrylov_watch), intent(in) :: self
       logical, optional, intent(in) :: only_user
       ! internal
       integer :: i
@@ -222,31 +256,33 @@ contains
       character(len=128) :: msg
       only_user_ = optval(only_user, .true.)
       if (.not. only_user_) then
-         call logger%log_message('Registered timers: default', module=this_module)
+         call logger%log_message('Registered timers: all', module=this_module)
          do i = 1, self%private_count
             write(msg,'(4X,I4,A,A)') i, ' : ', trim(self%timers(i)%name)
             call logger%log_message(msg, module=this_module)
          end do
       end if
-      call logger%log_message('Registered timers: user', module=this_module)
-      do i = self%private_count+1, self%timer_count
-         write(msg,'(4X,I4,A,A)') i, ' : ', trim(self%timers(i)%name)
-         call logger%log_message(msg, module=this_module)
-      end do
+      if (self%user_count > 0) then
+         call logger%log_message('Registered timers: user', module=this_module)
+         do i = self%private_count+1, self%timer_count
+            write(msg,'(4X,I4,A,A)') i, ' : ', trim(self%timers(i)%name)
+            call logger%log_message(msg, module=this_module)
+         end do
+      end if
    end subroutine enumerate
 
    subroutine initialize(self)
-      class(watch_type), intent(inout) :: self
+      class(lightkrylov_watch), intent(inout) :: self
       ! timers for LightKrylov_BaseKrylov
       #:for kind, type in RC_KINDS_TYPES
       ! ${type[0]}$${kind}$
-      call self%add_timer('QR_with_pivoting_${type[0]}$${kind}$')
-      call self%add_timer('QR_no_pivoting_${type[0]}$${kind}$')
-      call self%add_timer('Orthonormalize_basis_${type[0]}$${kind}$')
-      call self%add_timer('Orthonormalize_vector_against_basis_${type[0]}$${kind}$')
-      call self%add_timer('Orthonormalize_basis_against_basis_${type[0]}$${kind}$')
-      call self%add_timer('DGS_vector_against_basis_${type[0]}$${kind}$')
-      call self%add_timer('DGS_basis_against_basis_${type[0]}$${kind}$')
+      call self%add_timer('qr_with_pivoting_${type[0]}$${kind}$')
+      call self%add_timer('qr_no_pivoting_${type[0]}$${kind}$')
+      call self%add_timer('orthonormalize_basis_${type[0]}$${kind}$')
+      call self%add_timer('orthonormalize_vector_against_basis_${type[0]}$${kind}$')
+      call self%add_timer('orthonormalize_basis_against_basis_${type[0]}$${kind}$')
+      call self%add_timer('dgs_vector_against_basis_${type[0]}$${kind}$')
+      call self%add_timer('dgs_basis_against_basis_${type[0]}$${kind}$')
       self%basekrylov_count = self%timer_count
       #:endfor
       ! timers for LightKrylov_IterativeSolvers
@@ -269,14 +305,17 @@ contains
       self%private_count = self%timer_count
       self%user_mode = .true.
       if_time = .true.
+      call logger%log_message('LightKrylov system timer initialization complete.', module=this_module)
+      print *, self%private_count
+      print *, self%user_count
    end subroutine initialize
 
-   subroutine finalize(self)
-      class(watch_type), intent(inout) :: self
+   subroutine finalize_watch(self)
+      class(lightkrylov_watch), intent(inout) :: self
       ! internal
       integer :: i, j, icalled
       integer :: ic_bk, ic_is, ic_nk, ic_user
-      character(len=128) :: msg
+      character(len=128) :: msg, timer_fmt
       icalled = 0
       ic_bk = 0
       do i = 1, self%timer_count
@@ -292,21 +331,27 @@ contains
       end do
       ic_user = icalled - ic_nk
       if_time = .false.
-      call logger%log_message('##############        Timer summary        ##############', module=this_module)
-      write(msg, '(2X,A20,I3)') 'Total active timers:', self%timer_count
+      call logger%log_message('###############        Global timer summary        ##############', module=this_module)
+      call logger%log_message('____________________', module=this_module)
+      call logger%log_message('Overview:', module=this_module)
+      call logger%log_message('_________________________________________________________________', module=this_module)
+      write(msg, '(2X,A20,I5)') 'Total active timers:', self%timer_count
       call logger%log_message(msg, module=this_module)
-      write(msg, '(2X,A20,I3)') 'User defined:', self%user_count
+      write(msg, '(2X,A20,I5)') 'User defined:', self%user_count
       call logger%log_message(msg, module=this_module)
-      write(msg, '(2X,A20,I3)') 'Called timers:', icalled
+      write(msg, '(2X,A20,I5)') 'Called timers:', icalled
       call logger%log_message(msg, module=this_module)
-      write(msg, '(A32,A5,2(1X,A10))') 'name', 'cnt', 'total', 'avg'
+      write(msg, '(A32,A7,2(1X,A12))') 'name', 'calls', 'total (s)', 'avg (s)'
       call logger%log_message(msg, module=this_module)
+      timer_fmt = '(2X,A30,I7,2(1X,F12.6))'
       if (ic_bk > 0) then
+         call logger%log_message('____________________', module=this_module)
          call logger%log_message('BaseKrylov:', module=this_module)
+         call logger%log_message('_________________________________________________________________', module=this_module)
          do i = 1, self%basekrylov_count
             associate(t => self%timers(i))
                if (t%count > 0) then
-                  write(msg,'(2X,A30,I5,2(1X,F10.6))') trim(t%name), t%count, t%get_time(), t%get_time()/t%count
+                  write(msg,timer_fmt) trim(t%name), t%count, t%get_time(), t%get_time()/t%count
                   call logger%log_message(msg, module=this_module)
                end if
             end associate
@@ -314,11 +359,13 @@ contains
       end if
       j = self%basekrylov_count
       if (ic_is > 0) then
+         call logger%log_message('____________________', module=this_module)
          call logger%log_message('IterativeSolvers:', module=this_module)
+         call logger%log_message('_________________________________________________________________', module=this_module)
          do i = j, self%iterativesolvers_count
             associate(t => self%timers(i))
                if (t%count > 0) then
-                  write(msg,'(2X,A30,I5,2(1X,F10.6))') trim(t%name), t%count, t%get_time(), t%get_time()/t%count
+                  write(msg,timer_fmt) trim(t%name), t%count, t%get_time(), t%get_time()/t%count
                   call logger%log_message(msg, module=this_module)
                end if
             end associate
@@ -326,11 +373,13 @@ contains
       end if
       j = self%iterativesolvers_count
       if (ic_nk > 0) then
+         call logger%log_message('____________________', module=this_module)
          call logger%log_message('NewtonKrylov:', module=this_module)
+         call logger%log_message('_________________________________________________________________', module=this_module)
          do i = j, self%newtonkrylov_count
             associate(t => self%timers(i))
                if (t%count > 0) then
-                  write(msg,'(2X,A30,I5,2(1X,F10.6))') trim(t%name), t%count, t%get_time(), t%get_time()/t%count
+                  write(msg,timer_fmt) trim(t%name), t%count, t%get_time(), t%get_time()/t%count
                   call logger%log_message(msg, module=this_module)
                end if
             end associate
@@ -338,17 +387,19 @@ contains
       end if
       if (self%user_count > 0 .and. ic_user > 0) then
          j = self%private_count
+         call logger%log_message('____________________', module=this_module)
          call logger%log_message('User-defined:', module=this_module)
+         call logger%log_message('_________________________________________________________________', module=this_module)
          do i = j, self%timer_count
             associate(t => self%timers(i))
                if (t%count > 0) then
-                  write(msg,'(2X,A30,I5,2(1X,F10.6))') trim(t%name), t%count, t%get_time(), t%get_time()/t%count
+                  write(msg,timer_fmt) trim(t%name), t%count, t%get_time(), t%get_time()/t%count
                   call logger%log_message(msg, module=this_module)
                end if
             end associate
          end do
       end if
-      call logger%log_message('##############        Timer summary        ##############', module=this_module)
-   end subroutine finalize
+      call logger%log_message('###############        Global timer summary        ##############', module=this_module)
+   end subroutine finalize_watch
 
-end module LightKrylov_Timer
+end module LightKrylov_Timing

--- a/src/Timer.fypp
+++ b/src/Timer.fypp
@@ -47,6 +47,7 @@ module LightKrylov_Timing
       integer :: private_count = 0
       logical :: user_mode = .false.
       integer :: user_count = 0
+      logical :: is_initialized
    contains
       private
       procedure, pass(self), public :: add_timer
@@ -166,12 +167,25 @@ contains
       ! internal
       logical :: ifsave
       ifsave = optval(save_history, .true.)
-      if (self%count > 0) then
-         if (ifsave) call self%save_timer_history()
+      if (ifsave) then
+         ! soft reset, only if data was collected
+         if (self%count > 0) then
+            call self%save_timer_history()
+            self%elapsed_time = 0.0_dp
+            self%start_time = 0.0_dp
+            self%running = .false.
+            self%count = 0
+         end if
+      else
+         ! hard reset
          self%elapsed_time = 0.0_dp
          self%start_time = 0.0_dp
          self%running = .false.
          self%count = 0
+         self%reset_counter = 0
+         deallocate(self%etime_history)
+         deallocate(self%etavg_history)
+         deallocate(self%count_history)
       end if
    end subroutine reset_timer
 
@@ -404,42 +418,57 @@ contains
 
    subroutine initialize_lightkrylov_watch(self)
       class(lightkrylov_watch), intent(inout) :: self
-      ! timers for LightKrylov_BaseKrylov
-      #:for kind, type in RC_KINDS_TYPES
-      ! ${type[0]}$${kind}$
-      call self%add_timer('qr_with_pivoting_${type[0]}$${kind}$')
-      call self%add_timer('qr_no_pivoting_${type[0]}$${kind}$')
-      call self%add_timer('orthonormalize_basis_${type[0]}$${kind}$')
-      call self%add_timer('orthonormalize_vector_against_basis_${type[0]}$${kind}$')
-      call self%add_timer('orthonormalize_basis_against_basis_${type[0]}$${kind}$')
-      call self%add_timer('dgs_vector_against_basis_${type[0]}$${kind}$')
-      call self%add_timer('dgs_basis_against_basis_${type[0]}$${kind}$')
-      call self%add_timer('arnoldi_${type[0]}$${kind}$')
-      call self%add_timer('lanczos_bidiagonalization_${type[0]}$${kind}$')
-      call self%add_timer('lanczos_tridiagonalization_${type[0]}$${kind}$')
-      self%basekrylov_count = self%timer_count
-      #:endfor
-      ! timers for LightKrylov_IterativeSolvers
-      #:for kind, type in RC_KINDS_TYPES
-      ! ${type[0]}$${kind}$
-      call self%add_timer('eigs_${type[0]}$${kind}$')
-      call self%add_timer('eighs_${type[0]}$${kind}$')
-      call self%add_timer('svds_${type[0]}$${kind}$')
-      call self%add_timer('gmres_${type[0]}$${kind}$')
-      call self%add_timer('fgmres_${type[0]}$${kind}$')
-      call self%add_timer('cg_${type[0]}$${kind}$')
-      self%iterativesolvers_count = self%timer_count
-      #:endfor
-      ! timers for LightKrylov_NewtonKrylov
-      #:for kind, type in RC_KINDS_TYPES
-      ! ${type[0]}$${kind}$
-      call self%add_timer('newton_${type[0]}$${kind}$')
-      #:endfor
-      self%newtonkrylov_count = self%timer_count
-      self%private_count = self%timer_count
+      ! internal
+      character(len=128) :: msg
+      if (.not. self%is_initialized) then
+         ! timers for LightKrylov_BaseKrylov
+         #:for kind, type in RC_KINDS_TYPES
+         ! ${type[0]}$${kind}$
+         call self%add_timer('qr_with_pivoting_${type[0]}$${kind}$')
+         call self%add_timer('qr_no_pivoting_${type[0]}$${kind}$')
+         call self%add_timer('orthonormalize_basis_${type[0]}$${kind}$')
+         call self%add_timer('orthonormalize_vector_against_basis_${type[0]}$${kind}$')
+         call self%add_timer('orthonormalize_basis_against_basis_${type[0]}$${kind}$')
+         call self%add_timer('dgs_vector_against_basis_${type[0]}$${kind}$')
+         call self%add_timer('dgs_basis_against_basis_${type[0]}$${kind}$')
+         call self%add_timer('arnoldi_${type[0]}$${kind}$')
+         call self%add_timer('lanczos_bidiagonalization_${type[0]}$${kind}$')
+         call self%add_timer('lanczos_tridiagonalization_${type[0]}$${kind}$')
+         self%basekrylov_count = self%timer_count
+         #:endfor
+         ! timers for LightKrylov_IterativeSolvers
+         #:for kind, type in RC_KINDS_TYPES
+         ! ${type[0]}$${kind}$
+         call self%add_timer('eigs_${type[0]}$${kind}$')
+         call self%add_timer('eighs_${type[0]}$${kind}$')
+         call self%add_timer('svds_${type[0]}$${kind}$')
+         call self%add_timer('gmres_${type[0]}$${kind}$')
+         call self%add_timer('fgmres_${type[0]}$${kind}$')
+         call self%add_timer('cg_${type[0]}$${kind}$')
+         self%iterativesolvers_count = self%timer_count
+         #:endfor
+         ! timers for LightKrylov_NewtonKrylov
+         #:for kind, type in RC_KINDS_TYPES
+         ! ${type[0]}$${kind}$
+         call self%add_timer('newton_${type[0]}$${kind}$')
+         #:endfor
+         self%newtonkrylov_count = self%timer_count
+         self%private_count = self%timer_count
+         write(msg,'(3X,I4,A)') self%private_count, ' system timers registered.'
+         call logger%log_information(msg, module=this_module, procedure='timer initialization')
+      else
+         call self%reset_all(save_history = .false.)
+         write(msg,'(3X,I4,A)') self%private_count, ' system timers registered and fully reset.'
+         call logger%log_information(msg, module=this_module, procedure='timer initialization')
+         if (self%user_count > 0) then
+            write(msg,'(3X,I4,A)') self%user_count, ' user defined timers registered and fully reset.'
+            call logger%log_information(msg, module=this_module, procedure='timer initialization')
+         end if
+      end if
       self%user_mode = .true.
       if_time = .true.
       call logger%log_message('LightKrylov system timer initialization complete.', module=this_module)
+      
    end subroutine initialize_lightkrylov_watch
 
    subroutine finalize_lightkrylov_watch(self)

--- a/src/Timer.fypp
+++ b/src/Timer.fypp
@@ -154,7 +154,8 @@ contains
       real(dp) :: etime, etavg
       character(len=128) :: msg, timer_fmt
       timer_fmt       = '(2X,A30," : ",I7,2(1X,F12.6))'
-      call logger%log_message('###        Timer info                  #######################################', module=this_module)
+      call logger%log_message('###        Timer info                  #######################################', & 
+                              & module=this_module)
       write(msg, '(A32," : ",A7,2(1X,A12))') 'name', 'calls', 'total (s)', 'avg (s)'
       call logger%log_message(msg, module=this_module)
       etime = 0.0_dp
@@ -163,7 +164,8 @@ contains
       if (self%count > 0) etavg = etime/self%count
       write(msg,timer_fmt) trim(self%name), self%count, etime, etavg
       call logger%log_message(msg, module=this_module)
-      call logger%log_message('###        Timer info                  #######################################', module=this_module)
+      call logger%log_message('###        Timer info                  #######################################', & 
+                              & module=this_module)
    end subroutine print_timer_info
 
    subroutine finalize_timer(self)
@@ -176,10 +178,12 @@ contains
       timer_fmt       = '(2X,A30," : ",A6,1X,I7,2(1X,F12.6))'
       timer_fmt_reset = '(2X,33X,A6,I3,1X,I7,2(1X,F12.6))'
       icalled = 0
-      call logger%log_message('###        Timer summary               #######################################', module=this_module)
+      call logger%log_message('###        Timer summary               #######################################', & 
+                              & module=this_module)
       write(msg, '(A32," : ",7X,A7,2(1X,A12))') 'name', 'calls', 'total (s)', 'avg (s)'
       call logger%log_message(msg, module=this_module)
-      call logger%log_message('______________________________________________________________________________', module=this_module)
+      call logger%log_message('______________________________________________________________________________', & 
+                              & module=this_module)
       etavg = 0.0_dp
       if (self%count > 0 .or. self%reset_counter > 0) then
          if (self%reset_counter == 0) call self%save_timer_history()
@@ -198,7 +202,8 @@ contains
             end do
          end if
       end if
-      call logger%log_message('###        Timer summary               #######################################', module=this_module)
+      call logger%log_message('###        Timer summary               #######################################', & 
+                              & module=this_module)
    end subroutine finalize_timer
 
    !--------------------------------------------------------------
@@ -227,7 +232,8 @@ contains
          self%timer_count = 1
       else
          if (self%get_timer_id(name) > 0) then
-            call stop_error('Timer "'//to_lower(trim(name))//'" already defined!', module=this_module, procedure='add_timer')
+            call stop_error('Timer "'//to_lower(trim(name))//'" already defined!', & 
+                              & module=this_module, procedure='add_timer')
          end if
          self%timers = [ self%timers, lightkrylov_timer(name) ]
          self%timer_count = self%timer_count + 1
@@ -244,10 +250,12 @@ contains
       integer :: id
       id = self%get_timer_id(name)
       if (id == 0) then
-         call stop_error('Timer "'//to_lower(trim(name))//'" not defined!', module=this_module, procedure='remove_timer')
+         call stop_error('Timer "'//to_lower(trim(name))//'" not defined!', & 
+                              & module=this_module, procedure='remove_timer')
       else
          if (id <= self%private_count) then
-            call logger%log_message('Cannot remove private timer "'//to_lower(trim(name))//'".', module=this_module, procedure='remove_timer')
+            call logger%log_message('Cannot remove private timer "'//to_lower(trim(name))//'".', & 
+                              & module=this_module, procedure='remove_timer')
          else
             self%timer_count = self%timer_count - 1
             allocate(new_timers(self%timer_count))
@@ -267,7 +275,8 @@ contains
       integer :: id
       id = self%get_timer_id(name)
       if (id == 0) then 
-         call stop_error('Timer "'//to_lower(trim(name))//'" not found!', module=this_module, procedure='start_timer_by_name')
+         call stop_error('Timer "'//to_lower(trim(name))//'" not found!', & 
+                              & module=this_module, procedure='start_timer_by_name')
       else
          call self%timers(id)%start()
       end if
@@ -281,7 +290,8 @@ contains
       integer :: id
       id = self%get_timer_id(name)
       if (id == 0) then 
-         call stop_error('Timer "'//to_lower(trim(name))//'" not found!', module=this_module, procedure='start_timer_by_name')
+         call stop_error('Timer "'//to_lower(trim(name))//'" not found!', & 
+                              & module=this_module, procedure='start_timer_by_name')
       else
          call self%timers(id)%stop()
       end if
@@ -295,7 +305,8 @@ contains
       integer :: id
       id = self%get_timer_id(name)
       if (id == 0) then 
-         call stop_error('Timer "'//to_lower(trim(name))//'" not found!', module=this_module, procedure='start_timer_by_name')
+         call stop_error('Timer "'//to_lower(trim(name))//'" not found!', & 
+                              & module=this_module, procedure='start_timer_by_name')
       else
          call self%timers(id)%pause()
       end if
@@ -310,7 +321,8 @@ contains
       integer :: id
       id = self%get_timer_id(name)
       if (id == 0) then 
-         call stop_error('Timer "'//to_lower(trim(name))//'" not found!', module=this_module, procedure='start_timer_by_name')
+         call stop_error('Timer "'//to_lower(trim(name))//'" not found!', & 
+                              & module=this_module, procedure='start_timer_by_name')
       else
          call self%timers(id)%reset(save_history)
       end if
@@ -416,7 +428,8 @@ contains
       end do
       ic_user = icalled - ic_nk - ic_is - ic_bk
       if_time = .false.
-      call logger%log_message('###        Global timer summary        #######################################', module=this_module)
+      call logger%log_message('###        Global timer summary        #######################################', & 
+                              & module=this_module)
       call logger%log_message('____________________', module=this_module)
       call logger%log_message('Overview:', module=this_module)
       write(msg, '(2X,A40,I5)') 'Total active timers:', self%timer_count
@@ -432,7 +445,8 @@ contains
          call logger%log_message('BaseKrylov:', module=this_module)
          write(msg, '(A32," : ",7X,A7,2(1X,A12))') 'name', 'calls', 'total (s)', 'avg (s)'
          call logger%log_message(msg, module=this_module)
-         call logger%log_message('______________________________________________________________________________', module=this_module)
+         call logger%log_message('______________________________________________________________________________', & 
+                              & module=this_module)
          do i = 1, self%basekrylov_count
             associate(t => self%timers(i))
                rcount = t%reset_counter
@@ -461,7 +475,8 @@ contains
          call logger%log_message('IterativeSolvers:', module=this_module)
          write(msg, '(A32," : ",7X,A7,2(1X,A12))') 'name', 'calls', 'total (s)', 'avg (s)'
          call logger%log_message(msg, module=this_module)
-         call logger%log_message('______________________________________________________________________________', module=this_module)
+         call logger%log_message('______________________________________________________________________________', & 
+                              & module=this_module)
          do i = j, self%iterativesolvers_count
             associate(t => self%timers(i))
                rcount = t%reset_counter
@@ -490,7 +505,8 @@ contains
          call logger%log_message('NewtonKrylov:', module=this_module)
          write(msg, '(A32," : ",7X,A7,2(1X,A12))') 'name', 'calls', 'total (s)', 'avg (s)'
          call logger%log_message(msg, module=this_module)
-         call logger%log_message('_________________________________________________________________', module=this_module)
+         call logger%log_message('______________________________________________________________________________', & 
+                              & module=this_module)
          do i = j, self%newtonkrylov_count
             associate(t => self%timers(i))
                rcount = t%reset_counter
@@ -519,7 +535,8 @@ contains
          call logger%log_message('User-defined:', module=this_module)
          write(msg, '(A32," : ",7X,A7,2(1X,A12))') 'name', 'calls', 'total (s)', 'avg (s)'
          call logger%log_message(msg, module=this_module)
-         call logger%log_message('_________________________________________________________________', module=this_module)
+         call logger%log_message('______________________________________________________________________________', & 
+                              & module=this_module)
          do i = j, self%timer_count
             associate(t => self%timers(i))
                rcount = t%reset_counter

--- a/src/Timer.fypp
+++ b/src/Timer.fypp
@@ -112,14 +112,26 @@ contains
          allocate(self%etime_history(1))
          allocate(self%etavg_history(1))
          allocate(self%count_history(1))
-         self%etime_history(1) = self%elapsed_time
-         self%etavg_history(1) = self%elapsed_time/self%count
-         self%count_history(1) = self%count
+         if (self%count > 0) then
+            self%etime_history(1) = self%elapsed_time
+            self%etavg_history(1) = self%elapsed_time/self%count
+            self%count_history(1) = self%count
+         else
+            self%etime_history(1) = 0.0_dp
+            self%etavg_history(1) = 0.0_dp
+            self%count_history(1) = self%count
+         end if
          self%reset_counter = 1
       else
-         self%etime_history = [ self%etime_history, self%elapsed_time ]
-         self%etavg_history = [ self%etavg_history, self%elapsed_time/self%count ]
-         self%count_history = [ self%count_history, self%count ]
+         if (self%count > 0) then
+            self%etime_history = [ self%etime_history, self%elapsed_time ]
+            self%etavg_history = [ self%etavg_history, self%elapsed_time/self%count ]
+            self%count_history = [ self%count_history, self%count ]
+         else
+            self%etime_history(1) = 0.0_dp
+            self%etavg_history(1) = 0.0_dp
+            self%count_history(1) = self%count
+         end if
          self%reset_counter = self%reset_counter + 1
       end if
    end subroutine save_timer_history
@@ -171,13 +183,12 @@ contains
    subroutine finalize_timer(self)
       class(lightkrylov_timer), intent(inout) :: self
       ! internal
-      integer :: i, j, icalled
+      integer :: i
       integer :: ic_bk, ic_is, ic_nk, ic_user, count
       real(dp) :: etime, etavg
       character(len=128) :: msg, timer_fmt, timer_fmt_reset
       timer_fmt       = '(2X,A30," : ",A6,1X,I7,2(1X,F12.6))'
       timer_fmt_reset = '(2X,33X,A6,I3,1X,I7,2(1X,F12.6))'
-      icalled = 0
       call logger%log_message('###        Timer summary               #######################################', & 
                               & module=this_module)
       write(msg, '(A32," : ",7X,A7,2(1X,A12))') 'name', 'calls', 'total (s)', 'avg (s)'
@@ -193,11 +204,11 @@ contains
          write(msg,timer_fmt) trim(self%name), 'total', count, etime, etavg
          call logger%log_message(msg, module=this_module)
          if (self%reset_counter > 1) then
-            do j = 1, self%reset_counter
-               etime = self%etime_history(j)
-               etavg = self%etavg_history(j)
-               count = self%count_history(j)
-               write(msg,timer_fmt_reset) 'reset', j, count, etime, etavg
+            do i = 1, self%reset_counter
+               etime = self%etime_history(i)
+               etavg = self%etavg_history(i)
+               count = self%count_history(i)
+               write(msg,timer_fmt_reset) 'reset', i, count, etime, etavg
                call logger%log_message(msg, module=this_module)
             end do
          end if
@@ -401,8 +412,6 @@ contains
       self%user_mode = .true.
       if_time = .true.
       call logger%log_message('LightKrylov system timer initialization complete.', module=this_module)
-      print *, self%private_count
-      print *, self%user_count
    end subroutine initialize
 
    subroutine finalize_watch(self)
@@ -413,7 +422,6 @@ contains
       real(dp) :: etime, etavg
       character(len=128) :: msg, timer_fmt, timer_fmt_reset
       icalled = 0
-      ic_bk = 0
       do i = 1, self%timer_count
          call self%timers(i)%stop()
          if (self%timers(i)%count > 0) icalled = icalled + 1
@@ -428,6 +436,7 @@ contains
       end do
       ic_user = icalled - ic_nk - ic_is - ic_bk
       if_time = .false.
+      call logger%log_message('LightKrylov timer finalization complete.', module=this_module)
       call logger%log_message('###        Global timer summary        #######################################', & 
                               & module=this_module)
       call logger%log_message('____________________', module=this_module)
@@ -559,7 +568,8 @@ contains
             end associate
          end do
       end if
-      call logger%log_message('###        Global timer summary        #######################################', module=this_module)
+      call logger%log_message('###        Global timer summary        #######################################',  & 
+                              & module=this_module)
    end subroutine finalize_watch
 
 end module LightKrylov_Timing

--- a/src/Timer.fypp
+++ b/src/Timer.fypp
@@ -1,0 +1,268 @@
+#:include "../include/common.fypp"
+#:set RC_KINDS_TYPES = REAL_KINDS_TYPES + CMPLX_KINDS_TYPES
+module LightKrylov_Timer
+   use LightKrylov_Constants, only: dp
+   use LightKrylov_Logger
+   implicit none
+   private
+   character(len=128), parameter :: this_module = 'LightKrylov_Timer'
+   logical :: if_time = .false.
+
+   public :: initialize_timers, enumerate_timers, finalize_timers
+   public :: timeit
+
+   ! Timer type
+   type, public :: timer_type
+      private
+      character(len=128) :: name
+      real(dp) :: elapsed_time = 0.0_dp
+      real(dp) :: start_time = 0.0_dp
+      logical :: running = .false.
+      integer :: count = 0
+   contains
+      procedure, pass(self), public :: start => start_timer
+      procedure, pass(self), public :: stop => stop_timer
+      procedure, pass(self), public :: pause => pause_timer
+      procedure, pass(self), public :: reset => reset_timer
+      procedure, pass(self), public :: get_time => get_timer_time
+   end type timer_type
+
+   ! Watch type
+   type :: watch_type
+      private
+      type(timer_type), dimension(:), allocatable :: timers
+      integer :: timer_count = 0
+      integer :: private_count = 0
+   contains
+      procedure, pass(self), public :: add_timer
+      procedure, pass(self), public :: remove_timer
+      procedure, pass(self), public :: enumerate_timers
+      procedure, pass(self), public :: start => start_timer_by_name
+      procedure, pass(self), public :: stop => stop_timer_by_name
+      procedure, pass(self), public :: pause => pause_timer_by_name
+      procedure, pass(self), public :: reset => reset_timer_by_name
+   end type watch_type
+
+   type(watch_type), public :: global_timer
+
+contains
+
+   function timeit() result(if_time_lightkrylov)
+      logical :: if_time_lightkrylov
+      if_time_lightkrylov = if_time
+   end function timeit
+
+   subroutine initialize_timers()
+      ! timers for LightKrylov_BaseKrylov
+      #:for kind, type in RC_KINDS_TYPES
+      ! ${type[0]}$${kind}$
+      !call global_timer%add_timer('QR_with_pivoting_${type[0]}$${kind}$')
+      !call global_timer%add_timer('QR_no_pivoting_${type[0]}$${kind}$')
+      !call global_timer%add_timer('Orthonormalize_basis_${type[0]}$${kind}$')
+      !call global_timer%add_timer('Orthonormalize_vector_against_basis_${type[0]}$${kind}$')
+      !call global_timer%add_timer('Orthonormalize_basis_against_basis_${type[0]}$${kind}$')
+      !call global_timer%add_timer('DGS_vector_against_basis_${type[0]}$${kind}$')
+      !call global_timer%add_timer('DGS_basis_against_basis_${type[0]}$${kind}$')
+      !#:endfor
+      ! timers for LightKrylov_IterativeSolvers
+      !#:for kind, type in RC_KINDS_TYPES
+      ! ${type[0]}$${kind}$
+      !call global_timer%add_timer('eigs_${type[0]}$${kind}$')
+      !call global_timer%add_timer('eighs_${type[0]}$${kind}$')
+      call global_timer%add_timer('svds_${type[0]}$${kind}$')
+      call global_timer%add_timer('gmres_${type[0]}$${kind}$')
+      !call global_timer%add_timer('fgmres_${type[0]}$${kind}$')
+      !call global_timer%add_timer('cg_${type[0]}$${kind}$')
+      #:endfor
+      ! timers for LightKrylov_NewtonKrylov
+      #:for kind, type in RC_KINDS_TYPES
+      ! ${type[0]}$${kind}$
+      call global_timer%add_timer('newton_${type[0]}$${kind}$')
+      #:endfor
+      global_timer%private_count = global_timer%timer_count
+      if_time = .true.
+   end subroutine initialize_timers
+
+   subroutine finalize_timers()
+      ! internal
+      integer :: i
+      do i = 1, global_timer%timer_count
+         call global_timer%timers(i)%stop()
+      end do
+      if_time = .false.
+      do i = 1, global_timer%timer_count
+         print *, trim(global_timer%timers(i)%name), ':', global_timer%timers(i)%count, global_timer%timers(i)%get_time()
+      end do
+   end subroutine finalize_timers
+
+   subroutine start_timer(self)
+      class(timer_type), intent(inout) :: self
+      if (.not. self%running) then
+         call cpu_time(self%start_time)
+         self%running = .true.
+      end if
+   end subroutine start_timer
+
+   subroutine stop_timer(self)
+      class(timer_type), intent(inout) :: self
+      ! internal
+      real(dp) :: t_now
+      call cpu_time(t_now)
+      if (self%running) then
+         self%elapsed_time = self%elapsed_time + (t_now - self%start_time)
+         self%count = self%count + 1
+         self%running = .false.
+      end if
+   end subroutine stop_timer
+
+   subroutine pause_timer(self)
+      class(timer_type), intent(inout) :: self
+      ! internal
+      real(dp) :: t_now
+      call cpu_time(t_now)
+      if (self%running) then
+         self%elapsed_time = self%elapsed_time + (t_now - self%start_time)
+         self%running = .false.
+      end if
+   end subroutine pause_timer
+
+   subroutine reset_timer(self)
+      class(timer_type), intent(inout) :: self
+      self%elapsed_time = 0.0_dp
+      self%start_time = 0.0_dp
+      self%running = .false.
+      self%count = 0
+   end subroutine reset_timer
+
+   real(dp) function get_timer_time(self) result(etime)
+      class(timer_type), intent(inout) :: self
+      if (self%running) then
+         call self%stop()
+      end if
+      etime = self%elapsed_time
+   end function
+
+   subroutine add_timer(self, name)
+      class(watch_type), intent(inout) :: self
+      character(len=*), intent(in) :: name
+      ! internal
+      integer :: i
+      if (self%timer_count == 0) then
+         allocate(self%timers(1))
+         self%timers(1) = timer_type(name)
+         self%timer_count = 1
+      else
+         do i = 1, self%timer_count
+            if (self%timers(i)%name == name) then
+               call stop_error('Timer "'//trim(name)//'" already defined!', module=this_module, procedure='add_timer')
+            end if
+         end do
+         self%timers = [ self%timers, timer_type(name) ]
+         self%timer_count = self%timer_count + 1
+      end if
+   end subroutine add_timer
+
+   subroutine remove_timer(self, name)
+      class(watch_type), intent(inout) :: self
+      character(len=*), intent(in) :: name
+      ! internal
+      type(timer_type), dimension(:), allocatable :: new_timers
+      integer :: i, i_rm
+      logical :: found
+      found = .false.
+      do i = 1, self%timer_count
+         if (self%timers(i)%name == name) then
+            i_rm = i
+            found = .true.
+         end if
+      end do
+      if (.not. found) then
+         call stop_error('Timer "'//trim(name)//'" not defined!', module=this_module, procedure='remove_timer')
+      else
+         if (i_rm <= self%private_count) then
+            call logger%log_message('Cannot remove private timer "'//trim(name)//'".', module=this_module, procedure='remove_timer')
+         else
+            self%timer_count = self%timer_count - 1
+            allocate(new_timers(self%timer_count))
+            new_timers(1:i_rm-1) = self%timers(1:i_rm-1)
+            new_timers(i_rm:)    = self%timers(i_rm+1:)
+            deallocate(self%timers)
+            self%timers = new_timers
+         end if
+      end if
+   end subroutine remove_timer
+
+   subroutine enumerate_timers(self)
+      class(watch_type), intent(in) :: self
+      ! internal
+      integer :: i
+      do i = 1, self%timer_count
+         print *, 'Timer', i, ':', trim(self%timers(i)%name)
+      end do
+   end subroutine
+   
+   subroutine start_timer_by_name(self, name)
+      class(watch_type), intent(inout) :: self
+      character(len=*), intent(in) :: name
+      ! internal
+      integer :: i
+      logical :: found
+      found = .false.
+      do i = 1, self%timer_count
+         if (self%timers(i)%name == name) then
+            call self%timers(i)%start()
+            found = .true.
+         end if
+      end do
+      if (.not. found) call stop_error('Timer "'//trim(name)//'" not found!', module=this_module, procedure='start_timer_by_name')
+   end subroutine start_timer_by_name
+
+   subroutine stop_timer_by_name(self, name)
+      class(watch_type), intent(inout) :: self
+      character(len=*), intent(in) :: name
+      ! internal
+      integer :: i
+      logical :: found
+      found = .false.
+      do i = 1, self%timer_count
+         if (self%timers(i)%name == name) then
+            call self%timers(i)%stop()
+            found = .true.
+         end if
+      end do
+      if (.not. found) call stop_error('Timer "'//trim(name)//'" not found!', module=this_module, procedure='stop_timer_by_name')
+   end subroutine stop_timer_by_name
+
+   subroutine pause_timer_by_name(self, name)
+      class(watch_type), intent(inout) :: self
+      character(len=*), intent(in) :: name
+      ! internal
+      integer :: i
+      logical :: found
+      found = .false.
+      do i = 1, self%timer_count
+         if (self%timers(i)%name == name) then
+            call self%timers(i)%pause()
+            found = .true.
+         end if
+      end do
+      if (.not. found) call stop_error('Timer "'//trim(name)//'" not found!', module=this_module, procedure='pause_timer_by_name')
+   end subroutine
+
+   subroutine reset_timer_by_name(self, name)
+      class(watch_type), intent(inout) :: self
+      character(len=*), intent(in) :: name
+      ! internal
+      integer :: i
+      logical :: found
+      found = .false.
+      do i = 1, self%timer_count
+         if (self%timers(i)%name == name) then
+            call self%timers(i)%reset()
+            found = .true.
+         end if
+      end do
+      if (.not. found) call stop_error('Timer "'//trim(name)//'" not found!', module=this_module, procedure='reset_timer_by_name')
+   end subroutine
+
+end module LightKrylov_Timer

--- a/src/Timer.fypp
+++ b/src/Timer.fypp
@@ -1,6 +1,7 @@
 #:include "../include/common.fypp"
 #:set RC_KINDS_TYPES = REAL_KINDS_TYPES + CMPLX_KINDS_TYPES
 module LightKrylov_Timer
+   use stdlib_optval, only: optval
    use LightKrylov_Constants, only: dp
    use LightKrylov_Logger
    implicit none
@@ -8,8 +9,8 @@ module LightKrylov_Timer
    character(len=128), parameter :: this_module = 'LightKrylov_Timer'
    logical :: if_time = .false.
 
-   public :: initialize_timers, enumerate_timers, finalize_timers
-   public :: timeit
+   public :: time_lightkrylov
+   public :: global_timer
 
    ! Timer type
    type, public :: timer_type
@@ -32,74 +33,40 @@ module LightKrylov_Timer
       private
       type(timer_type), dimension(:), allocatable :: timers
       integer :: timer_count = 0
+      integer :: basekrylov_count = 0
+      integer :: iterativesolvers_count = 0
+      integer :: newtonkrylov_count = 0
       integer :: private_count = 0
+      logical :: user_mode = .false.
+      integer :: user_count = 0
    contains
       procedure, pass(self), public :: add_timer
       procedure, pass(self), public :: remove_timer
-      procedure, pass(self), public :: enumerate_timers
+      procedure, pass(self), public :: get_timer_id
+      procedure, pass(self), public :: initialize
+      procedure, pass(self), public :: enumerate
+      procedure, pass(self), public :: finalize
       procedure, pass(self), public :: start => start_timer_by_name
       procedure, pass(self), public :: stop => stop_timer_by_name
       procedure, pass(self), public :: pause => pause_timer_by_name
       procedure, pass(self), public :: reset => reset_timer_by_name
    end type watch_type
 
-   type(watch_type), public :: global_timer
+   type(watch_type) :: global_timer
 
 contains
 
-   function timeit() result(if_time_lightkrylov)
+   function time_lightkrylov() result(if_time_lightkrylov)
       logical :: if_time_lightkrylov
       if_time_lightkrylov = if_time
-   end function timeit
-
-   subroutine initialize_timers()
-      ! timers for LightKrylov_BaseKrylov
-      #:for kind, type in RC_KINDS_TYPES
-      ! ${type[0]}$${kind}$
-      !call global_timer%add_timer('QR_with_pivoting_${type[0]}$${kind}$')
-      !call global_timer%add_timer('QR_no_pivoting_${type[0]}$${kind}$')
-      !call global_timer%add_timer('Orthonormalize_basis_${type[0]}$${kind}$')
-      !call global_timer%add_timer('Orthonormalize_vector_against_basis_${type[0]}$${kind}$')
-      !call global_timer%add_timer('Orthonormalize_basis_against_basis_${type[0]}$${kind}$')
-      !call global_timer%add_timer('DGS_vector_against_basis_${type[0]}$${kind}$')
-      !call global_timer%add_timer('DGS_basis_against_basis_${type[0]}$${kind}$')
-      !#:endfor
-      ! timers for LightKrylov_IterativeSolvers
-      !#:for kind, type in RC_KINDS_TYPES
-      ! ${type[0]}$${kind}$
-      !call global_timer%add_timer('eigs_${type[0]}$${kind}$')
-      !call global_timer%add_timer('eighs_${type[0]}$${kind}$')
-      call global_timer%add_timer('svds_${type[0]}$${kind}$')
-      call global_timer%add_timer('gmres_${type[0]}$${kind}$')
-      !call global_timer%add_timer('fgmres_${type[0]}$${kind}$')
-      !call global_timer%add_timer('cg_${type[0]}$${kind}$')
-      #:endfor
-      ! timers for LightKrylov_NewtonKrylov
-      #:for kind, type in RC_KINDS_TYPES
-      ! ${type[0]}$${kind}$
-      call global_timer%add_timer('newton_${type[0]}$${kind}$')
-      #:endfor
-      global_timer%private_count = global_timer%timer_count
-      if_time = .true.
-   end subroutine initialize_timers
-
-   subroutine finalize_timers()
-      ! internal
-      integer :: i
-      do i = 1, global_timer%timer_count
-         call global_timer%timers(i)%stop()
-      end do
-      if_time = .false.
-      do i = 1, global_timer%timer_count
-         print *, trim(global_timer%timers(i)%name), ':', global_timer%timers(i)%count, global_timer%timers(i)%get_time()
-      end do
-   end subroutine finalize_timers
+   end function time_lightkrylov
 
    subroutine start_timer(self)
       class(timer_type), intent(inout) :: self
       if (.not. self%running) then
          call cpu_time(self%start_time)
          self%running = .true.
+         self%count = self%count + 1
       end if
    end subroutine start_timer
 
@@ -110,7 +77,6 @@ contains
       call cpu_time(t_now)
       if (self%running) then
          self%elapsed_time = self%elapsed_time + (t_now - self%start_time)
-         self%count = self%count + 1
          self%running = .false.
       end if
    end subroutine stop_timer
@@ -142,23 +108,33 @@ contains
       etime = self%elapsed_time
    end function
 
+   integer function get_timer_id(self, name) result(id)
+      class(watch_type) :: self
+      character(len=*)  :: name
+      ! internal
+      integer :: i
+      id = 0
+      do i = 1, self%timer_count
+         if (self%timers(i)%name == name) then
+            id = i
+         end if
+      end do
+   end function get_timer_id
+
    subroutine add_timer(self, name)
       class(watch_type), intent(inout) :: self
       character(len=*), intent(in) :: name
-      ! internal
-      integer :: i
       if (self%timer_count == 0) then
          allocate(self%timers(1))
          self%timers(1) = timer_type(name)
          self%timer_count = 1
       else
-         do i = 1, self%timer_count
-            if (self%timers(i)%name == name) then
-               call stop_error('Timer "'//trim(name)//'" already defined!', module=this_module, procedure='add_timer')
-            end if
-         end do
+         if (self%get_timer_id(name) > 0) then
+            call stop_error('Timer "'//trim(name)//'" already defined!', module=this_module, procedure='add_timer')
+         end if
          self%timers = [ self%timers, timer_type(name) ]
          self%timer_count = self%timer_count + 1
+         if (self%user_mode) self%user_count = self%user_count + 1
       end if
    end subroutine add_timer
 
@@ -167,102 +143,212 @@ contains
       character(len=*), intent(in) :: name
       ! internal
       type(timer_type), dimension(:), allocatable :: new_timers
-      integer :: i, i_rm
-      logical :: found
-      found = .false.
-      do i = 1, self%timer_count
-         if (self%timers(i)%name == name) then
-            i_rm = i
-            found = .true.
-         end if
-      end do
-      if (.not. found) then
+      integer :: id
+      id = self%get_timer_id(name)
+      if (id == 0) then
          call stop_error('Timer "'//trim(name)//'" not defined!', module=this_module, procedure='remove_timer')
       else
-         if (i_rm <= self%private_count) then
+         if (id <= self%private_count) then
             call logger%log_message('Cannot remove private timer "'//trim(name)//'".', module=this_module, procedure='remove_timer')
          else
             self%timer_count = self%timer_count - 1
             allocate(new_timers(self%timer_count))
-            new_timers(1:i_rm-1) = self%timers(1:i_rm-1)
-            new_timers(i_rm:)    = self%timers(i_rm+1:)
+            new_timers(1:id-1) = self%timers(1:id-1)
+            new_timers(id:)    = self%timers(id+1:)
             deallocate(self%timers)
             self%timers = new_timers
          end if
       end if
    end subroutine remove_timer
-
-   subroutine enumerate_timers(self)
-      class(watch_type), intent(in) :: self
-      ! internal
-      integer :: i
-      do i = 1, self%timer_count
-         print *, 'Timer', i, ':', trim(self%timers(i)%name)
-      end do
-   end subroutine
    
    subroutine start_timer_by_name(self, name)
       class(watch_type), intent(inout) :: self
       character(len=*), intent(in) :: name
       ! internal
-      integer :: i
-      logical :: found
-      found = .false.
-      do i = 1, self%timer_count
-         if (self%timers(i)%name == name) then
-            call self%timers(i)%start()
-            found = .true.
-         end if
-      end do
-      if (.not. found) call stop_error('Timer "'//trim(name)//'" not found!', module=this_module, procedure='start_timer_by_name')
+      integer :: id
+      id = self%get_timer_id(name)
+      if (id == 0) then 
+         call stop_error('Timer "'//trim(name)//'" not found!', module=this_module, procedure='start_timer_by_name')
+      else
+         call self%timers(id)%start()
+      end if
    end subroutine start_timer_by_name
 
    subroutine stop_timer_by_name(self, name)
       class(watch_type), intent(inout) :: self
       character(len=*), intent(in) :: name
       ! internal
-      integer :: i
-      logical :: found
-      found = .false.
-      do i = 1, self%timer_count
-         if (self%timers(i)%name == name) then
-            call self%timers(i)%stop()
-            found = .true.
-         end if
-      end do
-      if (.not. found) call stop_error('Timer "'//trim(name)//'" not found!', module=this_module, procedure='stop_timer_by_name')
+      integer :: id
+      id = self%get_timer_id(name)
+      if (id == 0) then 
+         call stop_error('Timer "'//trim(name)//'" not found!', module=this_module, procedure='start_timer_by_name')
+      else
+         call self%timers(id)%stop()
+      end if
    end subroutine stop_timer_by_name
 
    subroutine pause_timer_by_name(self, name)
       class(watch_type), intent(inout) :: self
       character(len=*), intent(in) :: name
       ! internal
-      integer :: i
-      logical :: found
-      found = .false.
-      do i = 1, self%timer_count
-         if (self%timers(i)%name == name) then
-            call self%timers(i)%pause()
-            found = .true.
-         end if
-      end do
-      if (.not. found) call stop_error('Timer "'//trim(name)//'" not found!', module=this_module, procedure='pause_timer_by_name')
+      integer :: id
+      id = self%get_timer_id(name)
+      if (id == 0) then 
+         call stop_error('Timer "'//trim(name)//'" not found!', module=this_module, procedure='start_timer_by_name')
+      else
+         call self%timers(id)%start()
+      end if
    end subroutine
 
    subroutine reset_timer_by_name(self, name)
       class(watch_type), intent(inout) :: self
       character(len=*), intent(in) :: name
       ! internal
+      integer :: id
+      id = self%get_timer_id(name)
+      if (id == 0) then 
+         call stop_error('Timer "'//trim(name)//'" not found!', module=this_module, procedure='start_timer_by_name')
+      else
+         call self%timers(id)%start()
+      end if
+   end subroutine
+
+   subroutine enumerate(self, only_user)
+      class(watch_type), intent(in) :: self
+      logical, optional, intent(in) :: only_user
+      ! internal
       integer :: i
-      logical :: found
-      found = .false.
+      logical :: only_user_
+      character(len=128) :: msg
+      only_user_ = optval(only_user, .true.)
+      if (.not. only_user_) then
+         call logger%log_message('Registered timers: default', module=this_module)
+         do i = 1, self%private_count
+            write(msg,'(4X,I4,A,A)') i, ' : ', trim(self%timers(i)%name)
+            call logger%log_message(msg, module=this_module)
+         end do
+      end if
+      call logger%log_message('Registered timers: user', module=this_module)
+      do i = self%private_count+1, self%timer_count
+         write(msg,'(4X,I4,A,A)') i, ' : ', trim(self%timers(i)%name)
+         call logger%log_message(msg, module=this_module)
+      end do
+   end subroutine enumerate
+
+   subroutine initialize(self)
+      class(watch_type), intent(inout) :: self
+      ! timers for LightKrylov_BaseKrylov
+      #:for kind, type in RC_KINDS_TYPES
+      ! ${type[0]}$${kind}$
+      call self%add_timer('QR_with_pivoting_${type[0]}$${kind}$')
+      call self%add_timer('QR_no_pivoting_${type[0]}$${kind}$')
+      call self%add_timer('Orthonormalize_basis_${type[0]}$${kind}$')
+      call self%add_timer('Orthonormalize_vector_against_basis_${type[0]}$${kind}$')
+      call self%add_timer('Orthonormalize_basis_against_basis_${type[0]}$${kind}$')
+      call self%add_timer('DGS_vector_against_basis_${type[0]}$${kind}$')
+      call self%add_timer('DGS_basis_against_basis_${type[0]}$${kind}$')
+      self%basekrylov_count = self%timer_count
+      #:endfor
+      ! timers for LightKrylov_IterativeSolvers
+      #:for kind, type in RC_KINDS_TYPES
+      ! ${type[0]}$${kind}$
+      call self%add_timer('eigs_${type[0]}$${kind}$')
+      call self%add_timer('eighs_${type[0]}$${kind}$')
+      call self%add_timer('svds_${type[0]}$${kind}$')
+      call self%add_timer('gmres_${type[0]}$${kind}$')
+      call self%add_timer('fgmres_${type[0]}$${kind}$')
+      call self%add_timer('cg_${type[0]}$${kind}$')
+      self%iterativesolvers_count = self%timer_count
+      #:endfor
+      ! timers for LightKrylov_NewtonKrylov
+      #:for kind, type in RC_KINDS_TYPES
+      ! ${type[0]}$${kind}$
+      call self%add_timer('newton_${type[0]}$${kind}$')
+      #:endfor
+      self%newtonkrylov_count = self%timer_count
+      self%private_count = self%timer_count
+      self%user_mode = .true.
+      if_time = .true.
+   end subroutine initialize
+
+   subroutine finalize(self)
+      class(watch_type), intent(inout) :: self
+      ! internal
+      integer :: i, j, icalled
+      integer :: ic_bk, ic_is, ic_nk, ic_user
+      character(len=128) :: msg
+      icalled = 0
+      ic_bk = 0
       do i = 1, self%timer_count
-         if (self%timers(i)%name == name) then
-            call self%timers(i)%reset()
-            found = .true.
+         call self%timers(i)%stop()
+         if (self%timers(i)%count > 0) icalled = icalled + 1
+         if (i == self%basekrylov_count) then
+            ic_bk = icalled
+         else if (i == self%iterativesolvers_count) then
+            ic_is = icalled - ic_bk
+         else if (i == self%newtonkrylov_count) then
+            ic_nk = icalled - ic_is
          end if
       end do
-      if (.not. found) call stop_error('Timer "'//trim(name)//'" not found!', module=this_module, procedure='reset_timer_by_name')
-   end subroutine
+      ic_user = icalled - ic_nk
+      if_time = .false.
+      call logger%log_message('##############        Timer summary        ##############', module=this_module)
+      write(msg, '(2X,A20,I3)') 'Total active timers:', self%timer_count
+      call logger%log_message(msg, module=this_module)
+      write(msg, '(2X,A20,I3)') 'User defined:', self%user_count
+      call logger%log_message(msg, module=this_module)
+      write(msg, '(2X,A20,I3)') 'Called timers:', icalled
+      call logger%log_message(msg, module=this_module)
+      write(msg, '(A32,A5,2(1X,A10))') 'name', 'cnt', 'total', 'avg'
+      call logger%log_message(msg, module=this_module)
+      if (ic_bk > 0) then
+         call logger%log_message('BaseKrylov:', module=this_module)
+         do i = 1, self%basekrylov_count
+            associate(t => self%timers(i))
+               if (t%count > 0) then
+                  write(msg,'(2X,A30,I5,2(1X,F10.6))') trim(t%name), t%count, t%get_time(), t%get_time()/t%count
+                  call logger%log_message(msg, module=this_module)
+               end if
+            end associate
+         end do
+      end if
+      j = self%basekrylov_count
+      if (ic_is > 0) then
+         call logger%log_message('IterativeSolvers:', module=this_module)
+         do i = j, self%iterativesolvers_count
+            associate(t => self%timers(i))
+               if (t%count > 0) then
+                  write(msg,'(2X,A30,I5,2(1X,F10.6))') trim(t%name), t%count, t%get_time(), t%get_time()/t%count
+                  call logger%log_message(msg, module=this_module)
+               end if
+            end associate
+         end do
+      end if
+      j = self%iterativesolvers_count
+      if (ic_nk > 0) then
+         call logger%log_message('NewtonKrylov:', module=this_module)
+         do i = j, self%newtonkrylov_count
+            associate(t => self%timers(i))
+               if (t%count > 0) then
+                  write(msg,'(2X,A30,I5,2(1X,F10.6))') trim(t%name), t%count, t%get_time(), t%get_time()/t%count
+                  call logger%log_message(msg, module=this_module)
+               end if
+            end associate
+         end do
+      end if
+      if (self%user_count > 0 .and. ic_user > 0) then
+         j = self%private_count
+         call logger%log_message('User-defined:', module=this_module)
+         do i = j, self%timer_count
+            associate(t => self%timers(i))
+               if (t%count > 0) then
+                  write(msg,'(2X,A30,I5,2(1X,F10.6))') trim(t%name), t%count, t%get_time(), t%get_time()/t%count
+                  call logger%log_message(msg, module=this_module)
+               end if
+            end associate
+         end do
+      end if
+      call logger%log_message('##############        Timer summary        ##############', module=this_module)
+   end subroutine finalize
 
 end module LightKrylov_Timer


### PR DESCRIPTION
- [x] Added an optional output to `logger_setup` to return the file identifier of the created logfile.
- [x] Added an optional input to `logger_setup` which closes previously opened logfiles if present, allowing finer logfile control for more complicated applications. The default behaviour of `logger_setup` is now that all open logfiles are removed from the active list and closed (with the exception of `stdout`).
- [x] Created and deployed a timing module for `Lightkrylov`: `Lightkrylov_timing`.
  - `lightkrylov_timer` : The fundamental timer type that records the cpu time. Referenced by `name`.
  - `abstract_watch`: Abstract type that gathers all the individual timers throughout the toolbox and centralizes manipulation. Includes functionalities to add and remove timers, start, stop, pause and reset each timer by name. The extended type requires only definitions for the initalization (choose default timers and private elements) and finalization (compute averages and print results).
  - `lightkrylov_watch`: Global timer interface for `lightkrylov`, extends `abstract_watch`. 
  - Timings are only recorded if the global timer is initialized. This creates a private list of timers for all major subroutines by name and subsequently triggers timing when they are called throughout the toolbox. The internal system timers are gathered into sections by source file for convenience and cannot be removed by the user.
  - Using a finalization routine, the timing information for all routines that were called during execution is presented.
  - The user has the possibility to add their own timers, again referenced by name, that will also be displayed at finalization.
  - The module `lightkrylov_timing` exposes the global timer object `global_lightkrylov_logger`.
- [x] Added default timers for the basic abstract types of `lightkrylov`:
  - `abstract_linop`: 2 timers, `matvec_timer` and `rmatvec_timer` for direct and adjoint matvec calls. The timing is automatically triggered in the matvec wrapper.
  - `abstract_system`: `eval_timer` for the time for the residual evaluation. The timing is automatically triggered in the eval wrapper.