### PR TITLE
Added testdrive as regular deps (Logger.f90 imports some types from it.)

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -23,7 +23,6 @@ source-form = "free"
 
 [dependencies]
 stdlib = "*"
-test-drive.git = "https://github.com/nekStab/test-drive.git"
 FACE = {git="https://github.com/szaghi/FACE.git"}
 
 [dev-dependencies]

--- a/src/Utilities/Logger.f90
+++ b/src/Utilities/Logger.f90
@@ -7,8 +7,6 @@ module LightKrylov_Logger
    use stdlib_logger, only: logger => global_logger
    use stdlib_ascii, only: to_lower
    use stdlib_strings, only: chomp, replace_all
-   ! Testdrive
-   use testdrive, only: error_type, test_failed
    ! LightKrylov
    use LightKrylov_Constants
 
@@ -24,7 +22,6 @@ module LightKrylov_Logger
    public :: stop_error
    public :: type_error
    public :: check_info
-   public :: check_test
    public :: logger
    public :: log_message, log_information, log_warning, log_error, log_debug
 
@@ -689,59 +686,5 @@ contains
       end if
 
    end subroutine error_handler
-
-   subroutine check_test(error, test_name, info, eq, context)
-      use face
-      type(error_type), allocatable, intent(inout) :: error
-      character(len=*), intent(in)    :: test_name
-      character(len=*), optional, intent(in)    :: info
-      character(len=*), optional, intent(in)    :: eq
-      character(len=*), optional, intent(in)    :: context
-      character(len=128)                           :: name
-
-      ! internals
-      character(len=128)                           :: msg, info_, eq_
-      ! character(len=*), parameter :: indent = repeat(" ", 7)
-      character(len=4), dimension(4) :: substrings
-      integer :: i
-
-      info_ = optval(info, '')
-      eq_ = optval(eq, '')
-
-      name = trim(to_lower(test_name))
-      substrings = ["_rsp", "_rdp", "_csp", "_cdp"]
-      do i = 1, size(substrings)
-         name = replace_all(name, substrings(i), "")
-      end do
-      name = replace_all(name, "test_", "")
-
-      write (*, '(A33)', ADVANCE='NO') name
-      write (*, '(A3)', ADVANCE='NO') ' % '
-
-      if (len(trim(info_)) == 0) then
-         msg = eq_
-      else
-         if (len(info_) > 30) then
-            msg = info_(:30)//eq_
-         else
-            msg = info_//repeat(' ', 30 - len(trim(info_)))//eq_
-         end if
-      end if
-      write (*, '(A62)', ADVANCE='NO') msg
-
-      if (allocated(error)) then
-         print *, colorize('FAILED', color_fg='red')
-         if (present(context)) then
-            write (*, '(A)', ADVANCE='NO') trim(context)
-         end if
-         write (*, *)
-         write (*, *) 'The most recent test failed. Aborting calculation as per user directive.'
-         write (*, *)
-         STOP 1
-      else
-         print *, colorize('PASSED', color_fg='green')
-      end if
-
-   end subroutine check_test
 
 end module LightKrylov_Logger

--- a/test/TestExpmlib.f90
+++ b/test/TestExpmlib.f90
@@ -13,6 +13,7 @@ module TestExpmlib
     use LightKrylov_Utils, only : eig, sqrtm
     ! Test Utilities
     use LightKrylov_TestUtils
+    use TestUtils
 
     implicit none
 

--- a/test/TestExpmlib.fypp
+++ b/test/TestExpmlib.fypp
@@ -15,6 +15,7 @@ module TestExpmlib
     use LightKrylov_Utils, only : eig, sqrtm
     ! Test Utilities
     use LightKrylov_TestUtils
+    use TestUtils
 
     implicit none
 

--- a/test/TestIterativeSolvers.f90
+++ b/test/TestIterativeSolvers.f90
@@ -14,6 +14,7 @@ module TestIterativeSolvers
     use LightKrylov_AbstractVectors
     ! Test Utilities
     use LightKrylov_TestUtils
