### PR TITLE
Abstract Symmetric/Hermitian linop super type

### DIFF
--- a/src/AbstractTypes/AbstractLinops.f90
+++ b/src/AbstractTypes/AbstractLinops.f90
@@ -45,6 +45,9 @@ module LightKrylov_AbstractLinops
         !! Finalize timers and print complete history_info
     end type abstract_linop
 
+    type, abstract, extends(abstract_linop), public :: abstract_sym_linop
+    end type abstract_sym_linop
+
     !------------------------------------------------------------------------------
     !-----     Definition of an abstract real(sp) operator with kind=sp     -----
     !------------------------------------------------------------------------------
@@ -490,31 +493,113 @@ module LightKrylov_AbstractLinops
     !----------------------------------------------------------------
     !-----     Definition of an abstract symmetric operator     -----
     !----------------------------------------------------------------
-    type, abstract, extends(abstract_linop_rsp), public :: abstract_sym_linop_rsp
+    type, abstract, extends(abstract_sym_linop), public :: abstract_sym_linop_rsp
         !! Abstract representation of an abstract symmetric (real valued) linear operator.
     contains
+        private
+        ! User defined procedures
+        procedure(abstract_sym_matvec_rsp), pass(self), deferred, public :: matvec
+        !! Procedure to compute the matrix-vector product \( \mathbf{y} = \mathbf{Ax} \).
+        ! Wrappers including counter increment
+        procedure, pass(self), public :: apply_matvec => apply_sym_matvec_rsp
+        !! Wrapper for matvec including the counter increment
     end type abstract_sym_linop_rsp
+    abstract interface
+        subroutine abstract_sym_matvec_rsp(self, vec_in, vec_out)
+            !! Interface for the matrix-vector product.
+            use lightkrylov_AbstractVectors
+            import abstract_sym_linop_rsp
+            implicit none(type, external)
+            class(abstract_sym_linop_rsp) , intent(inout)  :: self
+            !! Linear operator \(\mathbf{A}\).
+            class(abstract_vector_rsp), intent(in)  :: vec_in
+            !! Vector to be multiplied by \(\mathbf{A}\).
+            class(abstract_vector_rsp), intent(out) :: vec_out
+            !! Result of the matrix-vector product.
+        end subroutine abstract_sym_matvec_rsp
+    end interface
     !----------------------------------------------------------------
     !-----     Definition of an abstract symmetric operator     -----
     !----------------------------------------------------------------
-    type, abstract, extends(abstract_linop_rdp), public :: abstract_sym_linop_rdp
+    type, abstract, extends(abstract_sym_linop), public :: abstract_sym_linop_rdp
         !! Abstract representation of an abstract symmetric (real valued) linear operator.
     contains
+        private
+        ! User defined procedures
+        procedure(abstract_sym_matvec_rdp), pass(self), deferred, public :: matvec
+        !! Procedure to compute the matrix-vector product \( \mathbf{y} = \mathbf{Ax} \).
+        ! Wrappers including counter increment
+        procedure, pass(self), public :: apply_matvec => apply_sym_matvec_rdp
+        !! Wrapper for matvec including the counter increment
     end type abstract_sym_linop_rdp
+    abstract interface
+        subroutine abstract_sym_matvec_rdp(self, vec_in, vec_out)
+            !! Interface for the matrix-vector product.
+            use lightkrylov_AbstractVectors
+            import abstract_sym_linop_rdp
+            implicit none(type, external)
+            class(abstract_sym_linop_rdp) , intent(inout)  :: self
+            !! Linear operator \(\mathbf{A}\).
+            class(abstract_vector_rdp), intent(in)  :: vec_in
+            !! Vector to be multiplied by \(\mathbf{A}\).
+            class(abstract_vector_rdp), intent(out) :: vec_out
+            !! Result of the matrix-vector product.
+        end subroutine abstract_sym_matvec_rdp
+    end interface
     !----------------------------------------------------------------------------------
     !-----     Definition of an abstract Hermitian positive definite operator     -----
     !----------------------------------------------------------------------------------
-    type, abstract, extends(abstract_linop_csp), public :: abstract_hermitian_linop_csp
+    type, abstract, extends(abstract_sym_linop), public :: abstract_hermitian_linop_csp
         !! Abstract representation of an abstract hermitian (complex-valued) linear operator.
     contains
+        ! User defined procedures
+        procedure(abstract_herm_matvec_csp), pass(self), deferred, public :: matvec
+        !! Procedure to compute the matrix-vector product \( \mathbf{y} = \mathbf{Ax} \).
+        ! Wrappers including counter increment
+        procedure, pass(self), public :: apply_matvec => apply_herm_matvec_csp
+        !! Wrapper for matvec including the counter increment
     end type abstract_hermitian_linop_csp
+    abstract interface
+        subroutine abstract_herm_matvec_csp(self, vec_in, vec_out)
+            !! Interface for the matrix-vector product.
+            use lightkrylov_AbstractVectors
+            import abstract_hermitian_linop_csp
+            implicit none(type, external)
+            class(abstract_hermitian_linop_csp) , intent(inout)  :: self
+            !! Linear operator \(\mathbf{A}\).
+            class(abstract_vector_csp), intent(in)  :: vec_in
+            !! Vector to be multiplied by \(\mathbf{A}\).
+            class(abstract_vector_csp), intent(out) :: vec_out
+            !! Result of the matrix-vector product.
+        end subroutine abstract_herm_matvec_csp
+    end interface
     !----------------------------------------------------------------------------------
     !-----     Definition of an abstract Hermitian positive definite operator     -----
     !----------------------------------------------------------------------------------
