### PR TITLE
Added intermediate eigenvalue/singular value outputs for eigs, eigh, …

### DIFF
--- a/src/IterativeSolvers/EIGHS/eighs.f90
+++ b/src/IterativeSolvers/EIGHS/eighs.f90
@@ -2,6 +2,7 @@ submodule (lightkrylov_iterativesolvers) hermitian_eigensolvers
     use stdlib_strings, only: padr
     use stdlib_linalg, only: eigh
     implicit none
+    character(len=*), parameter :: eighs_output = 'eighs_output.txt'
 contains
 
     !----- Utility functions -----
@@ -73,13 +74,15 @@ contains
         integer :: i, j, k, nev, conv
         real(sp) :: tol
         real(sp) :: beta
+        logical :: outpost
         character(len=256) :: msg
 
         if (time_lightkrylov()) call timer%start('eighs_rsp')
         ! Deaks with the optional args.
         nev = size(X)
-        kdim_ = optval(kdim, 4*nev)
-        tol = optval(tolerance, rtol_sp)
+        kdim_   = optval(kdim, 4*nev)
+        tol     = optval(tolerance, rtol_sp)
+        outpost = optval(write_intermediate, .false.)
 
         ! Allocate working variables.
         allocate(Xwrk(kdim_+1), mold=X(1)) ; call zero_basis(Xwrk)
@@ -113,6 +116,7 @@ contains
             write(msg,'(I0,A,I0,A,I0,A)') conv, '/', nev, ' eigenvalues converged after ', k, &
                             & ' iterations of the Lanczos process.'
             call log_information(msg, module=this_module, procedure='eighs_rsp')
+            if (outpost) call write_results_rsp(eighs_output, eigvals_wrk(:k), residuals_wrk(:k), tol)
             if (conv >= nev) exit lanczos_iter
         enddo lanczos_iter
 
@@ -163,13 +167,15 @@ contains
         integer :: i, j, k, nev, conv
         real(dp) :: tol
         real(dp) :: beta
+        logical :: outpost
         character(len=256) :: msg
 
         if (time_lightkrylov()) call timer%start('eighs_rdp')
         ! Deaks with the optional args.
         nev = size(X)
-        kdim_ = optval(kdim, 4*nev)
-        tol = optval(tolerance, rtol_dp)
+        kdim_   = optval(kdim, 4*nev)
+        tol     = optval(tolerance, rtol_dp)
+        outpost = optval(write_intermediate, .false.)
 
         ! Allocate working variables.
         allocate(Xwrk(kdim_+1), mold=X(1)) ; call zero_basis(Xwrk)
@@ -203,6 +209,7 @@ contains
             write(msg,'(I0,A,I0,A,I0,A)') conv, '/', nev, ' eigenvalues converged after ', k, &
                             & ' iterations of the Lanczos process.'
             call log_information(msg, module=this_module, procedure='eighs_rdp')
+            if (outpost) call write_results_rdp(eighs_output, eigvals_wrk(:k), residuals_wrk(:k), tol)
             if (conv >= nev) exit lanczos_iter
         enddo lanczos_iter
 
@@ -253,13 +260,15 @@ contains
         integer :: i, j, k, nev, conv
         real(sp) :: tol
         complex(sp) :: beta
+        logical :: outpost
         character(len=256) :: msg
 
         if (time_lightkrylov()) call timer%start('eighs_csp')
         ! Deaks with the optional args.
         nev = size(X)
-        kdim_ = optval(kdim, 4*nev)
-        tol = optval(tolerance, rtol_sp)
+        kdim_   = optval(kdim, 4*nev)
+        tol     = optval(tolerance, rtol_sp)
+        outpost = optval(write_intermediate, .false.)
 
         ! Allocate working variables.
         allocate(Xwrk(kdim_+1), mold=X(1)) ; call zero_basis(Xwrk)
@@ -293,6 +302,7 @@ contains
             write(msg,'(I0,A,I0,A,I0,A)') conv, '/', nev, ' eigenvalues converged after ', k, &
                             & ' iterations of the Lanczos process.'
             call log_information(msg, module=this_module, procedure='eighs_csp')
+            if (outpost) call write_results_rsp(eighs_output, eigvals_wrk(:k), residuals_wrk(:k), tol)
             if (conv >= nev) exit lanczos_iter
         enddo lanczos_iter
 
@@ -343,13 +353,15 @@ contains
         integer :: i, j, k, nev, conv
         real(dp) :: tol
         complex(dp) :: beta
+        logical :: outpost
         character(len=256) :: msg
 
         if (time_lightkrylov()) call timer%start('eighs_cdp')
         ! Deaks with the optional args.
         nev = size(X)
-        kdim_ = optval(kdim, 4*nev)
-        tol = optval(tolerance, rtol_dp)
+        kdim_   = optval(kdim, 4*nev)
+        tol     = optval(tolerance, rtol_dp)
+        outpost = optval(write_intermediate, .false.)
 
         ! Allocate working variables.
         allocate(Xwrk(kdim_+1), mold=X(1)) ; call zero_basis(Xwrk)
@@ -383,6 +395,7 @@ contains
             write(msg,'(I0,A,I0,A,I0,A)') conv, '/', nev, ' eigenvalues converged after ', k, &
                             & ' iterations of the Lanczos process.'
             call log_information(msg, module=this_module, procedure='eighs_cdp')
+            if (outpost) call write_results_rdp(eighs_output, eigvals_wrk(:k), residuals_wrk(:k), tol)
             if (conv >= nev) exit lanczos_iter
         enddo lanczos_iter
 