+    use TestUtils
 
     implicit none
     

--- a/test/TestIterativeSolvers.fypp
+++ b/test/TestIterativeSolvers.fypp
@@ -16,6 +16,7 @@ module TestIterativeSolvers
     use LightKrylov_AbstractVectors
     ! Test Utilities
     use LightKrylov_TestUtils
+    use TestUtils
 
     implicit none
     

--- a/test/TestKrylov.f90
+++ b/test/TestKrylov.f90
@@ -13,6 +13,7 @@ module TestKrylov
     use LightKrylov_AbstractVectors
     ! Test Utilities
     use LightKrylov_TestUtils
+    use TestUtils
 
     implicit none
     

--- a/test/TestKrylov.fypp
+++ b/test/TestKrylov.fypp
@@ -15,6 +15,7 @@ module TestKrylov
     use LightKrylov_AbstractVectors
     ! Test Utilities
     use LightKrylov_TestUtils
+    use TestUtils
 
     implicit none
     

--- a/test/TestLinops.f90
+++ b/test/TestLinops.f90
@@ -10,6 +10,7 @@ module TestLinops
     use LightKrylov_Logger
     ! Test Utilities
     use LightKrylov_TestUtils
+    use TestUtils
 
     implicit none
     

--- a/test/TestLinops.fypp
+++ b/test/TestLinops.fypp
@@ -12,6 +12,7 @@ module TestLinops
     use LightKrylov_Logger
     ! Test Utilities
     use LightKrylov_TestUtils
+    use TestUtils
 
     implicit none
     

--- a/test/TestNewtonKrylov.f90
+++ b/test/TestNewtonKrylov.f90
@@ -12,6 +12,7 @@ module TestNewtonKrylov
     use LightKrylov_Utils
     ! Test Utilities
     use LightKrylov_TestUtils
+    use TestUtils
 
     implicit none
     

--- a/test/TestNewtonKrylov.fypp
+++ b/test/TestNewtonKrylov.fypp
@@ -14,6 +14,7 @@ module TestNewtonKrylov
     use LightKrylov_Utils
     ! Test Utilities
     use LightKrylov_TestUtils
+    use TestUtils
 
     implicit none
     

--- a/test/TestSpecialMatrices.f90
+++ b/test/TestSpecialMatrices.f90
@@ -1,159 +1,160 @@
 module TestSpecialMatrices
-    ! Fortran Standard Library.
-    use iso_fortran_env
-    use stdlib_math, only: is_close, all_close
-    use stdlib_io_npy, only: save_npy
-    ! Testdrive
-    use testdrive, only: new_unittest, unittest_type, error_type, check
-    ! LightKrylov
-    use LightKrylov
-    use LightKrylov_Logger
-    use LightKrylov_TestUtils
-    ! SpecialMatrices
-    use SpecialMatrices
+   ! Fortran Standard Library.
+   use iso_fortran_env
+   use stdlib_math, only: is_close, all_close
+   use stdlib_io_npy, only: save_npy
+   ! Testdrive
+   use testdrive, only: new_unittest, unittest_type, error_type, check
+   ! LightKrylov
+   use LightKrylov
+   use LightKrylov_Logger
+   use LightKrylov_TestUtils
+   ! SpecialMatrices
+   use SpecialMatrices
+   use TestUtils
 
-    implicit none
-    private
+   implicit none
+   private
 
-    character(len=*), parameter, private :: this_module      = "LK_TSpecialMatrices"
-    character(len=*), parameter, private :: this_module_long = "LightKrylov_TestSpecialMatrices"
-    integer, parameter :: nx = 16, ny = 8
-    real(dp), parameter :: dx = 1.0_dp/(nx+1), dy = 1.0_dp/(ny+1)
+   character(len=*), parameter, private :: this_module = "LK_TSpecialMatrices"
+   character(len=*), parameter, private :: this_module_long = "LightKrylov_TestSpecialMatrices"
+   integer, parameter :: nx = 16, ny = 8
+   real(dp), parameter :: dx = 1.0_dp/(nx + 1), dy = 1.0_dp/(ny + 1)
 