-    type, abstract, extends(abstract_linop_cdp), public :: abstract_hermitian_linop_cdp
+    type, abstract, extends(abstract_sym_linop), public :: abstract_hermitian_linop_cdp
         !! Abstract representation of an abstract hermitian (complex-valued) linear operator.
     contains
+        ! User defined procedures
+        procedure(abstract_herm_matvec_cdp), pass(self), deferred, public :: matvec
+        !! Procedure to compute the matrix-vector product \( \mathbf{y} = \mathbf{Ax} \).
+        ! Wrappers including counter increment
+        procedure, pass(self), public :: apply_matvec => apply_herm_matvec_cdp
+        !! Wrapper for matvec including the counter increment
     end type abstract_hermitian_linop_cdp
+    abstract interface
+        subroutine abstract_herm_matvec_cdp(self, vec_in, vec_out)
+            !! Interface for the matrix-vector product.
+            use lightkrylov_AbstractVectors
+            import abstract_hermitian_linop_cdp
+            implicit none(type, external)
+            class(abstract_hermitian_linop_cdp) , intent(inout)  :: self
+            !! Linear operator \(\mathbf{A}\).
+            class(abstract_vector_cdp), intent(in)  :: vec_in
+            !! Vector to be multiplied by \(\mathbf{A}\).
+            class(abstract_vector_cdp), intent(out) :: vec_out
+            !! Result of the matrix-vector product.
+        end subroutine abstract_herm_matvec_cdp
+    end interface
 
     !------------------------------------------------
     !-----     Convenience dense linop type     -----
@@ -697,6 +782,24 @@ contains
         write(msg,'(I0,1X,A)') self%rmatvec_counter, 'end'
         call log_debug(msg, this_module, 'rmatvec')
     end subroutine apply_rmatvec_rsp
+
+    subroutine apply_sym_matvec_rsp(self, vec_in, vec_out)
+        implicit none(type, external)
+        class(abstract_sym_linop_rsp), intent(inout) :: self
+        class(abstract_vector_rsp), intent(in) :: vec_in
+        class(abstract_vector_rsp), intent(out) :: vec_out
+        ! internal
+        character(len=128) :: msg
+        self%matvec_counter = self%matvec_counter + 1
+        write(msg,'(I0,1X,A)') self%matvec_counter, 'start'
+        call log_debug(msg, this_module, 'matvec')
+        call self%matvec_timer%start()
+        call self%matvec(vec_in, vec_out)
+        call self%matvec_timer%stop()
+        write(msg,'(I0,1X,A)') self%matvec_counter, 'end'
+        call log_debug(msg, this_module, 'matvec')
+        return
+    end subroutine apply_sym_matvec_rsp
     subroutine apply_matvec_rdp(self, vec_in, vec_out)
         implicit none(type, external)
         class(abstract_linop_rdp), intent(inout) :: self
@@ -731,6 +834,24 @@ contains
         write(msg,'(I0,1X,A)') self%rmatvec_counter, 'end'
         call log_debug(msg, this_module, 'rmatvec')
     end subroutine apply_rmatvec_rdp
+
+    subroutine apply_sym_matvec_rdp(self, vec_in, vec_out)
+        implicit none(type, external)
+        class(abstract_sym_linop_rdp), intent(inout) :: self
+        class(abstract_vector_rdp), intent(in) :: vec_in
+        class(abstract_vector_rdp), intent(out) :: vec_out
+        ! internal
+        character(len=128) :: msg
+        self%matvec_counter = self%matvec_counter + 1
+        write(msg,'(I0,1X,A)') self%matvec_counter, 'start'
+        call log_debug(msg, this_module, 'matvec')
+        call self%matvec_timer%start()
+        call self%matvec(vec_in, vec_out)
+        call self%matvec_timer%stop()
+        write(msg,'(I0,1X,A)') self%matvec_counter, 'end'
+        call log_debug(msg, this_module, 'matvec')
+        return
+    end subroutine apply_sym_matvec_rdp
     subroutine apply_matvec_csp(self, vec_in, vec_out)
         implicit none(type, external)
         class(abstract_linop_csp), intent(inout) :: self
@@ -765,6 +886,25 @@ contains
         write(msg,'(I0,1X,A)') self%rmatvec_counter, 'end'
         call log_debug(msg, this_module, 'rmatvec')
     end subroutine apply_rmatvec_csp
+
+    subroutine apply_herm_matvec_csp(self, vec_in, vec_out)
+        implicit none(type, external)
+        class(abstract_hermitian_linop_csp), intent(inout) :: self
+        class(abstract_vector_csp), intent(in) :: vec_in
+        class(abstract_vector_csp), intent(out) :: vec_out
+        ! internal
+        character(len=128) :: msg
+        self%matvec_counter = self%matvec_counter + 1
+        write(msg,'(I0,1X,A)') self%matvec_counter, 'start'
+        call log_debug(msg, this_module, 'matvec')
+        call self%matvec_timer%start()
+        call self%matvec(vec_in, vec_out)
+        call self%matvec_timer%stop()
+        write(msg,'(I0,1X,A)') self%matvec_counter, 'end'
+        call log_debug(msg, this_module, 'matvec')
+        return
+    end subroutine apply_herm_matvec_csp
+
     subroutine apply_matvec_cdp(self, vec_in, vec_out)
         implicit none(type, external)
         class(abstract_linop_cdp), intent(inout) :: self