--- a/src/IterativeSolvers/EIGHS/eighs.fypp
+++ b/src/IterativeSolvers/EIGHS/eighs.fypp
@@ -4,6 +4,7 @@ submodule (lightkrylov_iterativesolvers) hermitian_eigensolvers
     use stdlib_strings, only: padr
     use stdlib_linalg, only: eigh
     implicit none
+    character(len=*), parameter :: eighs_output = 'eighs_output.txt'
 contains
 
     !----- Utility functions -----
@@ -45,13 +46,15 @@ contains
         integer :: i, j, k, nev, conv
         real(${kind}$) :: tol
         ${type}$ :: beta
+        logical :: outpost
         character(len=256) :: msg
 
         if (time_lightkrylov()) call timer%start('eighs_${type[0]}$${kind}$')
         ! Deaks with the optional args.
         nev = size(X)
-        kdim_ = optval(kdim, 4*nev)
-        tol = optval(tolerance, rtol_${kind}$)
+        kdim_   = optval(kdim, 4*nev)
+        tol     = optval(tolerance, rtol_${kind}$)
+        outpost = optval(write_intermediate, .false.)
 
         ! Allocate working variables.
         allocate(Xwrk(kdim_+1), mold=X(1)) ; call zero_basis(Xwrk)
@@ -85,6 +88,7 @@ contains
             write(msg,'(I0,A,I0,A,I0,A)') conv, '/', nev, ' eigenvalues converged after ', k, &
                             & ' iterations of the Lanczos process.'
             call log_information(msg, module=this_module, procedure='eighs_${type[0]}$${kind}$')
+            if (outpost) call write_results_r${kind}$(eighs_output, eigvals_wrk(:k), residuals_wrk(:k), tol)
             if (conv >= nev) exit lanczos_iter
         enddo lanczos_iter
 

--- a/src/IterativeSolvers/IterativeSolvers.f90
+++ b/src/IterativeSolvers/IterativeSolvers.f90
@@ -42,6 +42,7 @@ module lightkrylov_IterativeSolvers
 
     character(len=*), parameter :: this_module      = 'LK_Solvers'
     character(len=*), parameter :: this_module_long = 'LightKrylov_IterativeSolvers'
+    character(len=*), parameter :: eigs_output      = 'eigs_output.txt'
 
     public :: abstract_linear_solver_rsp
     public :: abstract_linear_solver_rdp
@@ -66,6 +67,10 @@ module lightkrylov_IterativeSolvers
     public :: cg_rdp
     public :: cg_csp
     public :: cg_cdp
+    public :: write_results_rsp
+    public :: write_results_rdp
+    public :: write_results_csp
+    public :: write_results_cdp
 
     !------------------------------------------------------
     !-----     ABSTRACT PRECONDITIONER DEFINITION     -----
@@ -1029,7 +1034,7 @@ module lightkrylov_IterativeSolvers
         !!  This implementation does not currently include an automatic restarting procedure
         !!  such as `krylov_schur` for `eigs`. This is work in progress.
         !!  @endnote
-        module subroutine svds_rsp(A, U, S, V, residuals, info, u0, kdim, tolerance)
+        module subroutine svds_rsp(A, U, S, V, residuals, info, u0, kdim, tolerance, write_intermediate)
         class(abstract_linop_rsp), intent(inout) :: A
         !! Linear operator whose leading singular triplets need to be computed.
         class(abstract_vector_rsp), intent(out) :: U(:)
@@ -1047,8 +1052,10 @@ module lightkrylov_IterativeSolvers
         !! Desired number of eigenpairs.
         real(sp), optional, intent(in) :: tolerance
         !! Tolerance.
+        logical, optional, intent(in) :: write_intermediate
+        !! Write intermediate eigenvalues to file during iteration?
         end subroutine
-        module subroutine svds_rdp(A, U, S, V, residuals, info, u0, kdim, tolerance)
+        module subroutine svds_rdp(A, U, S, V, residuals, info, u0, kdim, tolerance, write_intermediate)
         class(abstract_linop_rdp), intent(inout) :: A
         !! Linear operator whose leading singular triplets need to be computed.
         class(abstract_vector_rdp), intent(out) :: U(:)
@@ -1066,8 +1073,10 @@ module lightkrylov_IterativeSolvers
         !! Desired number of eigenpairs.
         real(dp), optional, intent(in) :: tolerance
         !! Tolerance.
+        logical, optional, intent(in) :: write_intermediate
+        !! Write intermediate eigenvalues to file during iteration?
         end subroutine
-        module subroutine svds_csp(A, U, S, V, residuals, info, u0, kdim, tolerance)
+        module subroutine svds_csp(A, U, S, V, residuals, info, u0, kdim, tolerance, write_intermediate)
         class(abstract_linop_csp), intent(inout) :: A
         !! Linear operator whose leading singular triplets need to be computed.
         class(abstract_vector_csp), intent(out) :: U(:)
@@ -1085,8 +1094,10 @@ module lightkrylov_IterativeSolvers
         !! Desired number of eigenpairs.
         real(sp), optional, intent(in) :: tolerance
         !! Tolerance.
+        logical, optional, intent(in) :: write_intermediate
+        !! Write intermediate eigenvalues to file during iteration?
         end subroutine
-        module subroutine svds_cdp(A, U, S, V, residuals, info, u0, kdim, tolerance)
+        module subroutine svds_cdp(A, U, S, V, residuals, info, u0, kdim, tolerance, write_intermediate)
         class(abstract_linop_cdp), intent(inout) :: A
         !! Linear operator whose leading singular triplets need to be computed.
         class(abstract_vector_cdp), intent(out) :: U(:)
@@ -1104,6 +1115,8 @@ module lightkrylov_IterativeSolvers
         !! Desired number of eigenpairs.
         real(dp), optional, intent(in) :: tolerance
         !! Tolerance.