-    public :: collect_specialmatrices_rdp_testsuite
+   public :: collect_specialmatrices_rdp_testsuite
 
-    !-----------------------------------------------
-    !-----     ABSTRACT POISSON2D OPERATOR     -----
-    !-----------------------------------------------
+   !-----------------------------------------------
+   !-----     ABSTRACT POISSON2D OPERATOR     -----
+   !-----------------------------------------------
 
-    type, extends(abstract_sym_linop_rdp), public :: AbstractPoisson2D
-        type(Poisson2D), allocatable :: data
-    contains
-        private
-        procedure, pass(self), public :: matvec => matvec_rdp
-        procedure, pass(self), public :: rmatvec => rmatvec_rdp
-    end type
+   type, extends(abstract_sym_linop_rdp), public :: AbstractPoisson2D
+      type(Poisson2D), allocatable :: data
+   contains
+      private
+      procedure, pass(self), public :: matvec => matvec_rdp
+      procedure, pass(self), public :: rmatvec => rmatvec_rdp
+   end type
 
-    type, extends(abstract_precond_rdp) :: BlockJacobiPreconditioner
-        type(SymTridiagonal), allocatable :: D
-    contains
-        private
-        procedure, pass(self), public :: apply => apply_blockjacobi
-    end type
+   type, extends(abstract_precond_rdp) :: BlockJacobiPreconditioner
+      type(SymTridiagonal), allocatable :: D
+   contains
+      private
+      procedure, pass(self), public :: apply => apply_blockjacobi
+   end type
 
 contains
 
-    !---------------------------------------------------------------
-    !-----     TYPE-BOUND PROCEDURES FOR AbstractPoisson2D     -----
-    !---------------------------------------------------------------
+   !---------------------------------------------------------------
+   !-----     TYPE-BOUND PROCEDURES FOR AbstractPoisson2D     -----
+   !---------------------------------------------------------------
 
-    subroutine matvec_rdp(self, vec_in, vec_out)
-        class(AbstractPoisson2D), intent(inout) :: self
-        class(abstract_vector_rdp), intent(in) :: vec_in
-        class(abstract_vector_rdp), intent(out) :: vec_out
+   subroutine matvec_rdp(self, vec_in, vec_out)
+      class(AbstractPoisson2D), intent(inout) :: self
+      class(abstract_vector_rdp), intent(in) :: vec_in
+      class(abstract_vector_rdp), intent(out) :: vec_out
 
-        select type(vec_in)
-        type is(vector_rdp)
-            select type(vec_out)
-            type is(vector_rdp)
-                vec_out%data = -matmul(self%data, vec_in%data)
-            class default
-                call type_error('vec_out','state_vector','OUT',this_module,'Poisson2D_matvec')
-            end select
-        class default
-            call type_error('vec_in','state_vector','IN',this_module,'Poisson2D_matvec')
-        end select
-    end subroutine
+      select type (vec_in)
+      type is (vector_rdp)
+         select type (vec_out)
+         type is (vector_rdp)
+            vec_out%data = -matmul(self%data, vec_in%data)
+         class default
+            call type_error('vec_out', 'state_vector', 'OUT', this_module, 'Poisson2D_matvec')
+         end select
+      class default
+         call type_error('vec_in', 'state_vector', 'IN', this_module, 'Poisson2D_matvec')
+      end select
+   end subroutine
 