@@ -799,6 +939,25 @@ contains
         write(msg,'(I0,1X,A)') self%rmatvec_counter, 'end'
         call log_debug(msg, this_module, 'rmatvec')
     end subroutine apply_rmatvec_cdp
+
+    subroutine apply_herm_matvec_cdp(self, vec_in, vec_out)
+        implicit none(type, external)
+        class(abstract_hermitian_linop_cdp), intent(inout) :: self
+        class(abstract_vector_cdp), intent(in) :: vec_in
+        class(abstract_vector_cdp), intent(out) :: vec_out
+        ! internal
+        character(len=128) :: msg
+        self%matvec_counter = self%matvec_counter + 1
+        write(msg,'(I0,1X,A)') self%matvec_counter, 'start'
+        call log_debug(msg, this_module, 'matvec')
+        call self%matvec_timer%start()
+        call self%matvec(vec_in, vec_out)
+        call self%matvec_timer%stop()
+        write(msg,'(I0,1X,A)') self%matvec_counter, 'end'
+        call log_debug(msg, this_module, 'matvec')
+        return
+    end subroutine apply_herm_matvec_cdp
+
 
     !------------------------------------------------------------------------------
     !-----     Concrete matvec/rmatvec implementations for special linops     -----

--- a/src/AbstractTypes/AbstractLinops.fypp
+++ b/src/AbstractTypes/AbstractLinops.fypp
@@ -47,6 +47,9 @@ module LightKrylov_AbstractLinops
         !! Finalize timers and print complete history_info
     end type abstract_linop
 
+    type, abstract, extends(abstract_linop), public :: abstract_sym_linop
+    end type abstract_sym_linop
+
     #:for kind, type in RC_KINDS_TYPES
     !------------------------------------------------------------------------------
     !-----     Definition of an abstract ${type}$ operator with kind=${kind}$     -----
@@ -197,18 +200,59 @@ module LightKrylov_AbstractLinops
     !----------------------------------------------------------------
     !-----     Definition of an abstract symmetric operator     -----
     !----------------------------------------------------------------
-    type, abstract, extends(abstract_linop_${type[0]}$${kind}$), public :: abstract_sym_linop_${type[0]}$${kind}$
+    type, abstract, extends(abstract_sym_linop), public :: abstract_sym_linop_${type[0]}$${kind}$
         !! Abstract representation of an abstract symmetric (real valued) linear operator.
     contains
+        private
+        ! User defined procedures
+        procedure(abstract_sym_matvec_${type[0]}$${kind}$), pass(self), deferred, public :: matvec
+        !! Procedure to compute the matrix-vector product \( \mathbf{y} = \mathbf{Ax} \).
+        ! Wrappers including counter increment
+        procedure, pass(self), public :: apply_matvec => apply_sym_matvec_${type[0]}$${kind}$
+        !! Wrapper for matvec including the counter increment
     end type abstract_sym_linop_${type[0]}$${kind}$
+    abstract interface
+        subroutine abstract_sym_matvec_${type[0]}$${kind}$(self, vec_in, vec_out)
+            !! Interface for the matrix-vector product.
+            use lightkrylov_AbstractVectors
+            import abstract_sym_linop_${type[0]}$${kind}$
+            implicit none(type, external)
+            class(abstract_sym_linop_${type[0]}$${kind}$) , intent(inout)  :: self
+            !! Linear operator \(\mathbf{A}\).
+            class(abstract_vector_${type[0]}$${kind}$), intent(in)  :: vec_in
+            !! Vector to be multiplied by \(\mathbf{A}\).
+            class(abstract_vector_${type[0]}$${kind}$), intent(out) :: vec_out
+            !! Result of the matrix-vector product.
+        end subroutine abstract_sym_matvec_${type[0]}$${kind}$
+    end interface
     #:else
     !----------------------------------------------------------------------------------
     !-----     Definition of an abstract Hermitian positive definite operator     -----
     !----------------------------------------------------------------------------------
-    type, abstract, extends(abstract_linop_${type[0]}$${kind}$), public :: abstract_hermitian_linop_${type[0]}$${kind}$
+    type, abstract, extends(abstract_sym_linop), public :: abstract_hermitian_linop_${type[0]}$${kind}$
         !! Abstract representation of an abstract hermitian (complex-valued) linear operator.
     contains
+        ! User defined procedures
+        procedure(abstract_herm_matvec_${type[0]}$${kind}$), pass(self), deferred, public :: matvec
+        !! Procedure to compute the matrix-vector product \( \mathbf{y} = \mathbf{Ax} \).
+        ! Wrappers including counter increment
+        procedure, pass(self), public :: apply_matvec => apply_herm_matvec_${type[0]}$${kind}$
+        !! Wrapper for matvec including the counter increment
     end type abstract_hermitian_linop_${type[0]}$${kind}$
