### PR TITLE
code clean up

### DIFF
--- a/src/IterativeSolvers/GMRES/gmres.f90
+++ b/src/IterativeSolvers/GMRES/gmres.f90
@@ -124,7 +124,7 @@ contains
 
         ! Miscellaneous.
         character(len=*), parameter :: this_procedure = 'gmres_rsp'
-        integer :: i, k, iter
+        integer :: k, iter
         class(abstract_vector_rsp), allocatable :: dx, wrk
         character(len=256) :: msg
 
@@ -299,7 +299,7 @@ contains
 
         ! Miscellaneous.
         character(len=*), parameter :: this_procedure = 'gmres_rdp'
-        integer :: i, k, iter
+        integer :: k, iter
         class(abstract_vector_rdp), allocatable :: dx, wrk
         character(len=256) :: msg
 
@@ -474,7 +474,7 @@ contains
 
         ! Miscellaneous.
         character(len=*), parameter :: this_procedure = 'gmres_csp'
-        integer :: i, k, iter
+        integer :: k, iter
         class(abstract_vector_csp), allocatable :: dx, wrk
         character(len=256) :: msg
 
@@ -649,7 +649,7 @@ contains
 
         ! Miscellaneous.
         character(len=*), parameter :: this_procedure = 'gmres_cdp'
-        integer :: i, k, iter
+        integer :: k, iter
         class(abstract_vector_cdp), allocatable :: dx, wrk
         character(len=256) :: msg
 

--- a/src/IterativeSolvers/GMRES/gmres.fypp
+++ b/src/IterativeSolvers/GMRES/gmres.fypp
@@ -2,7 +2,6 @@
 #:set RC_KINDS_TYPES = REAL_KINDS_TYPES + CMPLX_KINDS_TYPES
 submodule (lightkrylov_iterativesolvers) gmres_solver
     use stdlib_strings, only: padr
-    use stdlib_linalg, only: lstsq, norm
     implicit none
 contains
 
@@ -82,10 +81,6 @@ contains
         ! Givens rotations.
         ${type}$, allocatable :: c(:), s(:)
 
-        ! Preconditioner
-        logical :: has_precond
-        class(abstract_precond_${type[0]}$${kind}$), allocatable :: precond
-
         ! Miscellaneous.
         character(len=*), parameter :: this_procedure = 'gmres_${type[0]}$${kind}$'
         integer :: i, k, iter
@@ -108,21 +103,17 @@ contains
             opts = gmres_${kind}$_opts()
         endif
 
-        kdim = opts%kdim ; maxiter = opts%maxiter
-        tol = atol_ + rtol_ * b%norm()
+        kdim  = opts%kdim ; maxiter = opts%maxiter
+        tol   = atol_ + rtol_ * b%norm()
         trans = optval(transpose, .false.)
 
-        ! Deals with the preconditioner.
-        has_precond = optval(present(preconditioner), .false.)
-        if (has_precond) allocate(precond, source=preconditioner)
-
         ! Initialize working variables.
-        allocate(wrk, mold=b) ; call wrk%zero()
+        allocate(wrk, mold=b)       ; call wrk%zero()
         allocate(V(kdim+1), mold=b) ; call zero_basis(V)
-        allocate(H(kdim+1, kdim)) ; H = 0.0_${kind}$
-        allocate(e(kdim+1)) ; e = 0.0_${kind}$
-        allocate(c(kdim)) ; c = 0.0_${kind}$
-        allocate(s(kdim)) ; s = 0.0_${kind}$
+        allocate(H(kdim+1, kdim))   ; H = 0.0_${kind}$
+        allocate(e(kdim+1))         ; e = 0.0_${kind}$
+        allocate(c(kdim))           ; c = 0.0_${kind}$
+        allocate(s(kdim))           ; s = 0.0_${kind}$
 
         ! Initialize metadata and & reset matvec counter
         gmres_meta = gmres_${kind}$_metadata() ; gmres_meta%converged = .false.
@@ -130,6 +121,7 @@ contains
 
         info = 0 ; iter = 0
 
+        associate(ifprecond => present(preconditioner))
         do while ((.not. gmres_meta%converged) .and. (iter <= maxiter))
             !> Initialize data
             H = 0.0_${kind}$ ; call zero_basis(V)
@@ -142,7 +134,7 @@ contains
             e = 0.0_${kind}$ ; beta = V(1)%norm() ; e(1) = beta
             call V(1)%scal(one_${type[0]}$${kind}$/beta)
             c = 0.0_${kind}$ ; s = 0.0_${kind}$
-            allocate(gmres_meta%res(1)); gmres_meta%res(1) = abs(beta)
+            allocate(gmres_meta%res(1)) ; gmres_meta%res(1) = abs(beta)
             write(msg,'(2(A,E11.4))') 'GMRES(k)   init step     : |res|= ', &
                         & abs(beta), ', tol= ', tol
             call log_information(msg, this_module, this_procedure)
@@ -151,7 +143,8 @@ contains
                 !> Current number of iterations.
                 iter = iter + 1
                 !> Preconditioner.
-                wrk = V(k) ; if (has_precond) call precond%apply(wrk, k, beta, tol)
+                wrk = V(k) ; if (ifprecond) call preconditioner%apply(wrk, k, beta, tol)
+
                 !-----------------------------------------
                 !-----     Arnoldi factorization     -----
                 !-----------------------------------------
@@ -167,6 +160,7 @@ contains
                 !> Update Hessenberg matrix and normalize residual Krylov vector.
                 H(k+1, k) = V(k+1)%norm()
                 if (abs(H(k+1, k)) > tol) call V(k+1)%scal(one_${type[0]}$${kind}$ / H(k+1, k))
+
                 !-----------------------------------------
                 !-----     Least-Squares Problem     -----
                 !-----------------------------------------
@@ -180,7 +174,7 @@ contains
                 ! Save metadata.
                 gmres_meta%n_iter  = gmres_meta%n_iter + 1
                 gmres_meta%n_inner = gmres_meta%n_inner + 1
-                gmres_meta%res = [ gmres_meta%res, abs(beta) ]
+                gmres_meta%res     = [ gmres_meta%res, abs(beta) ]
 
                 ! Check convergence.
                 write(msg,'(A,I3,2(A,E11.4))') 'GMRES(k)   inner step ', k, ': |res|= ', &
@@ -194,7 +188,7 @@ contains
             ! Update solution.
             k = min(k, kdim) ; y = solve_triangular(H(:k, :k), e(:k))
             call linear_combination(dx, V(:k), y)
-            if (has_precond) call precond%apply(dx) ; call x%add(dx)
+            if (ifprecond) call preconditioner%apply(dx) ; call x%add(dx)
 
             ! Recompute residual for sanity check.
             if (trans) then
@@ -222,6 +216,7 @@ contains
                exit 
             end if
         enddo
+        end associate
 
         ! Returns the number of iterations.
         info = gmres_meta%n_iter
@@ -242,8 +237,6 @@ contains
 
         call A%reset_counter(trans, 'gmres%post')
         if (time_lightkrylov()) call timer%stop(this_procedure)
-        
-        return
     end procedure 
     #:endfor
 