-    subroutine rmatvec_rdp(self, vec_in, vec_out)
-        class(AbstractPoisson2D), intent(inout) :: self
-        class(abstract_vector_rdp), intent(in) :: vec_in
-        class(abstract_vector_rdp), intent(out) :: vec_out
-        call matvec_rdp(self, vec_in, vec_out)
-    end subroutine
+   subroutine rmatvec_rdp(self, vec_in, vec_out)
+      class(AbstractPoisson2D), intent(inout) :: self
+      class(abstract_vector_rdp), intent(in) :: vec_in
+      class(abstract_vector_rdp), intent(out) :: vec_out
+      call matvec_rdp(self, vec_in, vec_out)
+   end subroutine
 
-    function construct_preconditioner(A) result(M)
-        type(Poisson2D), intent(in) :: A
-        type(BlockJacobiPreconditioner) :: M
-        type(SymTridiagonal) :: D
-        real(dp), allocatable :: dv(:), ev(:)
-        integer :: i
+   function construct_preconditioner(A) result(M)
+      type(Poisson2D), intent(in) :: A
+      type(BlockJacobiPreconditioner) :: M
+      type(SymTridiagonal) :: D
+      real(dp), allocatable :: dv(:), ev(:)
+      integer :: i
 
-        dv = [(2*(1.0_dp/dx**2 + 1.0_dp/dy**2), i=1, nx)]
-        ev = [(-1.0_dp / dx**2, i=1, nx-1)]
-        D = SymTridiagonal(dv, ev)
-        M = BlockJacobiPreconditioner() ; M%D = D
-    end function
+      dv = [(2*(1.0_dp/dx**2 + 1.0_dp/dy**2), i=1, nx)]
+      ev = [(-1.0_dp/dx**2, i=1, nx - 1)]
+      D = SymTridiagonal(dv, ev)
+      M = BlockJacobiPreconditioner(); M%D = D
+   end function
 
-    subroutine apply_blockjacobi(self, vec, iter, current_residual, target_residual)
-        class(BlockJacobiPreconditioner), intent(inout) :: self
-        class(abstract_vector_rdp), intent(inout) :: vec
-        integer, optional, intent(in) :: iter
-        real(dp), optional, intent(in) :: current_residual
-        real(dp), optional, intent(in) :: target_residual
-        
-        real(dp), allocatable, target :: x(:), y(:)
-        real(dp), pointer :: xmat(:, :), ymat(:, :)
-        real(dp), allocatable :: z(:), Dmat(:, :)
-        integer :: i, j
+   subroutine apply_blockjacobi(self, vec, iter, current_residual, target_residual)
+      class(BlockJacobiPreconditioner), intent(inout) :: self
+      class(abstract_vector_rdp), intent(inout) :: vec
+      integer, optional, intent(in) :: iter
+      real(dp), optional, intent(in) :: current_residual
+      real(dp), optional, intent(in) :: target_residual
 
-        select type(vec)
-        type is(vector_rdp)
-            x = vec%data ; allocate(y(nx*ny)) ; y = 0.0_dp
-            xmat(1:nx, 1:ny) => x ; ymat(1:nx, 1:ny) => y
-            do i = 1, ny
-                ymat(:, i) = solve(self%D, xmat(:, i))
-            enddo
-            vec%data = y
-        end select
-    end subroutine
+      real(dp), allocatable, target :: x(:), y(:)
+      real(dp), pointer :: xmat(:, :), ymat(:, :)
+      real(dp), allocatable :: z(:), Dmat(:, :)
+      integer :: i, j
 
-    !--------------------------------------------------------------------
-    !-----     DEFINITION OF THE UNIT TESTS FOR SPECIALMATRICES     -----
-    !--------------------------------------------------------------------
+      select type (vec)
+      type is (vector_rdp)
+         x = vec%data; allocate (y(nx*ny)); y = 0.0_dp
+         xmat(1:nx, 1:ny) => x; ymat(1:nx, 1:ny) => y
+         do i = 1, ny
+            ymat(:, i) = solve(self%D, xmat(:, i))
+         end do
+         vec%data = y
+      end select
+   end subroutine
 