+    abstract interface
+        subroutine abstract_herm_matvec_${type[0]}$${kind}$(self, vec_in, vec_out)
+            !! Interface for the matrix-vector product.
+            use lightkrylov_AbstractVectors
+            import abstract_hermitian_linop_${type[0]}$${kind}$
+            implicit none(type, external)
+            class(abstract_hermitian_linop_${type[0]}$${kind}$) , intent(inout)  :: self
+            !! Linear operator \(\mathbf{A}\).
+            class(abstract_vector_${type[0]}$${kind}$), intent(in)  :: vec_in
+            !! Vector to be multiplied by \(\mathbf{A}\).
+            class(abstract_vector_${type[0]}$${kind}$), intent(out) :: vec_out
+            !! Result of the matrix-vector product.
+        end subroutine abstract_herm_matvec_${type[0]}$${kind}$
+    end interface
     #:endif
     #:endfor
 
@@ -377,6 +421,45 @@ contains
         write(msg,'(I0,1X,A)') self%rmatvec_counter, 'end'
         call log_debug(msg, this_module, 'rmatvec')
     end subroutine apply_rmatvec_${type[0]}$${kind}$
+
+    #:if type.startswith("real")
+    subroutine apply_sym_matvec_${type[0]}$${kind}$(self, vec_in, vec_out)
+        implicit none(type, external)
+        class(abstract_sym_linop_${type[0]}$${kind}$), intent(inout) :: self
+        class(abstract_vector_${type[0]}$${kind}$), intent(in) :: vec_in
+        class(abstract_vector_${type[0]}$${kind}$), intent(out) :: vec_out
+        ! internal
+        character(len=128) :: msg
+        self%matvec_counter = self%matvec_counter + 1
+        write(msg,'(I0,1X,A)') self%matvec_counter, 'start'
+        call log_debug(msg, this_module, 'matvec')
+        call self%matvec_timer%start()
+        call self%matvec(vec_in, vec_out)
+        call self%matvec_timer%stop()
+        write(msg,'(I0,1X,A)') self%matvec_counter, 'end'
+        call log_debug(msg, this_module, 'matvec')
+        return
+    end subroutine apply_sym_matvec_${type[0]}$${kind}$
+    #:else
+    subroutine apply_herm_matvec_${type[0]}$${kind}$(self, vec_in, vec_out)
+        implicit none(type, external)
+        class(abstract_hermitian_linop_${type[0]}$${kind}$), intent(inout) :: self
+        class(abstract_vector_${type[0]}$${kind}$), intent(in) :: vec_in
+        class(abstract_vector_${type[0]}$${kind}$), intent(out) :: vec_out
+        ! internal
+        character(len=128) :: msg
+        self%matvec_counter = self%matvec_counter + 1
+        write(msg,'(I0,1X,A)') self%matvec_counter, 'start'
+        call log_debug(msg, this_module, 'matvec')
+        call self%matvec_timer%start()
+        call self%matvec(vec_in, vec_out)
+        call self%matvec_timer%stop()
+        write(msg,'(I0,1X,A)') self%matvec_counter, 'end'
+        call log_debug(msg, this_module, 'matvec')
+        return
+    end subroutine apply_herm_matvec_${type[0]}$${kind}$
+
+    #:endif
     #:endfor
 
     !------------------------------------------------------------------------------

--- a/test/TestIterativeSolvers.f90
+++ b/test/TestIterativeSolvers.f90
@@ -1269,8 +1269,8 @@ contains
     subroutine collect_gmres_rsp_testsuite(testsuite)
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
         testsuite = [ &
-                    new_unittest("Full GMRES", test_gmres_rsp), &
-                    new_unittest("Full (SPD) GMRES", test_gmres_spd_rsp) &
+                    new_unittest("Full GMRES", test_gmres_rsp) &
+                    ! new_unittest("Full (SPD) GMRES", test_gmres_spd_rsp) &
                     ]
         return
     end subroutine collect_gmres_rsp_testsuite
@@ -1307,47 +1307,55 @@ contains
         return
     end subroutine test_gmres_rsp
     