+        logical, optional, intent(in) :: write_intermediate
+        !! Write intermediate eigenvalues to file during iteration?
         end subroutine
     end interface
 
@@ -1168,7 +1181,7 @@ module lightkrylov_IterativeSolvers
         !!  This implementation does not currently include an automatic restarting procedure
         !!  such as `krylov_schur` for `eigs`. This is work in progress.
         !!  @endnote
-        module subroutine eighs_rsp(A, X, eigvals, residuals, info, x0, kdim, tolerance)
+        module subroutine eighs_rsp(A, X, eigvals, residuals, info, x0, kdim, tolerance, write_intermediate)
             class(abstract_sym_linop_rsp), intent(inout) :: A
             !! Linear operator whose leading eigenpairs need to be computed.
             class(abstract_vector_rsp), intent(out) :: X(:)
@@ -1185,8 +1198,10 @@ module lightkrylov_IterativeSolvers
             !! Desired number of eigenpairs.
             real(sp), optional, intent(in) :: tolerance
             !! Tolerance
+            logical, optional, intent(in) :: write_intermediate
+            !! Write intermediate eigenvalues to file during iteration?
         end subroutine
-        module subroutine eighs_rdp(A, X, eigvals, residuals, info, x0, kdim, tolerance)
+        module subroutine eighs_rdp(A, X, eigvals, residuals, info, x0, kdim, tolerance, write_intermediate)
             class(abstract_sym_linop_rdp), intent(inout) :: A
             !! Linear operator whose leading eigenpairs need to be computed.
             class(abstract_vector_rdp), intent(out) :: X(:)
@@ -1203,8 +1218,10 @@ module lightkrylov_IterativeSolvers
             !! Desired number of eigenpairs.
             real(dp), optional, intent(in) :: tolerance
             !! Tolerance
+            logical, optional, intent(in) :: write_intermediate
+            !! Write intermediate eigenvalues to file during iteration?
         end subroutine
-        module subroutine eighs_csp(A, X, eigvals, residuals, info, x0, kdim, tolerance)
+        module subroutine eighs_csp(A, X, eigvals, residuals, info, x0, kdim, tolerance, write_intermediate)
             class(abstract_hermitian_linop_csp), intent(inout) :: A
             !! Linear operator whose leading eigenpairs need to be computed.
             class(abstract_vector_csp), intent(out) :: X(:)
@@ -1221,8 +1238,10 @@ module lightkrylov_IterativeSolvers
             !! Desired number of eigenpairs.
             real(sp), optional, intent(in) :: tolerance
             !! Tolerance
+            logical, optional, intent(in) :: write_intermediate
+            !! Write intermediate eigenvalues to file during iteration?
         end subroutine
-        module subroutine eighs_cdp(A, X, eigvals, residuals, info, x0, kdim, tolerance)
+        module subroutine eighs_cdp(A, X, eigvals, residuals, info, x0, kdim, tolerance, write_intermediate)
             class(abstract_hermitian_linop_cdp), intent(inout) :: A
             !! Linear operator whose leading eigenpairs need to be computed.
             class(abstract_vector_cdp), intent(out) :: X(:)
@@ -1239,6 +1258,8 @@ module lightkrylov_IterativeSolvers
             !! Desired number of eigenpairs.
             real(dp), optional, intent(in) :: tolerance
             !! Tolerance
+            logical, optional, intent(in) :: write_intermediate
+            !! Write intermediate eigenvalues to file during iteration?
         end subroutine
     end interface
 
@@ -1383,6 +1404,103 @@ contains
     !-----     UTILITY FUNCTIONS     -----
     !-------------------------------------
 