-    subroutine collect_specialmatrices_rdp_testsuite(testsuite)
-        type(unittest_type), allocatable, intent(out) :: testsuite(:)
-        testsuite = [ &
-                    new_unittest("Precond. Conj. Gradient (Poisson2D)", test_pcg_poisson_rdp) &
-                    ]
-    end subroutine
+   !--------------------------------------------------------------------
+   !-----     DEFINITION OF THE UNIT TESTS FOR SPECIALMATRICES     -----
+   !--------------------------------------------------------------------
 
-    subroutine test_pcg_poisson_rdp(error)
-        ! Error type.
-        type(error_type), allocatable, intent(out) :: error
-        ! Linear problem.
-        type(Poisson2D) :: Amat
-        type(AbstractPoisson2D) :: A
-        type(BlockJacobiPreconditioner) :: P
-        type(vector_rdp), allocatable :: x, b, r
-        ! CG options and metadata.
-        type(cg_dp_opts) :: opts
-        type(cg_dp_metadata) :: meta
-        ! Information flag.
-        integer :: info
-        ! Misc.
-        real(dp) :: err
-        character(len=256) :: msg
+   subroutine collect_specialmatrices_rdp_testsuite(testsuite)
+      type(unittest_type), allocatable, intent(out) :: testsuite(:)
+      testsuite = [ &
+                  new_unittest("Precond. Conj. Gradient (Poisson2D)", test_pcg_poisson_rdp) &
+                  ]
+   end subroutine
 
-        ! Initialize linear problem.
-        A = AbstractPoisson2D() ; A%data = Poisson2D(nx, ny)
-        P = construct_preconditioner(A%data)
-        b = vector_rdp() ; call init_rand(b)
-        x = vector_rdp() ; call x%zero()
-        r = vector_rdp() ; call r%zero()
+   subroutine test_pcg_poisson_rdp(error)
+      ! Error type.
+      type(error_type), allocatable, intent(out) :: error
+      ! Linear problem.
+      type(Poisson2D) :: Amat
+      type(AbstractPoisson2D) :: A
+      type(BlockJacobiPreconditioner) :: P
+      type(vector_rdp), allocatable :: x, b, r
+      ! CG options and metadata.
+      type(cg_dp_opts) :: opts
+      type(cg_dp_metadata) :: meta
+      ! Information flag.
+      integer :: info
+      ! Misc.
+      real(dp) :: err
+      character(len=256) :: msg
 
-        ! CG solver.
-        opts = cg_dp_opts(maxiter=2*nx*ny, if_print_metadata=.true.)
-        call cg(A, b, x, info, preconditioner=P, rtol=rtol_dp, atol=atol_dp, options=opts, meta=meta)
-        call check_info(info, 'cg', module=this_module_long, procedure='test_pcg_poisson_rdp')
+      ! Initialize linear problem.
+      A = AbstractPoisson2D(); A%data = Poisson2D(nx, ny)
+      P = construct_preconditioner(A%data)
+      b = vector_rdp(); call init_rand(b)
+      x = vector_rdp(); call x%zero()
+      r = vector_rdp(); call r%zero()
 
-        ! Check convergence.
-        call A%matvec(x, r) ; call r%sub(b) ; call P%apply(r)
-        err = r%norm()
-        call get_err_str(msg, "max_err:", err)
-        call check(error, err < b%norm()*rtol_dp)
-        call check_test(error, 'test_pcg_poisson_rdp', eq='A @ x = b', context=msg)
-    end subroutine
+      ! CG solver.
+      opts = cg_dp_opts(maxiter=2*nx*ny, if_print_metadata=.true.)
+      call cg(A, b, x, info, preconditioner=P, rtol=rtol_dp, atol=atol_dp, options=opts, meta=meta)
+      call check_info(info, 'cg', module=this_module_long, procedure='test_pcg_poisson_rdp')
+
+      ! Check convergence.
+      call A%matvec(x, r); call r%sub(b); call P%apply(r)
+      err = r%norm()
+      call get_err_str(msg, "max_err:", err)
+      call check(error, err < b%norm()*rtol_dp)
+      call check_test(error, 'test_pcg_poisson_rdp', eq='A @ x = b', context=msg)
+   end subroutine
 
 end module