--- a/src/IterativeSolvers/GMRES/gmres.fypp
+++ b/src/IterativeSolvers/GMRES/gmres.fypp
@@ -83,7 +83,7 @@ contains
 
         ! Miscellaneous.
         character(len=*), parameter :: this_procedure = 'gmres_${type[0]}$${kind}$'
-        integer :: i, k, iter
+        integer :: k, iter
         class(abstract_vector_${type[0]}$${kind}$), allocatable :: dx, wrk
         character(len=256) :: msg
 

--- a/src/IterativeSolvers/IterativeSolvers.f90
+++ b/src/IterativeSolvers/IterativeSolvers.f90
@@ -1035,88 +1035,88 @@ module lightkrylov_IterativeSolvers
         !!  such as `krylov_schur` for `eigs`. This is work in progress.
         !!  @endnote
         module subroutine svds_rsp(A, U, S, V, residuals, info, u0, kdim, tolerance, write_intermediate)
-        class(abstract_linop_rsp), intent(inout) :: A
-        !! Linear operator whose leading singular triplets need to be computed.
-        class(abstract_vector_rsp), intent(out) :: U(:)
-        !! Leading left singular vectors.
-        real(sp), allocatable, intent(out) :: S(:)
-        !! Leading singular values.
-        class(abstract_vector_rsp), intent(out) :: V(:)
-        !! Leading right singular vectors.
-        real(sp), allocatable, intent(out) :: residuals(:)
-        !! Residuals associated to each Ritz eigenpair.
-        integer, intent(out) :: info
-        !! Information flag.
-        class(abstract_vector_rsp), optional, intent(in) :: u0
-        integer, optional, intent(in) :: kdim
-        !! Desired number of eigenpairs.
-        real(sp), optional, intent(in) :: tolerance
-        !! Tolerance.
-        logical, optional, intent(in) :: write_intermediate
-        !! Write intermediate eigenvalues to file during iteration?
+            class(abstract_linop_rsp), intent(inout) :: A
+            !! Linear operator whose leading singular triplets need to be computed.
+            class(abstract_vector_rsp), intent(out) :: U(:)
+            !! Leading left singular vectors.
+            real(sp), allocatable, intent(out) :: S(:)
+            !! Leading singular values.
+            class(abstract_vector_rsp), intent(out) :: V(:)
+            !! Leading right singular vectors.
+            real(sp), allocatable, intent(out) :: residuals(:)
+            !! Residuals associated to each Ritz eigenpair.
+            integer, intent(out) :: info
+            !! Information flag.
+            class(abstract_vector_rsp), optional, intent(in) :: u0
+            integer, optional, intent(in) :: kdim
+            !! Desired number of eigenpairs.
+            real(sp), optional, intent(in) :: tolerance
+            !! Tolerance.
+            logical, optional, intent(in) :: write_intermediate
+            !! Write intermediate eigenvalues to file during iteration?
         end subroutine
         module subroutine svds_rdp(A, U, S, V, residuals, info, u0, kdim, tolerance, write_intermediate)
-        class(abstract_linop_rdp), intent(inout) :: A
-        !! Linear operator whose leading singular triplets need to be computed.
-        class(abstract_vector_rdp), intent(out) :: U(:)
-        !! Leading left singular vectors.
-        real(dp), allocatable, intent(out) :: S(:)
-        !! Leading singular values.
-        class(abstract_vector_rdp), intent(out) :: V(:)
-        !! Leading right singular vectors.
-        real(dp), allocatable, intent(out) :: residuals(:)
-        !! Residuals associated to each Ritz eigenpair.
-        integer, intent(out) :: info
-        !! Information flag.
-        class(abstract_vector_rdp), optional, intent(in) :: u0
-        integer, optional, intent(in) :: kdim
-        !! Desired number of eigenpairs.
-        real(dp), optional, intent(in) :: tolerance
-        !! Tolerance.
-        logical, optional, intent(in) :: write_intermediate
-        !! Write intermediate eigenvalues to file during iteration?
+            class(abstract_linop_rdp), intent(inout) :: A
+            !! Linear operator whose leading singular triplets need to be computed.
+            class(abstract_vector_rdp), intent(out) :: U(:)
+            !! Leading left singular vectors.
+            real(dp), allocatable, intent(out) :: S(:)
+            !! Leading singular values.
+            class(abstract_vector_rdp), intent(out) :: V(:)
+            !! Leading right singular vectors.
+            real(dp), allocatable, intent(out) :: residuals(:)
+            !! Residuals associated to each Ritz eigenpair.
+            integer, intent(out) :: info
+            !! Information flag.
+            class(abstract_vector_rdp), optional, intent(in) :: u0
+            integer, optional, intent(in) :: kdim
+            !! Desired number of eigenpairs.
+            real(dp), optional, intent(in) :: tolerance
+            !! Tolerance.
+            logical, optional, intent(in) :: write_intermediate
+            !! Write intermediate eigenvalues to file during iteration?
         end subroutine
         module subroutine svds_csp(A, U, S, V, residuals, info, u0, kdim, tolerance, write_intermediate)
-        class(abstract_linop_csp), intent(inout) :: A
-        !! Linear operator whose leading singular triplets need to be computed.
-        class(abstract_vector_csp), intent(out) :: U(:)
-        !! Leading left singular vectors.
-        real(sp), allocatable, intent(out) :: S(:)
-        !! Leading singular values.
-        class(abstract_vector_csp), intent(out) :: V(:)
-        !! Leading right singular vectors.
-        real(sp), allocatable, intent(out) :: residuals(:)
-        !! Residuals associated to each Ritz eigenpair.
-        integer, intent(out) :: info
-        !! Information flag.
-        class(abstract_vector_csp), optional, intent(in) :: u0
-        integer, optional, intent(in) :: kdim
-        !! Desired number of eigenpairs.
-        real(sp), optional, intent(in) :: tolerance
-        !! Tolerance.
-        logical, optional, intent(in) :: write_intermediate
-        !! Write intermediate eigenvalues to file during iteration?
+            class(abstract_linop_csp), intent(inout) :: A
+            !! Linear operator whose leading singular triplets need to be computed.
+            class(abstract_vector_csp), intent(out) :: U(:)
+            !! Leading left singular vectors.
+            real(sp), allocatable, intent(out) :: S(:)
+            !! Leading singular values.
+            class(abstract_vector_csp), intent(out) :: V(:)
+            !! Leading right singular vectors.
+            real(sp), allocatable, intent(out) :: residuals(:)
+            !! Residuals associated to each Ritz eigenpair.
+            integer, intent(out) :: info
+            !! Information flag.
+            class(abstract_vector_csp), optional, intent(in) :: u0
+            integer, optional, intent(in) :: kdim
+            !! Desired number of eigenpairs.
+            real(sp), optional, intent(in) :: tolerance
+            !! Tolerance.
+            logical, optional, intent(in) :: write_intermediate
+            !! Write intermediate eigenvalues to file during iteration?
         end subroutine
         module subroutine svds_cdp(A, U, S, V, residuals, info, u0, kdim, tolerance, write_intermediate)