-    subroutine test_gmres_spd_rsp(error)
-        ! Error type to be returned.
-        type(error_type), allocatable, intent(out) :: error
-        ! Linear problem.
-        type(spd_linop_rsp) , allocatable :: A ! Linear Operator.
-        type(vector_rsp), allocatable :: b ! Right-hand side vector.
-        type(vector_rsp), allocatable :: x ! Solution vector.
-        ! GMRES options.
-        type(gmres_sp_opts) :: opts
-        ! GMRES metadata.
-        type(gmres_sp_metadata) :: meta
-        ! Information flag.
-        integer :: info
-        ! Misc
-        real(sp) :: err
-        character(len=256) :: msg
-
-        ! Initialize linear problem.
-        A = spd_linop_rsp()  ; call init_rand(A)
-        b = vector_rsp() ; call init_rand(b)
-        x = vector_rsp() ; call x%zero()
-
-        ! GMRES solver.
-        opts = gmres_sp_opts(kdim=test_size, if_print_metadata=.true.)
-        call gmres(A, b, x, info, rtol=rtol_sp, atol=atol_sp, options=opts, meta=meta)
-        call check_info(info, 'gmres', module=this_module_long, procedure='test_gmres_spd_rsp')
-
-        ! Check convergence.
-        err = norm2(abs(matmul(A%data, x%data) - b%data))
-        call get_err_str(msg, "max err: ", err)
-        call check(error, err < b%norm() * rtol_sp)
-        call check_test(error, 'test_gmres_spd_rsp', eq='A @ x = b', context=msg)
-
-        return
-    end subroutine test_gmres_spd_rsp
+    ! subroutine test_gmres_spd_rsp(error)
+    !     ! Error type to be returned.
+    !     type(error_type), allocatable, intent(out) :: error
+    !     ! Linear problem.
+    !     #:if type[0] == "r"
+    !     type(spd_linop_rsp) , allocatable :: A ! Linear Operator.
+    !     #:else
+    !     type(hermitian_linop_rsp), allocatable :: A
+    !     #:endif
+    !     type(vector_rsp), allocatable :: b ! Right-hand side vector.
+    !     type(vector_rsp), allocatable :: x ! Solution vector.
+    !     ! GMRES options.
+    !     type(gmres_sp_opts) :: opts
+    !     ! GMRES metadata.
+    !     type(gmres_sp_metadata) :: meta
+    !     ! Information flag.
+    !     integer :: info
+    !     ! Misc
+    !     real(sp) :: err
+    !     character(len=256) :: msg
+    !
+    !     ! Initialize linear problem.
+    !     #:if type[0] == "r"
+    !     A = spd_linop_rsp()  ; call init_rand(A)
+    !     #:else
+    !     A = hermitian_linop_rsp() ; call init_rand(A)
+    !     #:endif
+    !     b = vector_rsp() ; call init_rand(b)
+    !     x = vector_rsp() ; call x%zero()
+    !
+    !     ! GMRES solver.
+    !     opts = gmres_sp_opts(kdim=test_size, if_print_metadata=.true.)
+    !     call gmres(A, b, x, info, rtol=rtol_sp, atol=atol_sp, options=opts, meta=meta)
+    !     call check_info(info, 'gmres', module=this_module_long, procedure='test_gmres_spd_rsp')
+    !
+    !     ! Check convergence.
+    !     err = norm2(abs(matmul(A%data, x%data) - b%data))
+    !     call get_err_str(msg, "max err: ", err)
+    !     call check(error, err < b%norm() * rtol_sp)
+    !     call check_test(error, 'test_gmres_spd_rsp', eq='A @ x = b', context=msg)
+    !
+    !     return
+    ! end subroutine test_gmres_spd_rsp
 
     subroutine collect_gmres_rdp_testsuite(testsuite)
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
         testsuite = [ &
-                    new_unittest("Full GMRES", test_gmres_rdp), &
-                    new_unittest("Full (SPD) GMRES", test_gmres_spd_rdp) &
+                    new_unittest("Full GMRES", test_gmres_rdp) &
+                    ! new_unittest("Full (SPD) GMRES", test_gmres_spd_rdp) &
                     ]
         return
     end subroutine collect_gmres_rdp_testsuite
@@ -1384,47 +1392,55 @@ contains
         return
     end subroutine test_gmres_rdp
     
-    subroutine test_gmres_spd_rdp(error)
-        ! Error type to be returned.
-        type(error_type), allocatable, intent(out) :: error
-        ! Linear problem.
-        type(spd_linop_rdp) , allocatable :: A ! Linear Operator.
-        type(vector_rdp), allocatable :: b ! Right-hand side vector.
-        type(vector_rdp), allocatable :: x ! Solution vector.
-        ! GMRES options.
-        type(gmres_dp_opts) :: opts
-        ! GMRES metadata.
-        type(gmres_dp_metadata) :: meta
-        ! Information flag.
-        integer :: info
-        ! Misc
-        real(dp) :: err
-        character(len=256) :: msg
-
-        ! Initialize linear problem.
-        A = spd_linop_rdp()  ; call init_rand(A)
-        b = vector_rdp() ; call init_rand(b)
-        x = vector_rdp() ; call x%zero()
-
-        ! GMRES solver.
-        opts = gmres_dp_opts(kdim=test_size, if_print_metadata=.true.)
-        call gmres(A, b, x, info, rtol=rtol_dp, atol=atol_dp, options=opts, meta=meta)
-        call check_info(info, 'gmres', module=this_module_long, procedure='test_gmres_spd_rdp')
-
-        ! Check convergence.
-        err = norm2(abs(matmul(A%data, x%data) - b%data))
-        call get_err_str(msg, "max err: ", err)
-        call check(error, err < b%norm() * rtol_dp)
-        call check_test(error, 'test_gmres_spd_rdp', eq='A @ x = b', context=msg)
-
-        return
-    end subroutine test_gmres_spd_rdp
+    ! subroutine test_gmres_spd_rdp(error)
+    !     ! Error type to be returned.
+    !     type(error_type), allocatable, intent(out) :: error
+    !     ! Linear problem.
+    !     #:if type[0] == "r"
+    !     type(spd_linop_rdp) , allocatable :: A ! Linear Operator.
+    !     #:else
+    !     type(hermitian_linop_rdp), allocatable :: A
+    !     #:endif
+    !     type(vector_rdp), allocatable :: b ! Right-hand side vector.
+    !     type(vector_rdp), allocatable :: x ! Solution vector.
+    !     ! GMRES options.
+    !     type(gmres_dp_opts) :: opts
+    !     ! GMRES metadata.
+    !     type(gmres_dp_metadata) :: meta
+    !     ! Information flag.
+    !     integer :: info
+    !     ! Misc
+    !     real(dp) :: err
+    !     character(len=256) :: msg
+    !
+    !     ! Initialize linear problem.
+    !     #:if type[0] == "r"
+    !     A = spd_linop_rdp()  ; call init_rand(A)
+    !     #:else
+    !     A = hermitian_linop_rdp() ; call init_rand(A)
+    !     #:endif
+    !     b = vector_rdp() ; call init_rand(b)
+    !     x = vector_rdp() ; call x%zero()
+    !
+    !     ! GMRES solver.
+    !     opts = gmres_dp_opts(kdim=test_size, if_print_metadata=.true.)
+    !     call gmres(A, b, x, info, rtol=rtol_dp, atol=atol_dp, options=opts, meta=meta)
+    !     call check_info(info, 'gmres', module=this_module_long, procedure='test_gmres_spd_rdp')
+    !
+    !     ! Check convergence.
+    !     err = norm2(abs(matmul(A%data, x%data) - b%data))
+    !     call get_err_str(msg, "max err: ", err)
+    !     call check(error, err < b%norm() * rtol_dp)
+    !     call check_test(error, 'test_gmres_spd_rdp', eq='A @ x = b', context=msg)
+    !
+    !     return
+    ! end subroutine test_gmres_spd_rdp
 
     subroutine collect_gmres_csp_testsuite(testsuite)
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
         testsuite = [ &
-                    new_unittest("Full GMRES", test_gmres_csp), &
-                    new_unittest("Full (SPD) GMRES", test_gmres_spd_csp) &
+                    new_unittest("Full GMRES", test_gmres_csp) &
+                    ! new_unittest("Full (SPD) GMRES", test_gmres_spd_csp) &
                     ]
         return
     end subroutine collect_gmres_csp_testsuite