+    subroutine write_results_rsp(filename, vals, res, tol)
+        !! Prints the intermediate results of iterative eigenvalue/singular value decompositions
+        character(len=*), intent(in) :: filename
+        !! Output filename. This file will be overwritten
+        real(sp), intent(in) :: vals(:)
+        !! Intermediate values
+        real(sp), intent(in) :: res(:)
+        !! Residuals
+        real(sp), intent(in) :: tol
+        !! Convergence tolerance
+        ! internals
+        integer :: i, k
+        character(len=*), parameter :: fmtc = '(I6,3(2X,E16.9),2X,L1)'
+        character(len=*), parameter :: fmtr = '(I6,2(2X,E16.9),2X,L1)'
+        k = size(vals)
+        if (io_rank()) then ! only master rank writes
+            open (1234, file=filename, status='replace', action='write')
+                write (1234, '(A6,2(A18),A3)') 'Iter', 'value', 'residual', 'C'
+            do i = 1, k
+                    write (1234, fmtr) k, vals(i),                res(i), res(i) < tol
+            end do 
+            close (1234)
+        end if
+    end subroutine
+    subroutine write_results_rdp(filename, vals, res, tol)
+        !! Prints the intermediate results of iterative eigenvalue/singular value decompositions
+        character(len=*), intent(in) :: filename
+        !! Output filename. This file will be overwritten
+        real(dp), intent(in) :: vals(:)
+        !! Intermediate values
+        real(dp), intent(in) :: res(:)
+        !! Residuals
+        real(dp), intent(in) :: tol
+        !! Convergence tolerance
+        ! internals
+        integer :: i, k
+        character(len=*), parameter :: fmtc = '(I6,3(2X,E16.9),2X,L1)'
+        character(len=*), parameter :: fmtr = '(I6,2(2X,E16.9),2X,L1)'
+        k = size(vals)
+        if (io_rank()) then ! only master rank writes
+            open (1234, file=filename, status='replace', action='write')
+                write (1234, '(A6,2(A18),A3)') 'Iter', 'value', 'residual', 'C'
+            do i = 1, k
+                    write (1234, fmtr) k, vals(i),                res(i), res(i) < tol
+            end do 
+            close (1234)
+        end if
+    end subroutine
+    subroutine write_results_csp(filename, vals, res, tol)
+        !! Prints the intermediate results of iterative eigenvalue/singular value decompositions
+        character(len=*), intent(in) :: filename
+        !! Output filename. This file will be overwritten
+        complex(sp), intent(in) :: vals(:)
+        !! Intermediate values
+        real(sp), intent(in) :: res(:)
+        !! Residuals
+        real(sp), intent(in) :: tol
+        !! Convergence tolerance
+        ! internals
+        integer :: i, k
+        character(len=*), parameter :: fmtc = '(I6,3(2X,E16.9),2X,L1)'
+        character(len=*), parameter :: fmtr = '(I6,2(2X,E16.9),2X,L1)'
+        k = size(vals)
+        if (io_rank()) then ! only master rank writes
+            open (1234, file=filename, status='replace', action='write')
+                write (1234, '(A6,2(A18),A3)') 'Iter', 'Re', 'Im', 'residual', 'C'
+            do i = 1, k
+                    write (1234, fmtc) k, vals(i)%re, vals(i)%im, res(i), res(i) < tol
+            end do 
+            close (1234)
+        end if
+    end subroutine
+    subroutine write_results_cdp(filename, vals, res, tol)
+        !! Prints the intermediate results of iterative eigenvalue/singular value decompositions
+        character(len=*), intent(in) :: filename
+        !! Output filename. This file will be overwritten
+        complex(dp), intent(in) :: vals(:)
+        !! Intermediate values
+        real(dp), intent(in) :: res(:)
+        !! Residuals
+        real(dp), intent(in) :: tol
+        !! Convergence tolerance
+        ! internals
+        integer :: i, k
+        character(len=*), parameter :: fmtc = '(I6,3(2X,E16.9),2X,L1)'
+        character(len=*), parameter :: fmtr = '(I6,2(2X,E16.9),2X,L1)'
+        k = size(vals)
+        if (io_rank()) then ! only master rank writes
+            open (1234, file=filename, status='replace', action='write')
+                write (1234, '(A6,2(A18),A3)') 'Iter', 'Re', 'Im', 'residual', 'C'
+            do i = 1, k
+                    write (1234, fmtc) k, vals(i)%re, vals(i)%im, res(i), res(i) < tol
+            end do 
+            close (1234)
+        end if
+    end subroutine
+
     elemental pure function compute_residual_rsp(beta, x) result(residual)
         !! Computes the residual associated with a Ritz eigenpair.
         real(sp), intent(in) :: beta
@@ -1392,7 +1510,6 @@ contains
         real(sp) :: residual
         !! Residual associated to the corresponding Ritz eigenpair.
         residual = abs(beta*x)
-        return
     end function compute_residual_rsp
     elemental pure function compute_residual_rdp(beta, x) result(residual)
         !! Computes the residual associated with a Ritz eigenpair.
@@ -1403,7 +1520,6 @@ contains
         real(dp) :: residual
         !! Residual associated to the corresponding Ritz eigenpair.
         residual = abs(beta*x)
-        return
     end function compute_residual_rdp
     elemental pure function compute_residual_csp(beta, x) result(residual)
         !! Computes the residual associated with a Ritz eigenpair.
@@ -1414,7 +1530,6 @@ contains
         real(sp) :: residual
         !! Residual associated to the corresponding Ritz eigenpair.
         residual = abs(beta*x)
-        return
     end function compute_residual_csp
     elemental pure function compute_residual_cdp(beta, x) result(residual)
         !! Computes the residual associated with a Ritz eigenpair.
@@ -1425,7 +1540,6 @@ contains
         real(dp) :: residual
         !! Residual associated to the corresponding Ritz eigenpair.
         residual = abs(beta*x)
-        return
     end function compute_residual_cdp
 
     module procedure save_eigenspectrum_rsp
@@ -1461,7 +1575,7 @@ contains
     !-----     GENERAL EIGENVALUE COMPUTATIONS     -----
     !---------------------------------------------------
 
-    subroutine eigs_rsp(A, X, eigvals, residuals, info, x0, kdim, tolerance, transpose)
+    subroutine eigs_rsp(A, X, eigvals, residuals, info, x0, kdim, tolerance, transpose, write_intermediate)
         class(abstract_linop_rsp), intent(inout) :: A
         !! Linear operator whose leading eigenpairs need to be computed.
         class(abstract_vector_rsp), intent(out) :: X(:)
@@ -1480,6 +1594,8 @@ contains
         !! Tolerance.
         logical, optional, intent(in) :: transpose
         !! Determine whether \(\mathbf{A}\) or \(\mathbf{A}^H\) is being used.
+        logical, optional, intent(in) :: write_intermediate
+        !! Write intermediate eigenvalues to file during iteration?
 
         !--------------------------------------
         !-----     Internal variables     -----
@@ -1500,6 +1616,7 @@ contains
         real(sp) :: tol, x0_norm
         real(sp) :: beta
         real(sp) :: alpha
+        logical :: outpost
         character(len=256) :: msg
 
         if (time_lightkrylov()) call timer%start('eigs_rsp')
@@ -1507,6 +1624,7 @@ contains
         nev = size(X)
         kdim_   = optval(kdim, 4*nev)
         tol     = optval(tolerance, rtol_sp)
+        outpost = optval(write_intermediate, .false.)
 
         ! Allocate eigenvalues.
         allocate(eigvals(nev)) ; eigvals = 0.0_sp