-        class(abstract_linop_cdp), intent(inout) :: A
-        !! Linear operator whose leading singular triplets need to be computed.
-        class(abstract_vector_cdp), intent(out) :: U(:)
-        !! Leading left singular vectors.
-        real(dp), allocatable, intent(out) :: S(:)
-        !! Leading singular values.
-        class(abstract_vector_cdp), intent(out) :: V(:)
-        !! Leading right singular vectors.
-        real(dp), allocatable, intent(out) :: residuals(:)
-        !! Residuals associated to each Ritz eigenpair.
-        integer, intent(out) :: info
-        !! Information flag.
-        class(abstract_vector_cdp), optional, intent(in) :: u0
-        integer, optional, intent(in) :: kdim
-        !! Desired number of eigenpairs.
-        real(dp), optional, intent(in) :: tolerance
-        !! Tolerance.
-        logical, optional, intent(in) :: write_intermediate
-        !! Write intermediate eigenvalues to file during iteration?
+            class(abstract_linop_cdp), intent(inout) :: A
+            !! Linear operator whose leading singular triplets need to be computed.
+            class(abstract_vector_cdp), intent(out) :: U(:)
+            !! Leading left singular vectors.
+            real(dp), allocatable, intent(out) :: S(:)
+            !! Leading singular values.
+            class(abstract_vector_cdp), intent(out) :: V(:)
+            !! Leading right singular vectors.
+            real(dp), allocatable, intent(out) :: residuals(:)
+            !! Residuals associated to each Ritz eigenpair.
+            integer, intent(out) :: info
+            !! Information flag.
+            class(abstract_vector_cdp), optional, intent(in) :: u0
+            integer, optional, intent(in) :: kdim
+            !! Desired number of eigenpairs.
+            real(dp), optional, intent(in) :: tolerance
+            !! Tolerance.
+            logical, optional, intent(in) :: write_intermediate
+            !! Write intermediate eigenvalues to file during iteration?
         end subroutine
     end interface
 

--- a/src/IterativeSolvers/IterativeSolvers.f90
+++ b/src/IterativeSolvers/IterativeSolvers.f90
@@ -181,7 +181,7 @@ module lightkrylov_IterativeSolvers
             !! Relative solver tolerance
             real(sp), optional, intent(in) :: atol
             !! Absolute solver tolerance
-            class(abstract_precond_rsp), optional, intent(in) :: preconditioner
+            class(abstract_precond_rsp), optional, intent(inout) :: preconditioner
             !! Preconditioner.
             class(abstract_opts), optional, intent(in) :: options
             !! Options passed to the linear solver.
@@ -205,7 +205,7 @@ module lightkrylov_IterativeSolvers
             !! Relative solver tolerance
             real(dp), optional, intent(in) :: atol
             !! Absolute solver tolerance
-            class(abstract_precond_rdp), optional, intent(in) :: preconditioner
+            class(abstract_precond_rdp), optional, intent(inout) :: preconditioner
             !! Preconditioner.
             class(abstract_opts), optional, intent(in) :: options
             !! Options passed to the linear solver.
@@ -229,7 +229,7 @@ module lightkrylov_IterativeSolvers
             !! Relative solver tolerance
             real(sp), optional, intent(in) :: atol
             !! Absolute solver tolerance
-            class(abstract_precond_csp), optional, intent(in) :: preconditioner
+            class(abstract_precond_csp), optional, intent(inout) :: preconditioner
             !! Preconditioner.
             class(abstract_opts), optional, intent(in) :: options
             !! Options passed to the linear solver.
@@ -253,7 +253,7 @@ module lightkrylov_IterativeSolvers
             !! Relative solver tolerance
             real(dp), optional, intent(in) :: atol
             !! Absolute solver tolerance
-            class(abstract_precond_cdp), optional, intent(in) :: preconditioner
+            class(abstract_precond_cdp), optional, intent(inout) :: preconditioner
             !! Preconditioner.
             class(abstract_opts), optional, intent(in) :: options
             !! Options passed to the linear solver.
@@ -428,7 +428,7 @@ module lightkrylov_IterativeSolvers
             !! Relative solver tolerance
             real(sp), optional, intent(in) :: atol
             !! Absolute solver tolerance
-            class(abstract_precond_rsp), optional, intent(in) :: preconditioner
+            class(abstract_precond_rsp), optional, intent(inout) :: preconditioner
             !! Preconditioner (optional).
             class(abstract_opts), optional, intent(in) :: options
             !! GMRES options.   
@@ -450,7 +450,7 @@ module lightkrylov_IterativeSolvers
             !! Relative solver tolerance
             real(dp), optional, intent(in) :: atol
             !! Absolute solver tolerance
-            class(abstract_precond_rdp), optional, intent(in) :: preconditioner
+            class(abstract_precond_rdp), optional, intent(inout) :: preconditioner
             !! Preconditioner (optional).
             class(abstract_opts), optional, intent(in) :: options
             !! GMRES options.   
@@ -472,7 +472,7 @@ module lightkrylov_IterativeSolvers
             !! Relative solver tolerance
             real(sp), optional, intent(in) :: atol
             !! Absolute solver tolerance
-            class(abstract_precond_csp), optional, intent(in) :: preconditioner
+            class(abstract_precond_csp), optional, intent(inout) :: preconditioner
             !! Preconditioner (optional).
             class(abstract_opts), optional, intent(in) :: options
             !! GMRES options.   
@@ -494,7 +494,7 @@ module lightkrylov_IterativeSolvers
             !! Relative solver tolerance
             real(dp), optional, intent(in) :: atol
             !! Absolute solver tolerance
-            class(abstract_precond_cdp), optional, intent(in) :: preconditioner
+            class(abstract_precond_cdp), optional, intent(inout) :: preconditioner
             !! Preconditioner (optional).
             class(abstract_opts), optional, intent(in) :: options
             !! GMRES options.   
@@ -667,7 +667,7 @@ module lightkrylov_IterativeSolvers
             !! Relative solver tolerance
             real(sp), optional, intent(in) :: atol
             !! Absolute solver tolerance
-            class(abstract_precond_rsp), optional, intent(in) :: preconditioner
+            class(abstract_precond_rsp), optional, intent(inout) :: preconditioner
             !! Preconditioner (optional).
             class(abstract_opts), optional, intent(in) :: options
             !! GMRES options.   
@@ -689,7 +689,7 @@ module lightkrylov_IterativeSolvers
             !! Relative solver tolerance
             real(dp), optional, intent(in) :: atol
             !! Absolute solver tolerance
-            class(abstract_precond_rdp), optional, intent(in) :: preconditioner
+            class(abstract_precond_rdp), optional, intent(inout) :: preconditioner
             !! Preconditioner (optional).
             class(abstract_opts), optional, intent(in) :: options
             !! GMRES options.   
@@ -711,7 +711,7 @@ module lightkrylov_IterativeSolvers
             !! Relative solver tolerance
             real(sp), optional, intent(in) :: atol
             !! Absolute solver tolerance
-            class(abstract_precond_csp), optional, intent(in) :: preconditioner
+            class(abstract_precond_csp), optional, intent(inout) :: preconditioner
             !! Preconditioner (optional).
             class(abstract_opts), optional, intent(in) :: options
             !! GMRES options.   
@@ -733,7 +733,7 @@ module lightkrylov_IterativeSolvers
             !! Relative solver tolerance
             real(dp), optional, intent(in) :: atol
             !! Absolute solver tolerance