@@ -1465,47 +1481,55 @@ contains
         return
     end subroutine test_gmres_csp
     
-    subroutine test_gmres_spd_csp(error)
-        ! Error type to be returned.
-        type(error_type), allocatable, intent(out) :: error
-        ! Linear problem.
-        type(hermitian_linop_csp), allocatable :: A
-        type(vector_csp), allocatable :: b ! Right-hand side vector.
-        type(vector_csp), allocatable :: x ! Solution vector.
-        ! GMRES options.
-        type(gmres_sp_opts) :: opts
-        ! GMRES metadata.
-        type(gmres_sp_metadata) :: meta
-        ! Information flag.
-        integer :: info
-        ! Misc
-        real(sp) :: err
-        character(len=256) :: msg
-
-        ! Initialize linear problem.
-        A = hermitian_linop_csp() ; call init_rand(A)
-        b = vector_csp() ; call init_rand(b)
-        x = vector_csp() ; call x%zero()
-
-        ! GMRES solver.
-        opts = gmres_sp_opts(kdim=test_size, if_print_metadata=.true.)
-        call gmres(A, b, x, info, rtol=rtol_sp, atol=atol_sp, options=opts, meta=meta)
-        call check_info(info, 'gmres', module=this_module_long, procedure='test_gmres_spd_csp')
-
-        ! Check convergence.
-        err = norm2(abs(matmul(A%data, x%data) - b%data))
-        call get_err_str(msg, "max err: ", err)
-        call check(error, err < b%norm() * rtol_sp)
-        call check_test(error, 'test_gmres_spd_csp', eq='A @ x = b', context=msg)
-
-        return
-    end subroutine test_gmres_spd_csp
+    ! subroutine test_gmres_spd_csp(error)
+    !     ! Error type to be returned.
+    !     type(error_type), allocatable, intent(out) :: error
+    !     ! Linear problem.
+    !     #:if type[0] == "r"
+    !     type(spd_linop_csp) , allocatable :: A ! Linear Operator.
+    !     #:else
+    !     type(hermitian_linop_csp), allocatable :: A
+    !     #:endif
+    !     type(vector_csp), allocatable :: b ! Right-hand side vector.
+    !     type(vector_csp), allocatable :: x ! Solution vector.
+    !     ! GMRES options.
+    !     type(gmres_sp_opts) :: opts
+    !     ! GMRES metadata.
+    !     type(gmres_sp_metadata) :: meta
+    !     ! Information flag.
+    !     integer :: info
+    !     ! Misc
+    !     real(sp) :: err
+    !     character(len=256) :: msg
+    !
+    !     ! Initialize linear problem.
+    !     #:if type[0] == "r"
+    !     A = spd_linop_csp()  ; call init_rand(A)
+    !     #:else
+    !     A = hermitian_linop_csp() ; call init_rand(A)
+    !     #:endif
+    !     b = vector_csp() ; call init_rand(b)
+    !     x = vector_csp() ; call x%zero()
+    !
+    !     ! GMRES solver.
+    !     opts = gmres_sp_opts(kdim=test_size, if_print_metadata=.true.)
+    !     call gmres(A, b, x, info, rtol=rtol_sp, atol=atol_sp, options=opts, meta=meta)
+    !     call check_info(info, 'gmres', module=this_module_long, procedure='test_gmres_spd_csp')
+    !
+    !     ! Check convergence.
+    !     err = norm2(abs(matmul(A%data, x%data) - b%data))
+    !     call get_err_str(msg, "max err: ", err)
+    !     call check(error, err < b%norm() * rtol_sp)
+    !     call check_test(error, 'test_gmres_spd_csp', eq='A @ x = b', context=msg)
+    !
+    !     return
+    ! end subroutine test_gmres_spd_csp
 
     subroutine collect_gmres_cdp_testsuite(testsuite)
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
         testsuite = [ &
-                    new_unittest("Full GMRES", test_gmres_cdp), &
-                    new_unittest("Full (SPD) GMRES", test_gmres_spd_cdp) &
+                    new_unittest("Full GMRES", test_gmres_cdp) &
+                    ! new_unittest("Full (SPD) GMRES", test_gmres_spd_cdp) &
                     ]
         return
     end subroutine collect_gmres_cdp_testsuite