@@ -1558,6 +1676,7 @@ contains
                 write(msg,'(I0,A,I0,A,I0,A)') conv, '/', nev, ' eigenvalues converged after ', niter, &
                             & ' steps of the Arnoldi process.'
                 call log_information(msg, module=this_module, procedure='eigs_rsp')
+                if (outpost) call write_results_csp(eigs_output, eigvals_wrk(:k), residuals_wrk(:k), tol)
                 if (conv >= nev) exit arnoldi_factorization
             enddo arnoldi_factorization
 
@@ -1606,7 +1725,7 @@ contains
             selected = abs(lambda) > median(abs(lambda))
         end function median_selector
     end subroutine eigs_rsp
-    subroutine eigs_rdp(A, X, eigvals, residuals, info, x0, kdim, tolerance, transpose)
+    subroutine eigs_rdp(A, X, eigvals, residuals, info, x0, kdim, tolerance, transpose, write_intermediate)
         class(abstract_linop_rdp), intent(inout) :: A
         !! Linear operator whose leading eigenpairs need to be computed.
         class(abstract_vector_rdp), intent(out) :: X(:)
@@ -1625,6 +1744,8 @@ contains
         !! Tolerance.
         logical, optional, intent(in) :: transpose
         !! Determine whether \(\mathbf{A}\) or \(\mathbf{A}^H\) is being used.
+        logical, optional, intent(in) :: write_intermediate
+        !! Write intermediate eigenvalues to file during iteration?
 
         !--------------------------------------
         !-----     Internal variables     -----
@@ -1645,6 +1766,7 @@ contains
         real(dp) :: tol, x0_norm
         real(dp) :: beta
         real(dp) :: alpha
+        logical :: outpost
         character(len=256) :: msg
 
         if (time_lightkrylov()) call timer%start('eigs_rdp')
@@ -1652,6 +1774,7 @@ contains
         nev = size(X)
         kdim_   = optval(kdim, 4*nev)
         tol     = optval(tolerance, rtol_dp)
+        outpost = optval(write_intermediate, .false.)
 
         ! Allocate eigenvalues.
         allocate(eigvals(nev)) ; eigvals = 0.0_dp
@@ -1703,6 +1826,7 @@ contains
                 write(msg,'(I0,A,I0,A,I0,A)') conv, '/', nev, ' eigenvalues converged after ', niter, &
                             & ' steps of the Arnoldi process.'
                 call log_information(msg, module=this_module, procedure='eigs_rdp')
+                if (outpost) call write_results_cdp(eigs_output, eigvals_wrk(:k), residuals_wrk(:k), tol)
                 if (conv >= nev) exit arnoldi_factorization
             enddo arnoldi_factorization
 
@@ -1751,7 +1875,7 @@ contains
             selected = abs(lambda) > median(abs(lambda))
         end function median_selector
     end subroutine eigs_rdp
-    subroutine eigs_csp(A, X, eigvals, residuals, info, x0, kdim, tolerance, transpose)
+    subroutine eigs_csp(A, X, eigvals, residuals, info, x0, kdim, tolerance, transpose, write_intermediate)
         class(abstract_linop_csp), intent(inout) :: A
         !! Linear operator whose leading eigenpairs need to be computed.
         class(abstract_vector_csp), intent(out) :: X(:)
@@ -1770,6 +1894,8 @@ contains
         !! Tolerance.
         logical, optional, intent(in) :: transpose
         !! Determine whether \(\mathbf{A}\) or \(\mathbf{A}^H\) is being used.
+        logical, optional, intent(in) :: write_intermediate
+        !! Write intermediate eigenvalues to file during iteration?
 
         !--------------------------------------
         !-----     Internal variables     -----
@@ -1789,6 +1915,7 @@ contains
         integer :: i, j, k, niter, krst
         real(sp) :: tol, x0_norm
         complex(sp) :: beta
+        logical :: outpost
         character(len=256) :: msg
 
         if (time_lightkrylov()) call timer%start('eigs_csp')
@@ -1796,6 +1923,7 @@ contains
         nev = size(X)
         kdim_   = optval(kdim, 4*nev)
         tol     = optval(tolerance, rtol_sp)
+        outpost = optval(write_intermediate, .false.)
 
         ! Allocate eigenvalues.
         allocate(eigvals(nev)) ; eigvals = 0.0_sp
@@ -1838,6 +1966,7 @@ contains
                 write(msg,'(I0,A,I0,A,I0,A)') conv, '/', nev, ' eigenvalues converged after ', niter, &
                             & ' steps of the Arnoldi process.'
                 call log_information(msg, module=this_module, procedure='eigs_csp')
+                if (outpost) call write_results_csp(eigs_output, eigvals_wrk(:k), residuals_wrk(:k), tol)
                 if (conv >= nev) exit arnoldi_factorization
             enddo arnoldi_factorization
 
@@ -1886,7 +2015,7 @@ contains
             selected = abs(lambda) > median(abs(lambda))
         end function median_selector
     end subroutine eigs_csp
-    subroutine eigs_cdp(A, X, eigvals, residuals, info, x0, kdim, tolerance, transpose)
+    subroutine eigs_cdp(A, X, eigvals, residuals, info, x0, kdim, tolerance, transpose, write_intermediate)
         class(abstract_linop_cdp), intent(inout) :: A
         !! Linear operator whose leading eigenpairs need to be computed.
         class(abstract_vector_cdp), intent(out) :: X(:)
@@ -1905,6 +2034,8 @@ contains
         !! Tolerance.
         logical, optional, intent(in) :: transpose
         !! Determine whether \(\mathbf{A}\) or \(\mathbf{A}^H\) is being used.
+        logical, optional, intent(in) :: write_intermediate
+        !! Write intermediate eigenvalues to file during iteration?
 
         !--------------------------------------
         !-----     Internal variables     -----