-            class(abstract_precond_cdp), optional, intent(in) :: preconditioner
+            class(abstract_precond_cdp), optional, intent(inout) :: preconditioner
             !! Preconditioner (optional).
             class(abstract_opts), optional, intent(in) :: options
             !! GMRES options.   
@@ -893,7 +893,7 @@ module lightkrylov_IterativeSolvers
             !! Relative solver tolerance
             real(sp), optional, intent(in) :: atol
             !! Absolute solver tolerance
-            class(abstract_precond_rsp), optional, intent(in) :: preconditioner
+            class(abstract_precond_rsp), optional, intent(inout) :: preconditioner
             !! Preconditioner (not yet supported).
             type(cg_sp_opts), optional, intent(in) :: options
             !! Options for the conjugate gradient solver.
@@ -913,7 +913,7 @@ module lightkrylov_IterativeSolvers
             !! Relative solver tolerance
             real(dp), optional, intent(in) :: atol
             !! Absolute solver tolerance
-            class(abstract_precond_rdp), optional, intent(in) :: preconditioner
+            class(abstract_precond_rdp), optional, intent(inout) :: preconditioner
             !! Preconditioner (not yet supported).
             type(cg_dp_opts), optional, intent(in) :: options
             !! Options for the conjugate gradient solver.
@@ -933,7 +933,7 @@ module lightkrylov_IterativeSolvers
             !! Relative solver tolerance
             real(sp), optional, intent(in) :: atol
             !! Absolute solver tolerance
-            class(abstract_precond_csp), optional, intent(in) :: preconditioner
+            class(abstract_precond_csp), optional, intent(inout) :: preconditioner
             !! Preconditioner (not yet supported).
             type(cg_sp_opts), optional, intent(in) :: options
             !! Options for the conjugate gradient solver.
@@ -953,7 +953,7 @@ module lightkrylov_IterativeSolvers
             !! Relative solver tolerance
             real(dp), optional, intent(in) :: atol
             !! Absolute solver tolerance
-            class(abstract_precond_cdp), optional, intent(in) :: preconditioner
+            class(abstract_precond_cdp), optional, intent(inout) :: preconditioner
             !! Preconditioner (not yet supported).
             type(cg_dp_opts), optional, intent(in) :: options
             !! Options for the conjugate gradient solver.

--- a/src/IterativeSolvers/IterativeSolvers.f90
+++ b/src/IterativeSolvers/IterativeSolvers.f90
@@ -1416,14 +1416,13 @@ contains
         !! Convergence tolerance
         ! internals
         integer :: i, k
-        character(len=*), parameter :: fmtc = '(I6,3(2X,E16.9),2X,L1)'
-        character(len=*), parameter :: fmtr = '(I6,2(2X,E16.9),2X,L1)'
+        character(len=*), parameter :: fmt = '(I6,2(2X,E16.9),2X,L1)'
         k = size(vals)
         if (io_rank()) then ! only master rank writes
             open (1234, file=filename, status='replace', action='write')
                 write (1234, '(A6,2(A18),A3)') 'Iter', 'value', 'residual', 'C'
             do i = 1, k
-                    write (1234, fmtr) k, vals(i),                res(i), res(i) < tol
+                    write (1234, fmt) k, vals(i),                res(i), res(i) < tol
             end do 
             close (1234)
         end if
@@ -1440,14 +1439,13 @@ contains
         !! Convergence tolerance
         ! internals
         integer :: i, k
-        character(len=*), parameter :: fmtc = '(I6,3(2X,E16.9),2X,L1)'
-        character(len=*), parameter :: fmtr = '(I6,2(2X,E16.9),2X,L1)'
+        character(len=*), parameter :: fmt = '(I6,2(2X,E16.9),2X,L1)'
         k = size(vals)
         if (io_rank()) then ! only master rank writes
             open (1234, file=filename, status='replace', action='write')
                 write (1234, '(A6,2(A18),A3)') 'Iter', 'value', 'residual', 'C'
             do i = 1, k
-                    write (1234, fmtr) k, vals(i),                res(i), res(i) < tol
+                    write (1234, fmt) k, vals(i),                res(i), res(i) < tol
             end do 
             close (1234)
         end if
@@ -1464,14 +1462,13 @@ contains
         !! Convergence tolerance
         ! internals
         integer :: i, k
-        character(len=*), parameter :: fmtc = '(I6,3(2X,E16.9),2X,L1)'
-        character(len=*), parameter :: fmtr = '(I6,2(2X,E16.9),2X,L1)'
+        character(len=*), parameter :: fmt = '(I6,3(2X,E16.9),2X,L1)'
         k = size(vals)
         if (io_rank()) then ! only master rank writes
             open (1234, file=filename, status='replace', action='write')
                 write (1234, '(A6,3(A18),A3)') 'Iter', 'Re', 'Im', 'residual', 'C'
             do i = 1, k
-                    write (1234, fmtc) k, vals(i)%re, vals(i)%im, res(i), res(i) < tol
+                    write (1234, fmt) k, vals(i)%re, vals(i)%im, res(i), res(i) < tol
             end do 
             close (1234)
         end if
@@ -1488,14 +1485,13 @@ contains
         !! Convergence tolerance
         ! internals
         integer :: i, k
-        character(len=*), parameter :: fmtc = '(I6,3(2X,E16.9),2X,L1)'
-        character(len=*), parameter :: fmtr = '(I6,2(2X,E16.9),2X,L1)'
+        character(len=*), parameter :: fmt = '(I6,3(2X,E16.9),2X,L1)'
         k = size(vals)
         if (io_rank()) then ! only master rank writes
             open (1234, file=filename, status='replace', action='write')
                 write (1234, '(A6,3(A18),A3)') 'Iter', 'Re', 'Im', 'residual', 'C'
             do i = 1, k
-                    write (1234, fmtc) k, vals(i)%re, vals(i)%im, res(i), res(i) < tol
+                    write (1234, fmt) k, vals(i)%re, vals(i)%im, res(i), res(i) < tol
             end do 
             close (1234)
         end if

--- a/src/IterativeSolvers/IterativeSolvers.fypp
+++ b/src/IterativeSolvers/IterativeSolvers.fypp
@@ -842,8 +842,11 @@ contains
         !! Convergence tolerance
         ! internals
         integer :: i, k
-        character(len=*), parameter :: fmtc = '(I6,3(2X,E16.9),2X,L1)'
-        character(len=*), parameter :: fmtr = '(I6,2(2X,E16.9),2X,L1)'
+        #:if type[0] == "c"
+        character(len=*), parameter :: fmt = '(I6,3(2X,E16.9),2X,L1)'
+        #:else
+        character(len=*), parameter :: fmt = '(I6,2(2X,E16.9),2X,L1)'
+        #:endif
         k = size(vals)
         if (io_rank()) then ! only master rank writes
             open (1234, file=filename, status='replace', action='write')
@@ -854,9 +857,9 @@ contains
             #:endif
             do i = 1, k
                 #:if type[0] == "c"
-                    write (1234, fmtc) k, vals(i)%re, vals(i)%im, res(i), res(i) < tol
+                    write (1234, fmt) k, vals(i)%re, vals(i)%im, res(i), res(i) < tol
                 #:else