@@ -1546,41 +1570,49 @@ contains
         return
     end subroutine test_gmres_cdp
     
-    subroutine test_gmres_spd_cdp(error)
-        ! Error type to be returned.
-        type(error_type), allocatable, intent(out) :: error
-        ! Linear problem.
-        type(hermitian_linop_cdp), allocatable :: A
-        type(vector_cdp), allocatable :: b ! Right-hand side vector.
-        type(vector_cdp), allocatable :: x ! Solution vector.
-        ! GMRES options.
-        type(gmres_dp_opts) :: opts
-        ! GMRES metadata.
-        type(gmres_dp_metadata) :: meta
-        ! Information flag.
-        integer :: info
-        ! Misc
-        real(dp) :: err
-        character(len=256) :: msg
-
-        ! Initialize linear problem.
-        A = hermitian_linop_cdp() ; call init_rand(A)
-        b = vector_cdp() ; call init_rand(b)
-        x = vector_cdp() ; call x%zero()
-
-        ! GMRES solver.
-        opts = gmres_dp_opts(kdim=test_size, if_print_metadata=.true.)
-        call gmres(A, b, x, info, rtol=rtol_dp, atol=atol_dp, options=opts, meta=meta)
-        call check_info(info, 'gmres', module=this_module_long, procedure='test_gmres_spd_cdp')
-
-        ! Check convergence.
-        err = norm2(abs(matmul(A%data, x%data) - b%data))
-        call get_err_str(msg, "max err: ", err)
-        call check(error, err < b%norm() * rtol_dp)
-        call check_test(error, 'test_gmres_spd_cdp', eq='A @ x = b', context=msg)
-
-        return
-    end subroutine test_gmres_spd_cdp
+    ! subroutine test_gmres_spd_cdp(error)
+    !     ! Error type to be returned.
+    !     type(error_type), allocatable, intent(out) :: error
+    !     ! Linear problem.
+    !     #:if type[0] == "r"
+    !     type(spd_linop_cdp) , allocatable :: A ! Linear Operator.
+    !     #:else
+    !     type(hermitian_linop_cdp), allocatable :: A
+    !     #:endif
+    !     type(vector_cdp), allocatable :: b ! Right-hand side vector.
+    !     type(vector_cdp), allocatable :: x ! Solution vector.
+    !     ! GMRES options.
+    !     type(gmres_dp_opts) :: opts
+    !     ! GMRES metadata.
+    !     type(gmres_dp_metadata) :: meta
+    !     ! Information flag.
+    !     integer :: info
+    !     ! Misc
+    !     real(dp) :: err
+    !     character(len=256) :: msg
+    !
+    !     ! Initialize linear problem.
+    !     #:if type[0] == "r"
+    !     A = spd_linop_cdp()  ; call init_rand(A)
+    !     #:else
+    !     A = hermitian_linop_cdp() ; call init_rand(A)
+    !     #:endif
+    !     b = vector_cdp() ; call init_rand(b)
+    !     x = vector_cdp() ; call x%zero()
+    !
+    !     ! GMRES solver.
+    !     opts = gmres_dp_opts(kdim=test_size, if_print_metadata=.true.)
+    !     call gmres(A, b, x, info, rtol=rtol_dp, atol=atol_dp, options=opts, meta=meta)
+    !     call check_info(info, 'gmres', module=this_module_long, procedure='test_gmres_spd_cdp')
+    !
+    !     ! Check convergence.
+    !     err = norm2(abs(matmul(A%data, x%data) - b%data))
+    !     call get_err_str(msg, "max err: ", err)
+    !     call check(error, err < b%norm() * rtol_dp)
+    !     call check_test(error, 'test_gmres_spd_cdp', eq='A @ x = b', context=msg)
+    !
+    !     return
+    ! end subroutine test_gmres_spd_cdp
 
 
     !----------------------------------------------------------

--- a/test/TestIterativeSolvers.fypp
+++ b/test/TestIterativeSolvers.fypp
@@ -520,8 +520,8 @@ contains
     subroutine collect_gmres_${type[0]}$${kind}$_testsuite(testsuite)
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
         testsuite = [ &
-                    new_unittest("Full GMRES", test_gmres_${type[0]}$${kind}$), &
-                    new_unittest("Full (SPD) GMRES", test_gmres_spd_${type[0]}$${kind}$) &
+                    new_unittest("Full GMRES", test_gmres_${type[0]}$${kind}$) &
+                    ! new_unittest("Full (SPD) GMRES", test_gmres_spd_${type[0]}$${kind}$) &
                     ]
         return
     end subroutine collect_gmres_${type[0]}$${kind}$_testsuite