@@ -1924,6 +2055,7 @@ contains
         integer :: i, j, k, niter, krst
         real(dp) :: tol, x0_norm
         complex(dp) :: beta
+        logical :: outpost
         character(len=256) :: msg
 
         if (time_lightkrylov()) call timer%start('eigs_cdp')
@@ -1931,6 +2063,7 @@ contains
         nev = size(X)
         kdim_   = optval(kdim, 4*nev)
         tol     = optval(tolerance, rtol_dp)
+        outpost = optval(write_intermediate, .false.)
 
         ! Allocate eigenvalues.
         allocate(eigvals(nev)) ; eigvals = 0.0_dp
@@ -1973,6 +2106,7 @@ contains
                 write(msg,'(I0,A,I0,A,I0,A)') conv, '/', nev, ' eigenvalues converged after ', niter, &
                             & ' steps of the Arnoldi process.'
                 call log_information(msg, module=this_module, procedure='eigs_cdp')
+                if (outpost) call write_results_cdp(eigs_output, eigvals_wrk(:k), residuals_wrk(:k), tol)
                 if (conv >= nev) exit arnoldi_factorization
             enddo arnoldi_factorization
 

--- a/src/IterativeSolvers/IterativeSolvers.fypp
+++ b/src/IterativeSolvers/IterativeSolvers.fypp
@@ -44,6 +44,7 @@ module lightkrylov_IterativeSolvers
 
     character(len=*), parameter :: this_module      = 'LK_Solvers'
     character(len=*), parameter :: this_module_long = 'LightKrylov_IterativeSolvers'
+    character(len=*), parameter :: eigs_output      = 'eigs_output.txt'
 
     #:for kind, type in RC_KINDS_TYPES
     public :: abstract_linear_solver_${type[0]}$${kind}$
@@ -63,6 +64,9 @@ module lightkrylov_IterativeSolvers
     public :: cg
     #:for kind, type in RC_KINDS_TYPES
     public :: cg_${type[0]}$${kind}$
+    #:endfor
+    #:for kind, type in RC_KINDS_TYPES
+    public :: write_results_${type[0]}$${kind}$
     #:endfor
 
     !------------------------------------------------------
@@ -597,7 +601,7 @@ module lightkrylov_IterativeSolvers
         !!  such as `krylov_schur` for `eigs`. This is work in progress.
         !!  @endnote
         #:for kind, type in RC_KINDS_TYPES
-        module subroutine svds_${type[0]}$${kind}$(A, U, S, V, residuals, info, u0, kdim, tolerance)
+        module subroutine svds_${type[0]}$${kind}$(A, U, S, V, residuals, info, u0, kdim, tolerance, write_intermediate)
         class(abstract_linop_${type[0]}$${kind}$), intent(inout) :: A
         !! Linear operator whose leading singular triplets need to be computed.
         class(abstract_vector_${type[0]}$${kind}$), intent(out) :: U(:)
@@ -615,6 +619,8 @@ module lightkrylov_IterativeSolvers
         !! Desired number of eigenpairs.
         real(${kind}$), optional, intent(in) :: tolerance
         !! Tolerance.
+        logical, optional, intent(in) :: write_intermediate
+        !! Write intermediate eigenvalues to file during iteration?
         end subroutine
         #:endfor
     end interface
@@ -681,7 +687,7 @@ module lightkrylov_IterativeSolvers
         !!  such as `krylov_schur` for `eigs`. This is work in progress.
         !!  @endnote
         #:for kind, type in RC_KINDS_TYPES
-        module subroutine eighs_${type[0]}$${kind}$(A, X, eigvals, residuals, info, x0, kdim, tolerance)
+        module subroutine eighs_${type[0]}$${kind}$(A, X, eigvals, residuals, info, x0, kdim, tolerance, write_intermediate)
             #:if type[0] == "r"
             class(abstract_sym_linop_${type[0]}$${kind}$), intent(inout) :: A
             #:else
@@ -702,6 +708,8 @@ module lightkrylov_IterativeSolvers
             !! Desired number of eigenpairs.
             real(${kind}$), optional, intent(in) :: tolerance
             !! Tolerance
+            logical, optional, intent(in) :: write_intermediate
+            !! Write intermediate eigenvalues to file during iteration?
         end subroutine
         #:endfor
     end interface
@@ -822,6 +830,41 @@ contains
     !-------------------------------------
 
     #:for kind, type in RC_KINDS_TYPES
+    subroutine write_results_${type[0]}$${kind}$(filename, vals, res, tol)
+        !! Prints the intermediate results of iterative eigenvalue/singular value decompositions
+        character(len=*), intent(in) :: filename
+        !! Output filename. This file will be overwritten
+        ${type}$, intent(in) :: vals(:)
+        !! Intermediate values
+        real(${kind}$), intent(in) :: res(:)
+        !! Residuals
+        real(${kind}$), intent(in) :: tol
+        !! Convergence tolerance
+        ! internals
+        integer :: i, k
+        character(len=*), parameter :: fmtc = '(I6,3(2X,E16.9),2X,L1)'
+        character(len=*), parameter :: fmtr = '(I6,2(2X,E16.9),2X,L1)'
+        k = size(vals)
+        if (io_rank()) then ! only master rank writes
+            open (1234, file=filename, status='replace', action='write')
+            #:if type[0] == "c"
+                write (1234, '(A6,2(A18),A3)') 'Iter', 'Re', 'Im', 'residual', 'C'
+            #:else
+                write (1234, '(A6,2(A18),A3)') 'Iter', 'value', 'residual', 'C'
+            #:endif
+            do i = 1, k
+                #:if type[0] == "c"
+                    write (1234, fmtc) k, vals(i)%re, vals(i)%im, res(i), res(i) < tol
+                #:else
+                    write (1234, fmtr) k, vals(i),                res(i), res(i) < tol
+                #:endif
+            end do 
+            close (1234)
+        end if
+    end subroutine
+    #:endfor
+
+    #:for kind, type in RC_KINDS_TYPES
     elemental pure function compute_residual_${type[0]}$${kind}$(beta, x) result(residual)
         !! Computes the residual associated with a Ritz eigenpair.
         ${type}$, intent(in) :: beta