-                    write (1234, fmtr) k, vals(i),                res(i), res(i) < tol
+                    write (1234, fmt) k, vals(i),                res(i), res(i) < tol
                 #:endif
             end do 
             close (1234)

--- a/src/IterativeSolvers/IterativeSolvers.fypp
+++ b/src/IterativeSolvers/IterativeSolvers.fypp
@@ -118,7 +118,7 @@ module lightkrylov_IterativeSolvers
             !! Relative solver tolerance
             real(${kind}$), optional, intent(in) :: atol
             !! Absolute solver tolerance
-            class(abstract_precond_${type[0]}$${kind}$), optional, intent(in) :: preconditioner
+            class(abstract_precond_${type[0]}$${kind}$), optional, intent(inout) :: preconditioner
             !! Preconditioner.
             class(abstract_opts), optional, intent(in) :: options
             !! Options passed to the linear solver.
@@ -253,7 +253,7 @@ module lightkrylov_IterativeSolvers
             !! Relative solver tolerance
             real(${kind}$), optional, intent(in) :: atol
             !! Absolute solver tolerance
-            class(abstract_precond_${type[0]}$${kind}$), optional, intent(in) :: preconditioner
+            class(abstract_precond_${type[0]}$${kind}$), optional, intent(inout) :: preconditioner
             !! Preconditioner (optional).
             class(abstract_opts), optional, intent(in) :: options
             !! GMRES options.   
@@ -386,7 +386,7 @@ module lightkrylov_IterativeSolvers
             !! Relative solver tolerance
             real(${kind}$), optional, intent(in) :: atol
             !! Absolute solver tolerance
-            class(abstract_precond_${type[0]}$${kind}$), optional, intent(in) :: preconditioner
+            class(abstract_precond_${type[0]}$${kind}$), optional, intent(inout) :: preconditioner
             !! Preconditioner (optional).
             class(abstract_opts), optional, intent(in) :: options
             !! GMRES options.   
@@ -518,7 +518,7 @@ module lightkrylov_IterativeSolvers
             !! Relative solver tolerance
             real(${kind}$), optional, intent(in) :: atol
             !! Absolute solver tolerance
-            class(abstract_precond_${type[0]}$${kind}$), optional, intent(in) :: preconditioner
+            class(abstract_precond_${type[0]}$${kind}$), optional, intent(inout) :: preconditioner
             !! Preconditioner (not yet supported).
             type(cg_${kind}$_opts), optional, intent(in) :: options
             !! Options for the conjugate gradient solver.

--- a/src/IterativeSolvers/IterativeSolvers.fypp
+++ b/src/IterativeSolvers/IterativeSolvers.fypp
@@ -602,25 +602,25 @@ module lightkrylov_IterativeSolvers
         !!  @endnote
         #:for kind, type in RC_KINDS_TYPES
         module subroutine svds_${type[0]}$${kind}$(A, U, S, V, residuals, info, u0, kdim, tolerance, write_intermediate)
-        class(abstract_linop_${type[0]}$${kind}$), intent(inout) :: A
-        !! Linear operator whose leading singular triplets need to be computed.
-        class(abstract_vector_${type[0]}$${kind}$), intent(out) :: U(:)
-        !! Leading left singular vectors.
-        real(${kind}$), allocatable, intent(out) :: S(:)
-        !! Leading singular values.
-        class(abstract_vector_${type[0]}$${kind}$), intent(out) :: V(:)
-        !! Leading right singular vectors.
-        real(${kind}$), allocatable, intent(out) :: residuals(:)
-        !! Residuals associated to each Ritz eigenpair.
-        integer, intent(out) :: info
-        !! Information flag.
-        class(abstract_vector_${type[0]}$${kind}$), optional, intent(in) :: u0
-        integer, optional, intent(in) :: kdim
-        !! Desired number of eigenpairs.
-        real(${kind}$), optional, intent(in) :: tolerance
-        !! Tolerance.
-        logical, optional, intent(in) :: write_intermediate
-        !! Write intermediate eigenvalues to file during iteration?
+            class(abstract_linop_${type[0]}$${kind}$), intent(inout) :: A
+            !! Linear operator whose leading singular triplets need to be computed.
+            class(abstract_vector_${type[0]}$${kind}$), intent(out) :: U(:)
+            !! Leading left singular vectors.
+            real(${kind}$), allocatable, intent(out) :: S(:)
+            !! Leading singular values.
+            class(abstract_vector_${type[0]}$${kind}$), intent(out) :: V(:)
+            !! Leading right singular vectors.
+            real(${kind}$), allocatable, intent(out) :: residuals(:)
+            !! Residuals associated to each Ritz eigenpair.
+            integer, intent(out) :: info
+            !! Information flag.
+            class(abstract_vector_${type[0]}$${kind}$), optional, intent(in) :: u0
+            integer, optional, intent(in) :: kdim
+            !! Desired number of eigenpairs.
+            real(${kind}$), optional, intent(in) :: tolerance
+            !! Tolerance.
+            logical, optional, intent(in) :: write_intermediate
+            !! Write intermediate eigenvalues to file during iteration?
         end subroutine
         #:endfor
     end interface

--- a/src/Newton/NewtonKrylov.f90
+++ b/src/Newton/NewtonKrylov.f90
@@ -365,7 +365,7 @@ contains
         !! Options for the Newton-Krylov iteration
         class(abstract_opts),                     optional, intent(in)    :: linear_solver_options
         !! Options for the linear solver
-        class(abstract_precond_rsp),              optional, intent(in)    :: preconditioner
+        class(abstract_precond_rsp),              optional, intent(inout)    :: preconditioner
         !! Preconditioner for the linear solver
         procedure(abstract_scheduler_sp),         optional                :: scheduler
         class(abstract_metadata),                       optional,   intent(out) :: meta
@@ -535,7 +535,7 @@ contains
         !! Options for the Newton-Krylov iteration
         class(abstract_opts),                     optional, intent(in)    :: linear_solver_options
         !! Options for the linear solver
-        class(abstract_precond_rdp),              optional, intent(in)    :: preconditioner
+        class(abstract_precond_rdp),              optional, intent(inout)    :: preconditioner
         !! Preconditioner for the linear solver
         procedure(abstract_scheduler_dp),         optional                :: scheduler
         class(abstract_metadata),                       optional,   intent(out) :: meta
@@ -705,7 +705,7 @@ contains
         !! Options for the Newton-Krylov iteration
         class(abstract_opts),                     optional, intent(in)    :: linear_solver_options
         !! Options for the linear solver
-        class(abstract_precond_csp),              optional, intent(in)    :: preconditioner
+        class(abstract_precond_csp),              optional, intent(inout)    :: preconditioner
         !! Preconditioner for the linear solver
         procedure(abstract_scheduler_sp),         optional                :: scheduler
         class(abstract_metadata),                       optional,   intent(out) :: meta
@@ -875,7 +875,7 @@ contains
         !! Options for the Newton-Krylov iteration
         class(abstract_opts),                     optional, intent(in)    :: linear_solver_options
         !! Options for the linear solver