@@ -566,49 +566,49 @@ contains
         return
     end subroutine test_gmres_${type[0]}$${kind}$
     
-    subroutine test_gmres_spd_${type[0]}$${kind}$(error)
-        ! Error type to be returned.
-        type(error_type), allocatable, intent(out) :: error
-        ! Linear problem.
-        #:if type[0] == "r"
-        type(spd_linop_${type[0]}$${kind}$) , allocatable :: A ! Linear Operator.
-        #:else
-        type(hermitian_linop_${type[0]}$${kind}$), allocatable :: A
-        #:endif
-        type(vector_${type[0]}$${kind}$), allocatable :: b ! Right-hand side vector.
-        type(vector_${type[0]}$${kind}$), allocatable :: x ! Solution vector.
-        ! GMRES options.
-        type(gmres_${kind}$_opts) :: opts
-        ! GMRES metadata.
-        type(gmres_${kind}$_metadata) :: meta
-        ! Information flag.
-        integer :: info
-        ! Misc
-        real(${kind}$) :: err
-        character(len=256) :: msg
-
-        ! Initialize linear problem.
-        #:if type[0] == "r"
-        A = spd_linop_${type[0]}$${kind}$()  ; call init_rand(A)
-        #:else
-        A = hermitian_linop_${type[0]}$${kind}$() ; call init_rand(A)
-        #:endif
-        b = vector_${type[0]}$${kind}$() ; call init_rand(b)
-        x = vector_${type[0]}$${kind}$() ; call x%zero()
-
-        ! GMRES solver.
-        opts = gmres_${kind}$_opts(kdim=test_size, if_print_metadata=.true.)
-        call gmres(A, b, x, info, rtol=rtol_${kind}$, atol=atol_${kind}$, options=opts, meta=meta)
-        call check_info(info, 'gmres', module=this_module_long, procedure='test_gmres_spd_${type[0]}$${kind}$')
-
-        ! Check convergence.
-        err = norm2(abs(matmul(A%data, x%data) - b%data))
-        call get_err_str(msg, "max err: ", err)
-        call check(error, err < b%norm() * rtol_${kind}$)
-        call check_test(error, 'test_gmres_spd_${type[0]}$${kind}$', eq='A @ x = b', context=msg)
-
-        return
-    end subroutine test_gmres_spd_${type[0]}$${kind}$
+    ! subroutine test_gmres_spd_${type[0]}$${kind}$(error)
+    !     ! Error type to be returned.
+    !     type(error_type), allocatable, intent(out) :: error
+    !     ! Linear problem.
+    !     #:if type[0] == "r"
+    !     type(spd_linop_${type[0]}$${kind}$) , allocatable :: A ! Linear Operator.
+    !     #:else
+    !     type(hermitian_linop_${type[0]}$${kind}$), allocatable :: A
+    !     #:endif
+    !     type(vector_${type[0]}$${kind}$), allocatable :: b ! Right-hand side vector.
+    !     type(vector_${type[0]}$${kind}$), allocatable :: x ! Solution vector.
+    !     ! GMRES options.
+    !     type(gmres_${kind}$_opts) :: opts
+    !     ! GMRES metadata.
+    !     type(gmres_${kind}$_metadata) :: meta
+    !     ! Information flag.
+    !     integer :: info
+    !     ! Misc
+    !     real(${kind}$) :: err
+    !     character(len=256) :: msg
+    !
+    !     ! Initialize linear problem.
+    !     #:if type[0] == "r"
+    !     A = spd_linop_${type[0]}$${kind}$()  ; call init_rand(A)
+    !     #:else
+    !     A = hermitian_linop_${type[0]}$${kind}$() ; call init_rand(A)
+    !     #:endif
+    !     b = vector_${type[0]}$${kind}$() ; call init_rand(b)
+    !     x = vector_${type[0]}$${kind}$() ; call x%zero()
+    !
+    !     ! GMRES solver.
+    !     opts = gmres_${kind}$_opts(kdim=test_size, if_print_metadata=.true.)
+    !     call gmres(A, b, x, info, rtol=rtol_${kind}$, atol=atol_${kind}$, options=opts, meta=meta)
+    !     call check_info(info, 'gmres', module=this_module_long, procedure='test_gmres_spd_${type[0]}$${kind}$')
+    !
+    !     ! Check convergence.
+    !     err = norm2(abs(matmul(A%data, x%data) - b%data))
+    !     call get_err_str(msg, "max err: ", err)
+    !     call check(error, err < b%norm() * rtol_${kind}$)
+    !     call check_test(error, 'test_gmres_spd_${type[0]}$${kind}$', eq='A @ x = b', context=msg)
+    !
+    !     return
+    ! end subroutine test_gmres_spd_${type[0]}$${kind}$
 
     #:endfor
 


### PR DESCRIPTION
As discussed, this PR introduces an `abstract_sym_linop` type directly derived from `abstract_linop` type (and not from the `abstract_linop_xxp` ones). Note that `call gmres(A, b, x)` no longer works since `gmres` is defined for `abstract_linop_xxp` types. We could easily extend the implementation to handle the symmetric/hermitian cases but I ain't sure it is worth it for now.