@@ -831,7 +874,6 @@ contains
         real(${kind}$) :: residual
         !! Residual associated to the corresponding Ritz eigenpair.
         residual = abs(beta*x)
-        return
     end function compute_residual_${type[0]}$${kind}$
     #:endfor
 
@@ -855,7 +897,7 @@ contains
     !---------------------------------------------------
 
     #:for kind, type in RC_KINDS_TYPES
-    subroutine eigs_${type[0]}$${kind}$(A, X, eigvals, residuals, info, x0, kdim, tolerance, transpose)
+    subroutine eigs_${type[0]}$${kind}$(A, X, eigvals, residuals, info, x0, kdim, tolerance, transpose, write_intermediate)
         class(abstract_linop_${type[0]}$${kind}$), intent(inout) :: A
         !! Linear operator whose leading eigenpairs need to be computed.
         class(abstract_vector_${type[0]}$${kind}$), intent(out) :: X(:)
@@ -874,6 +916,8 @@ contains
         !! Tolerance.
         logical, optional, intent(in) :: transpose
         !! Determine whether \(\mathbf{A}\) or \(\mathbf{A}^H\) is being used.
+        logical, optional, intent(in) :: write_intermediate
+        !! Write intermediate eigenvalues to file during iteration?
 
         !--------------------------------------
         !-----     Internal variables     -----
@@ -896,6 +940,7 @@ contains
         #:if type[0] == "r"
         ${type}$ :: alpha
         #:endif
+        logical :: outpost
         character(len=256) :: msg
 
         if (time_lightkrylov()) call timer%start('eigs_${type[0]}$${kind}$')
@@ -903,6 +948,7 @@ contains
         nev = size(X)
         kdim_   = optval(kdim, 4*nev)
         tol     = optval(tolerance, rtol_${kind}$)
+        outpost = optval(write_intermediate, .false.)
 
         ! Allocate eigenvalues.
         allocate(eigvals(nev)) ; eigvals = 0.0_${kind}$
@@ -958,6 +1004,7 @@ contains
                 write(msg,'(I0,A,I0,A,I0,A)') conv, '/', nev, ' eigenvalues converged after ', niter, &
                             & ' steps of the Arnoldi process.'
                 call log_information(msg, module=this_module, procedure='eigs_${type[0]}$${kind}$')
+                if (outpost) call write_results_c${kind}$(eigs_output, eigvals_wrk(:k), residuals_wrk(:k), tol)
                 if (conv >= nev) exit arnoldi_factorization
             enddo arnoldi_factorization
 

--- a/src/IterativeSolvers/SVDS/svd_solvers.f90
+++ b/src/IterativeSolvers/SVDS/svd_solvers.f90
@@ -1,6 +1,7 @@
 submodule (lightkrylov_iterativesolvers) svds_solver
     use stdlib_linalg, only: hermitian, svd
     implicit none
+    character(len=*), parameter :: svds_output = 'svds_output.txt'
 contains
 
     !----- Utility functions -----
@@ -15,7 +16,6 @@ contains
         residual = abs(beta*x)
         return
     end function svd_residual_rsp
-
     elemental pure function svd_residual_rdp(beta, x) result(residual)
         !! Computes the residual associated with a Ritz eigenpair.
         real(dp), intent(in) :: beta
@@ -27,7 +27,6 @@ contains
         residual = abs(beta*x)
         return
     end function svd_residual_rdp
-
     elemental pure function svd_residual_csp(beta, x) result(residual)
         !! Computes the residual associated with a Ritz eigenpair.
         complex(sp), intent(in) :: beta
@@ -39,7 +38,6 @@ contains
         residual = abs(beta*x)
         return
     end function svd_residual_csp
-
     elemental pure function svd_residual_cdp(beta, x) result(residual)
         !! Computes the residual associated with a Ritz eigenpair.
         complex(dp), intent(in) :: beta
@@ -51,7 +49,6 @@ contains
         residual = abs(beta*x)
         return
     end function svd_residual_cdp
-
 
     !----------------------------------------
     !-----     ITERATIVE SVD SOLVER     -----
@@ -71,13 +68,15 @@ contains
         integer :: nsv, conv
         integer :: i, j, k
         real(sp) :: tol, u0_norm
+        logical :: outpost
         character(len=256) :: msg
 
         if (time_lightkrylov()) call timer%start('svds_rsp')
         ! Deals with the optional arguments.
         nsv = size(U)
-        kdim_ = optval(kdim, 4*nsv)
+        kdim_   = optval(kdim, 4*nsv)
         tol     = optval(tolerance, rtol_sp)
+        outpost = optval(write_intermediate, .true.)
 
         ! Allocate working variables.
         allocate(Uwrk(kdim_+1), mold=U(1)) ; call zero_basis(Uwrk)
@@ -115,6 +114,7 @@ contains
             write(msg,'(I0,A,I0,A,I0,A)') conv, '/', nsv, ' singular values converged after ', k, &
                             & ' iterations of the Lanczos process.'
             call log_information(msg, module=this_module, procedure='svds_rsp')
+            if (outpost) call write_results_rsp(svds_output, svdvals_wrk(:k), residuals_wrk(:k), tol)
             if (conv >= nsv) exit lanczos_iter
         enddo lanczos_iter
 