-        class(abstract_precond_cdp),              optional, intent(in)    :: preconditioner
+        class(abstract_precond_cdp),              optional, intent(inout)    :: preconditioner
         !! Preconditioner for the linear solver
         procedure(abstract_scheduler_dp),         optional                :: scheduler
         class(abstract_metadata),                       optional,   intent(out) :: meta

--- a/src/Newton/NewtonKrylov.fypp
+++ b/src/Newton/NewtonKrylov.fypp
@@ -249,7 +249,7 @@ contains
         !! Options for the Newton-Krylov iteration
         class(abstract_opts),                     optional, intent(in)    :: linear_solver_options
         !! Options for the linear solver
-        class(abstract_precond_${type[0]}$${kind}$),              optional, intent(in)    :: preconditioner
+        class(abstract_precond_${type[0]}$${kind}$),              optional, intent(inout)    :: preconditioner
         !! Preconditioner for the linear solver
         procedure(abstract_scheduler_${kind}$),         optional                :: scheduler
         class(abstract_metadata),                       optional,   intent(out) :: meta

--- a/src/Utilities/Logger.f90
+++ b/src/Utilities/Logger.f90
@@ -201,10 +201,10 @@ contains
    subroutine comm_setup()
       ! internal
       character(len=*), parameter :: this_procedure = 'comm_setup'
-      integer :: ierr, nid, comm_size
-      logical :: mpi_is_initialized
       character(len=128) :: msg
 #ifdef MPI
+      integer :: ierr, nid, comm_size
+      logical :: mpi_is_initialized
       ! check if MPI has already been initialized and if not, initialize
       call MPI_Initialized(mpi_is_initialized, ierr)
       if (.not. mpi_is_initialized) then

--- a/src/Utilities/Logger.f90
+++ b/src/Utilities/Logger.f90
@@ -83,7 +83,7 @@ contains
       call logger%configure(level=log_level_, time_stamp=log_timestamp_) 
 
       ! set up LightKrylov log file