--- a/test/TestUtils.f90
+++ b/test/TestUtils.f90
@@ -1,0 +1,72 @@
+module TestUtils
+   use stdlib_optval, only: optval
+   use stdlib_ascii, only: to_lower
+   use stdlib_strings, only: replace_all
+   use testdrive, only: error_type
+   private
+   interface
+      module subroutine check_test(error, test_name, info, eq, context)
+         use face
+         type(error_type), allocatable, intent(inout) :: error
+         character(len=*), intent(in)    :: test_name
+         character(len=*), optional, intent(in)    :: info
+         character(len=*), optional, intent(in)    :: eq
+         character(len=*), optional, intent(in)    :: context
+      end subroutine
+   end interface
+   public :: check_test
+contains
+   module subroutine check_test(error, test_name, info, eq, context)
+      use face
+      type(error_type), allocatable, intent(inout) :: error
+      character(len=*), intent(in)    :: test_name
+      character(len=*), optional, intent(in)    :: info
+      character(len=*), optional, intent(in)    :: eq
+      character(len=*), optional, intent(in)    :: context
+      character(len=128)                           :: name
+
+      ! internals
+      character(len=128)                           :: msg, info_, eq_
+      ! character(len=*), parameter :: indent = repeat(" ", 7)
+      character(len=4), dimension(4) :: substrings
+      integer :: i
+
+      info_ = optval(info, '')
+      eq_ = optval(eq, '')
+
+      name = trim(to_lower(test_name))
+      substrings = ["_rsp", "_rdp", "_csp", "_cdp"]
+      do i = 1, size(substrings)
+         name = replace_all(name, substrings(i), "")
+      end do
+      name = replace_all(name, "test_", "")
+
+      write (*, '(A33)', ADVANCE='NO') name
+      write (*, '(A3)', ADVANCE='NO') ' % '
+
+      if (len(trim(info_)) == 0) then
+         msg = eq_
+      else
+         if (len(info_) > 30) then
+            msg = info_(:30)//eq_
+         else
+            msg = info_//repeat(' ', 30 - len(trim(info_)))//eq_
+         end if
+      end if
+      write (*, '(A62)', ADVANCE='NO') msg
+
+      if (allocated(error)) then
+         print *, colorize('FAILED', color_fg='red')
+         if (present(context)) then
+            write (*, '(A)', ADVANCE='NO') trim(context)
+         end if
+         write (*, *)
+         write (*, *) 'The most recent test failed. Aborting calculation as per user directive.'
+         write (*, *)
+         STOP 1
+      else
+         print *, colorize('PASSED', color_fg='green')
+      end if
+
+   end subroutine check_test
+end module

--- a/test/TestVectors.f90
+++ b/test/TestVectors.f90
@@ -11,7 +11,7 @@ module TestVectors
     use LightKrylov_Logger
     ! Test Utilities
     use LightKrylov_TestUtils
-    
+    use TestUtils    
     implicit none
     
     private

--- a/test/TestVectors.fypp
+++ b/test/TestVectors.fypp
@@ -13,7 +13,7 @@ module TestVectors
     use LightKrylov_Logger
     ! Test Utilities
     use LightKrylov_TestUtils
-    
+    use TestUtils    
     implicit none
     
     private


### PR DESCRIPTION
As noted in #207, Logger.f90 actually imports some types from testdrive yet the latter is left as a dev-deps only.
They've had some issue compiling the code in their own fpm project, possibly due to this. Not entirely sure why we haven't had this issue on our side.

In any case, this PR simply adds testdrive as a regular deps in the toml file.