@@ -153,13 +153,15 @@ contains
         integer :: nsv, conv
         integer :: i, j, k
         real(dp) :: tol, u0_norm
+        logical :: outpost
         character(len=256) :: msg
 
         if (time_lightkrylov()) call timer%start('svds_rdp')
         ! Deals with the optional arguments.
         nsv = size(U)
-        kdim_ = optval(kdim, 4*nsv)
+        kdim_   = optval(kdim, 4*nsv)
         tol     = optval(tolerance, rtol_dp)
+        outpost = optval(write_intermediate, .true.)
 
         ! Allocate working variables.
         allocate(Uwrk(kdim_+1), mold=U(1)) ; call zero_basis(Uwrk)
@@ -197,6 +199,7 @@ contains
             write(msg,'(I0,A,I0,A,I0,A)') conv, '/', nsv, ' singular values converged after ', k, &
                             & ' iterations of the Lanczos process.'
             call log_information(msg, module=this_module, procedure='svds_rdp')
+            if (outpost) call write_results_rdp(svds_output, svdvals_wrk(:k), residuals_wrk(:k), tol)
             if (conv >= nsv) exit lanczos_iter
         enddo lanczos_iter
 
@@ -235,13 +238,15 @@ contains
         integer :: nsv, conv
         integer :: i, j, k
         real(sp) :: tol, u0_norm
+        logical :: outpost
         character(len=256) :: msg
 
         if (time_lightkrylov()) call timer%start('svds_csp')
         ! Deals with the optional arguments.
         nsv = size(U)
-        kdim_ = optval(kdim, 4*nsv)
+        kdim_   = optval(kdim, 4*nsv)
         tol     = optval(tolerance, rtol_sp)
+        outpost = optval(write_intermediate, .true.)
 
         ! Allocate working variables.
         allocate(Uwrk(kdim_+1), mold=U(1)) ; call zero_basis(Uwrk)
@@ -279,6 +284,7 @@ contains
             write(msg,'(I0,A,I0,A,I0,A)') conv, '/', nsv, ' singular values converged after ', k, &
                             & ' iterations of the Lanczos process.'
             call log_information(msg, module=this_module, procedure='svds_csp')
+            if (outpost) call write_results_rsp(svds_output, svdvals_wrk(:k), residuals_wrk(:k), tol)
             if (conv >= nsv) exit lanczos_iter
         enddo lanczos_iter
 
@@ -317,13 +323,15 @@ contains
         integer :: nsv, conv
         integer :: i, j, k
         real(dp) :: tol, u0_norm
+        logical :: outpost
         character(len=256) :: msg
 
         if (time_lightkrylov()) call timer%start('svds_cdp')
         ! Deals with the optional arguments.
         nsv = size(U)
-        kdim_ = optval(kdim, 4*nsv)
+        kdim_   = optval(kdim, 4*nsv)
         tol     = optval(tolerance, rtol_dp)
+        outpost = optval(write_intermediate, .true.)
 
         ! Allocate working variables.
         allocate(Uwrk(kdim_+1), mold=U(1)) ; call zero_basis(Uwrk)
@@ -361,6 +369,7 @@ contains
             write(msg,'(I0,A,I0,A,I0,A)') conv, '/', nsv, ' singular values converged after ', k, &
                             & ' iterations of the Lanczos process.'
             call log_information(msg, module=this_module, procedure='svds_cdp')
+            if (outpost) call write_results_rdp(svds_output, svdvals_wrk(:k), residuals_wrk(:k), tol)
             if (conv >= nsv) exit lanczos_iter
         enddo lanczos_iter
 

--- a/src/IterativeSolvers/SVDS/svd_solvers.fypp
+++ b/src/IterativeSolvers/SVDS/svd_solvers.fypp
@@ -3,6 +3,7 @@
 submodule (lightkrylov_iterativesolvers) svds_solver
     use stdlib_linalg, only: hermitian, svd
     implicit none
+    character(len=*), parameter :: svds_output = 'svds_output.txt'
 contains
 
     !----- Utility functions -----
@@ -18,7 +19,6 @@ contains
         residual = abs(beta*x)
         return
     end function svd_residual_${type[0]}$${kind}$
-
     #:endfor
 
     !----------------------------------------
@@ -40,13 +40,15 @@ contains
         integer :: nsv, conv
         integer :: i, j, k
         real(${kind}$) :: tol, u0_norm
+        logical :: outpost
         character(len=256) :: msg
 
         if (time_lightkrylov()) call timer%start('svds_${type[0]}$${kind}$')
         ! Deals with the optional arguments.
         nsv = size(U)
-        kdim_ = optval(kdim, 4*nsv)
+        kdim_   = optval(kdim, 4*nsv)
         tol     = optval(tolerance, rtol_${kind}$)
+        outpost = optval(write_intermediate, .false.)
 
         ! Allocate working variables.
         allocate(Uwrk(kdim_+1), mold=U(1)) ; call zero_basis(Uwrk)
@@ -84,6 +86,7 @@ contains
             write(msg,'(I0,A,I0,A,I0,A)') conv, '/', nsv, ' singular values converged after ', k, &
                             & ' iterations of the Lanczos process.'
             call log_information(msg, module=this_module, procedure='svds_${type[0]}$${kind}$')
+            if (outpost) call write_results_r${kind}$(svds_output, svdvals_wrk(:k), residuals_wrk(:k), tol)
             if (conv >= nsv) exit lanczos_iter
         enddo lanczos_iter
 


### PR DESCRIPTION
…svds.

I added an optional kwarg to `eigs`, `svds` and `eigh` (default `.false.`) to choose whether to write intermediate files.