-      call logger%add_log_file(logfile_, unit=iunit, stat=stat)
+      call logger%add_log_file(logfile_, unit=iunit_, stat=stat)
       if (stat /= 0) call stop_error('Unable to open logfile '//trim(logfile_)//'.', module=this_module, procedure='logger_setup')
 
       ! Set up comms

--- a/src/Utilities/TestUtils.f90
+++ b/src/Utilities/TestUtils.f90
@@ -2,7 +2,7 @@ module LightKrylov_TestUtils
     ! Fortran Standard Library
     use stdlib_stats_distribution_normal, only: normal => rvs_normal
     use stdlib_optval, only: optval
-    use stdlib_linalg, only: eye
+    use stdlib_linalg, only: eye, hermitian
     ! LightKrylov
     use LightKrylov
     use LightKrylov_Logger
@@ -156,7 +156,7 @@ module LightKrylov_TestUtils
     end interface
 
     type, extends(abstract_linop_csp), public :: linop_csp
-        complex(sp), dimension(test_size, test_size) :: data = cmplx(0.0_sp, 0.0_sp, kind=sp)
+        complex(sp), dimension(test_size, test_size) :: data = zero_csp
     contains
         private
         procedure, pass(self), public :: matvec  => matvec_csp
@@ -170,7 +170,7 @@ module LightKrylov_TestUtils
     end interface
 
     type, extends(abstract_hermitian_linop_csp), public :: hermitian_linop_csp
-        complex(sp), dimension(test_size, test_size) :: data = cmplx(0.0_sp, 0.0_sp, kind=sp)
+        complex(sp), dimension(test_size, test_size) :: data = zero_csp
     contains
         private
         procedure, pass(self), public :: matvec => hermitian_matvec_csp
@@ -184,7 +184,7 @@ module LightKrylov_TestUtils
     end interface
 
     type, extends(abstract_linop_cdp), public :: linop_cdp
-        complex(dp), dimension(test_size, test_size) :: data = cmplx(0.0_dp, 0.0_dp, kind=dp)
+        complex(dp), dimension(test_size, test_size) :: data = zero_cdp
     contains
         private
         procedure, pass(self), public :: matvec  => matvec_cdp
@@ -198,7 +198,7 @@ module LightKrylov_TestUtils
     end interface
 
     type, extends(abstract_hermitian_linop_cdp), public :: hermitian_linop_cdp
-        complex(dp), dimension(test_size, test_size) :: data = cmplx(0.0_dp, 0.0_dp, kind=dp)
+        complex(dp), dimension(test_size, test_size) :: data = zero_cdp
     contains
         private
         procedure, pass(self), public :: matvec => hermitian_matvec_cdp
@@ -214,9 +214,9 @@ module LightKrylov_TestUtils
 
     ! ROESSLER SYSTEM
 
-    real(sp), parameter :: a_sp = 0.2
-    real(sp), parameter :: b_sp = 0.2
-    real(sp), parameter :: c_sp = 5.7
+    real(sp), parameter :: a_sp = 0.2_sp
+    real(sp), parameter :: b_sp = 0.2_sp
+    real(sp), parameter :: c_sp = 5.7_sp
 
     type, extends(abstract_vector_rsp), public :: state_vector_rsp
        real(sp) :: x = 0.0_sp
@@ -244,9 +244,9 @@ module LightKrylov_TestUtils
        procedure, pass(self), public :: matvec => lin_roessler_rsp
        procedure, pass(self), public :: rmatvec => adj_lin_roessler_rsp
     end type jacobian_rsp
-    real(dp), parameter :: a_dp = 0.2
-    real(dp), parameter :: b_dp = 0.2
-    real(dp), parameter :: c_dp = 5.7
+    real(dp), parameter :: a_dp = 0.2_dp
+    real(dp), parameter :: b_dp = 0.2_dp
+    real(dp), parameter :: c_dp = 5.7_dp
 
     type, extends(abstract_vector_rdp), public :: state_vector_rdp
        real(dp) :: x = 0.0_dp
@@ -648,9 +648,7 @@ contains
         type is(vector_rsp)
             select type(vec_out)
             type is(vector_rsp)
-
-                vec_out%data = matmul(transpose(self%data), vec_in%data)
-
+                vec_out%data = matmul(hermitian(self%data), vec_in%data)
             class default
                 call stop_error("The intent [OUT] argument 'vec_out' must be of type 'vector_rsp'", &
                               & this_module, 'rmatvec_rsp')
@@ -714,9 +712,7 @@ contains
         type is(vector_rdp)
             select type(vec_out)
             type is(vector_rdp)
-
-                vec_out%data = matmul(transpose(self%data), vec_in%data)
-
+                vec_out%data = matmul(hermitian(self%data), vec_in%data)
             class default
                 call stop_error("The intent [OUT] argument 'vec_out' must be of type 'vector_rdp'", &
                               & this_module, 'rmatvec_rdp')
@@ -780,9 +776,7 @@ contains
         type is(vector_csp)
             select type(vec_out)
             type is(vector_csp)
-
-                vec_out%data = matmul(transpose(conjg(self%data)), vec_in%data)
-
+                vec_out%data = matmul(hermitian(self%data), vec_in%data)
             class default
                 call stop_error("The intent [OUT] argument 'vec_out' must be of type 'vector_csp'", &
                               & this_module, 'rmatvec_csp')
@@ -846,9 +840,7 @@ contains
         type is(vector_cdp)
             select type(vec_out)
             type is(vector_cdp)
-
-                vec_out%data = matmul(transpose(conjg(self%data)), vec_in%data)
-
+                vec_out%data = matmul(hermitian(self%data), vec_in%data)
             class default
                 call stop_error("The intent [OUT] argument 'vec_out' must be of type 'vector_cdp'", &
                               & this_module, 'rmatvec_cdp')
@@ -1106,7 +1098,7 @@ contains
         allocate(var(test_size, test_size)) ; var = one_rsp
 
         data = normal(mu, var)
-        linop%data = matmul(data, transpose(data))/test_size + 0.01*eye(test_size)
+        linop%data = matmul(data, transpose(data))/test_size + 0.01_sp*eye(test_size, mold=1.0_sp)
 
     end subroutine init_rand_spd_linop_rsp
 
@@ -1140,7 +1132,7 @@ contains
         allocate(var(test_size, test_size)) ; var = one_rdp
 
         data = normal(mu, var)
-        linop%data = matmul(data, transpose(data))/test_size + 0.01*eye(test_size)
+        linop%data = matmul(data, transpose(data))/test_size + 0.01_dp*eye(test_size, mold=1.0_dp)
 
     end subroutine init_rand_spd_linop_rdp
 
@@ -1175,7 +1167,7 @@ contains
         allocate(var(test_size, test_size)) ; var = cmplx(1.0_sp, 1.0_sp, kind=sp)
 
         data = normal(mu, var)
-        data = matmul(data, transpose(conjg(data)))/test_size + 0.01*eye(test_size)
+        data = matmul(data, hermitian(data))/test_size + 0.01_sp*eye(test_size, mold=1.0_sp)
         linop%data = data
 
     end subroutine init_rand_hermitian_linop_csp
@@ -1211,7 +1203,7 @@ contains
         allocate(var(test_size, test_size)) ; var = cmplx(1.0_dp, 1.0_dp, kind=dp)
 
         data = normal(mu, var)
-        data = matmul(data, transpose(conjg(data)))/test_size + 0.01*eye(test_size)
+        data = matmul(data, hermitian(data))/test_size + 0.01_dp*eye(test_size, mold=1.0_dp)
         linop%data = data
 
     end subroutine init_rand_hermitian_linop_cdp

--- a/src/Utilities/TestUtils.fypp
+++ b/src/Utilities/TestUtils.fypp
@@ -4,7 +4,7 @@ module LightKrylov_TestUtils
     ! Fortran Standard Library
     use stdlib_stats_distribution_normal, only: normal => rvs_normal
     use stdlib_optval, only: optval
-    use stdlib_linalg, only: eye
+    use stdlib_linalg, only: eye, hermitian
     ! LightKrylov
     use LightKrylov
     use LightKrylov_Logger
@@ -85,7 +85,7 @@ module LightKrylov_TestUtils
 
     #:else
     type, extends(abstract_linop_${type[0]}$${kind}$), public :: linop_${type[0]}$${kind}$
-        ${type}$, dimension(test_size, test_size) :: data = cmplx(0.0_${kind}$, 0.0_${kind}$, kind=${kind}$)
+        ${type}$, dimension(test_size, test_size) :: data = zero_${type[0]}$${kind}$
     contains
         private
         procedure, pass(self), public :: matvec  => matvec_${type[0]}$${kind}$
@@ -99,7 +99,7 @@ module LightKrylov_TestUtils
     end interface
 
     type, extends(abstract_hermitian_linop_${type[0]}$${kind}$), public :: hermitian_linop_${type[0]}$${kind}$
-        ${type}$, dimension(test_size, test_size) :: data = cmplx(0.0_${kind}$, 0.0_${kind}$, kind=${kind}$)
+        ${type}$, dimension(test_size, test_size) :: data = zero_${type[0]}$${kind}$
     contains
         private
         procedure, pass(self), public :: matvec => hermitian_matvec_${type[0]}$${kind}$
@@ -118,9 +118,9 @@ module LightKrylov_TestUtils
     ! ROESSLER SYSTEM
 
     #:for kind in REAL_KINDS
-    real(${kind}$), parameter :: a_${kind}$ = 0.2
-    real(${kind}$), parameter :: b_${kind}$ = 0.2
-    real(${kind}$), parameter :: c_${kind}$ = 5.7
+    real(${kind}$), parameter :: a_${kind}$ = 0.2_${kind}$
+    real(${kind}$), parameter :: b_${kind}$ = 0.2_${kind}$
+    real(${kind}$), parameter :: c_${kind}$ = 5.7_${kind}$
 
     type, extends(abstract_vector_r${kind}$), public :: state_vector_r${kind}$
        real(${kind}$) :: x = 0.0_${kind}$
@@ -315,13 +315,7 @@ contains
         type is(vector_${type[0]}$${kind}$)
             select type(vec_out)
             type is(vector_${type[0]}$${kind}$)
-
-            #:if type[0] == "c"
-                vec_out%data = matmul(transpose(conjg(self%data)), vec_in%data)
-            #:else
-                vec_out%data = matmul(transpose(self%data), vec_in%data)
-            #:endif
-
+                vec_out%data = matmul(hermitian(self%data), vec_in%data)
             class default
                 call stop_error("The intent [OUT] argument 'vec_out' must be of type 'vector_${type[0]}$${kind}$'", &
                               & this_module, 'rmatvec_${type[0]}$${kind}$')
@@ -479,7 +473,7 @@ contains
         allocate(var(test_size, test_size)) ; var = one_${type[0]}$${kind}$
 
         data = normal(mu, var)
-        linop%data = matmul(data, transpose(data))/test_size + 0.01*eye(test_size)
+        linop%data = matmul(data, transpose(data))/test_size + 0.01_${kind}$*eye(test_size, mold=1.0_${kind}$)
 
     end subroutine init_rand_spd_linop_${type[0]}$${kind}$
     #:else
@@ -492,7 +486,7 @@ contains
         allocate(var(test_size, test_size)) ; var = cmplx(1.0_${kind}$, 1.0_${kind}$, kind=${kind}$)
 
         data = normal(mu, var)
-        data = matmul(data, transpose(conjg(data)))/test_size + 0.01*eye(test_size)
+        data = matmul(data, hermitian(data))/test_size + 0.01_${kind}$*eye(test_size, mold=1.0_${kind}$)
         linop%data = data
 
     end subroutine init_rand_hermitian_linop_${type[0]}$${kind}$

--- a/src/Utilities/Timer_Utils.f90
+++ b/src/Utilities/Timer_Utils.f90
@@ -464,11 +464,11 @@ contains
       character(len=128) :: msg, gname
       ! Sanity checks
       if (istart < 1 .or. iend < 1) then
-         call stop_error('Inconsistent input for istart, iend.', this_module, this_module)
+         call stop_error('Inconsistent input for istart, iend.', this_module, this_procedure)
       else if (istart > iend) then
-         call stop_error('istart > iend.', this_module, this_module)
+         call stop_error('istart > iend.', this_module, this_procedure)
       else if (iend > self%timer_count) then
-         call stop_error('iend > timer_count.', this_module, this_module)
+         call stop_error('iend > timer_count.', this_module, this_procedure)
       end if
       gname = to_lower(name)
       if (self%group_count == 0) then

--- a/src/Utilities/submodule_utility_functions.f90
+++ b/src/Utilities/submodule_utility_functions.f90
@@ -679,7 +679,7 @@ contains
     !----- Solving triangular systems -----
 
     module procedure solve_triangular_rsp
-        integer(ilp) :: i, j, n
+        integer(ilp) :: i, n
         !> Problem's dimensions.
         n = size(A, 1) ; allocate(x, mold=b) ; x = 0.0_sp
         !> Back-substitution algorithm.
@@ -689,7 +689,7 @@ contains
         enddo
     end procedure
     module procedure solve_triangular_rdp
-        integer(ilp) :: i, j, n
+        integer(ilp) :: i, n
         !> Problem's dimensions.
         n = size(A, 1) ; allocate(x, mold=b) ; x = 0.0_dp
         !> Back-substitution algorithm.
@@ -699,7 +699,7 @@ contains
         enddo
     end procedure
     module procedure solve_triangular_csp
-        integer(ilp) :: i, j, n
+        integer(ilp) :: i, n
         !> Problem's dimensions.
         n = size(A, 1) ; allocate(x, mold=b) ; x = 0.0_sp
         !> Back-substitution algorithm.
@@ -709,7 +709,7 @@ contains
         enddo
     end procedure
     module procedure solve_triangular_cdp
-        integer(ilp) :: i, j, n
+        integer(ilp) :: i, n
         !> Problem's dimensions.
         n = size(A, 1) ; allocate(x, mold=b) ; x = 0.0_dp
         !> Back-substitution algorithm.

--- a/src/Utilities/submodule_utility_functions.fypp
+++ b/src/Utilities/submodule_utility_functions.fypp
@@ -238,7 +238,7 @@ contains
 
     #:for kind, type in RC_KINDS_TYPES
     module procedure solve_triangular_${type[0]}$${kind}$
-        integer(ilp) :: i, j, n
+        integer(ilp) :: i, n
         !> Problem's dimensions.
         n = size(A, 1) ; allocate(x, mold=b) ; x = 0.0_${kind}$
         !> Back-substitution algorithm.

--- a/test/TestIterativeSolvers.f90
+++ b/test/TestIterativeSolvers.f90
@@ -279,7 +279,7 @@ contains
         G = Gram(X)
 
         ! Check orthonormality of the eigenvectors.
-        err = maxval(abs(G - eye(test_size)))
+        err = maxval(abs(G - eye(test_size, mold=1.0_sp)))
         call get_err_str(msg, "max err: ", err)
         call check(error, err < rtol_sp)
         call check_test(error, 'test_sym_evp_rsp', info='Eigenvector orthonormality', eq='V.H @ V = I', context=msg)
@@ -521,7 +521,7 @@ contains
         G = Gram(X)
 
         ! Check orthonormality of the eigenvectors.
-        err = maxval(abs(G - eye(test_size)))
+        err = maxval(abs(G - eye(test_size, mold=1.0_dp)))
         call get_err_str(msg, "max err: ", err)
         call check(error, err < rtol_dp)
         call check_test(error, 'test_sym_evp_rdp', info='Eigenvector orthonormality', eq='V.H @ V = I', context=msg)
@@ -733,7 +733,7 @@ contains
         G = Gram(U(1:test_size))
 
         ! Check orthonormality of the left singular vectors
-        err = maxval(abs(G - eye(test_size)))
+        err = maxval(abs(G - eye(test_size, mold=1.0_sp)))
         call get_err_str(msg, "max err: ", err)
         call check(error, err < rtol_sp)
         call check_test(error, 'test_svd_rsp', info='svec orthonormality (left)', eq='U.H @ U = I', context=msg)
@@ -742,7 +742,7 @@ contains
         G = Gram(V(1:test_size))
 
         ! Check orthonormality of the right singular vectors
-        err = maxval(abs(G - eye(test_size)))
+        err = maxval(abs(G - eye(test_size, mold=1.0_sp)))
         call get_err_str(msg, "max err: ", err)
         call check(error, err < rtol_sp)
         call check_test(error, 'test_svd_rsp', info='svec orthonormality (right)', eq='V.H @ V /= I', context=msg)
@@ -826,7 +826,7 @@ contains
         G = Gram(U(1:test_size))
 
         ! Check orthonormality of the left singular vectors
-        err = maxval(abs(G - eye(test_size)))
+        err = maxval(abs(G - eye(test_size, mold=1.0_dp)))
         call get_err_str(msg, "max err: ", err)
         call check(error, err < rtol_dp)
         call check_test(error, 'test_svd_rdp', info='svec orthonormality (left)', eq='U.H @ U = I', context=msg)
@@ -835,7 +835,7 @@ contains
         G = Gram(V(1:test_size))
 
         ! Check orthonormality of the right singular vectors
-        err = maxval(abs(G - eye(test_size)))
+        err = maxval(abs(G - eye(test_size, mold=1.0_dp)))
         call get_err_str(msg, "max err: ", err)
         call check(error, err < rtol_dp)
         call check_test(error, 'test_svd_rdp', info='svec orthonormality (right)', eq='V.H @ V /= I', context=msg)

--- a/test/TestIterativeSolvers.fypp
+++ b/test/TestIterativeSolvers.fypp
@@ -279,7 +279,7 @@ contains
         G = Gram(X)
 
         ! Check orthonormality of the eigenvectors.
-        err = maxval(abs(G - eye(test_size)))
+        err = maxval(abs(G - eye(test_size, mold=1.0_${kind}$)))
         call get_err_str(msg, "max err: ", err)
         call check(error, err < rtol_${kind}$)
         call check_test(error, 'test_sym_evp_${type[0]}$${kind}$', info='Eigenvector orthonormality', eq='V.H @ V = I', context=msg)
@@ -371,7 +371,7 @@ contains
         G = Gram(U(1:test_size))
 
         ! Check orthonormality of the left singular vectors
-        err = maxval(abs(G - eye(test_size)))
+        err = maxval(abs(G - eye(test_size, mold=1.0_${kind}$)))
         call get_err_str(msg, "max err: ", err)
         call check(error, err < rtol_${kind}$)
         call check_test(error, 'test_svd_${type[0]}$${kind}$', info='svec orthonormality (left)', eq='U.H @ U = I', context=msg)
@@ -380,7 +380,7 @@ contains
         G = Gram(V(1:test_size))
 
         ! Check orthonormality of the right singular vectors
-        err = maxval(abs(G - eye(test_size)))
+        err = maxval(abs(G - eye(test_size, mold=1.0_${kind}$)))
         call get_err_str(msg, "max err: ", err)
         call check(error, err < rtol_${kind}$)
         call check_test(error, 'test_svd_${type[0]}$${kind}$', info='svec orthonormality (right)', eq='V.H @ V /= I', context=msg)


### PR DESCRIPTION
- Consistent indentation for svds interface.
- Changed preconditioner to intent(inout) + remove unecessary allocations in gmres.
- Make sure there are no type conversion.
- Use latest stdlib utilities to simplify a bit the fypp logic.
- Changed possible error in the argument sequence (duplicated this_module).
- Tracked unused variables.
- Tracked unused variables.
- Fix iunit_ uninitialized.
