### PR TITLE
Newton fix

### DIFF
--- a/src/AbstractTypes/AbstractVectors.fypp
+++ b/src/AbstractTypes/AbstractVectors.fypp
@@ -35,7 +35,9 @@ module LightKrylov_AbstractVectors
     !! - `zero_basis(X)`                    : Zero-out a collection of `abstract_vectors`.
     !! - `copy_basis(out, from)`            : Copy a collection of `abstract_vectors`.
     !! - `rand_basis(X, ifnorm)`            : Create a collection of random `abstract_vectors`. If `ifnorm = .true.`, the vectors are normalized to have unit-norm.
-    !!                                        NOTE: The resulting vectors do not form an orthonormal basis. For this purpose use the utility function `initialize_random_orthonormal_basis`.
+    !! @warning
+    !! The resulting vectors do not form an orthonormal basis. For this purpose use the utility function `initialize_random_orthonormal_basis`.
+    !! @endwarning
 
     use stdlib_optval, only: optval
     use stdlib_linalg_blas, only: scal, axpy, dot, dotc

--- a/src/Newton/NewtonKrylov.f90
+++ b/src/Newton/NewtonKrylov.f90
@@ -227,27 +227,27 @@ contains
         ifverbose = optval(verbose, .false.)
 
         write(msg,'(A30,I20)') padr('Iterations: ', 30), self%n_iter
-        call logger%log_message(msg, this_module, this_procedure)
+        call log_message(msg, this_module, this_procedure)
         if (ifverbose) then
             write(msg,'(14X,A15,2X,A15)') 'Residual', 'Tolerance'
-            call logger%log_message(msg, this_module, this_procedure)
+            call log_message(msg, this_module, this_procedure)
             write(msg,'(A14,E15.8,2X,E15.8)') '   INIT:', self%res(1), self%tol(1)
-            call logger%log_message(msg, this_module, this_procedure)
+            call log_message(msg, this_module, this_procedure)
             do i = 2, size(self%res) - 1
                write(msg,'(A,I4,A,E15.8,2X,E15.8)') '   Step ', i-1, ': ', self%res(i), self%tol(i)
-               call logger%log_message(msg, this_module, this_procedure)
+               call log_message(msg, this_module, this_procedure)
             end do
             i = size(self%res)
             write(msg,'(A14,E15.8,2X,E15.8)') '   FINAL:', self%res(i), self%tol(i)
-            call logger%log_message(msg, this_module, this_procedure)
+            call log_message(msg, this_module, this_procedure)
         else
             write(msg,'(A30,E20.8)') padr('Residual: ', 30), self%res(size(self%res))
-            call logger%log_message(msg, this_module, this_procedure)
+            call log_message(msg, this_module, this_procedure)
         end if
         if (self%converged) then
-            call logger%log_message('Status: CONVERGED', this_module, this_procedure)
+            call log_message('Status: CONVERGED', this_module, this_procedure)
         else
-            call logger%log_message('Status: NOT CONVERGED', this_module, this_procedure)
+            call log_message('Status: NOT CONVERGED', this_module, this_procedure)
         end if
         if (ifreset) call self%reset()
     end subroutine print_newton_sp
@@ -302,27 +302,27 @@ contains
         ifverbose = optval(verbose, .false.)
 
         write(msg,'(A30,I20)') padr('Iterations: ', 30), self%n_iter
-        call logger%log_message(msg, this_module, this_procedure)
+        call log_message(msg, this_module, this_procedure)
         if (ifverbose) then
             write(msg,'(14X,A15,2X,A15)') 'Residual', 'Tolerance'
-            call logger%log_message(msg, this_module, this_procedure)
+            call log_message(msg, this_module, this_procedure)
             write(msg,'(A14,E15.8,2X,E15.8)') '   INIT:', self%res(1), self%tol(1)
-            call logger%log_message(msg, this_module, this_procedure)
+            call log_message(msg, this_module, this_procedure)
             do i = 2, size(self%res) - 1
                write(msg,'(A,I4,A,E15.8,2X,E15.8)') '   Step ', i-1, ': ', self%res(i), self%tol(i)
-               call logger%log_message(msg, this_module, this_procedure)
+               call log_message(msg, this_module, this_procedure)
             end do
             i = size(self%res)
             write(msg,'(A14,E15.8,2X,E15.8)') '   FINAL:', self%res(i), self%tol(i)
-            call logger%log_message(msg, this_module, this_procedure)
+            call log_message(msg, this_module, this_procedure)
         else
             write(msg,'(A30,E20.8)') padr('Residual: ', 30), self%res(size(self%res))
-            call logger%log_message(msg, this_module, this_procedure)
+            call log_message(msg, this_module, this_procedure)
         end if
         if (self%converged) then
-            call logger%log_message('Status: CONVERGED', this_module, this_procedure)
+            call log_message('Status: CONVERGED', this_module, this_procedure)
         else
-            call logger%log_message('Status: NOT CONVERGED', this_module, this_procedure)
+            call log_message('Status: NOT CONVERGED', this_module, this_procedure)
         end if
         if (ifreset) call self%reset()
     end subroutine print_newton_dp
@@ -441,21 +441,21 @@ contains
         ! Check for lucky convergence.
         if (rnorm < target_tol) then
             write(msg,'(2(A,E11.4))') 'rnorm= ', rnorm, ', target= ', target_tol
-            call logger%log_warning(msg, this_module, this_procedure)
+            call log_warning(msg, this_module, this_procedure)
             write(msg,'(A)') 'Initial guess is a fixed point to tolerance!'
-            call logger%log_warning(msg, this_module, this_procedure)
+            call log_warning(msg, this_module, this_procedure)
             newton_meta%converged = .true.
             newton_meta%input_is_fixed_point = .true.
         end if
 
-        call logger%log_information('Starting Newton iteration ...', this_module, this_procedure)
+        call log_information('Starting Newton iteration ...', this_module, this_procedure)
         ! Newton iteration
         newton: do i = 1, maxiter
 
             ! Set dynamic tolerances for Newton iteration and linear solves.
             call tolerance_scheduler(tol, target_tol, rnorm, i, info)
             write(msg,"(A,I0,3(A,E11.4))") 'Start step ', i, ': rnorm= ', rnorm, ', tol= ', tol, ', target= ', target_tol
-            call logger%log_message(msg, this_module, this_procedure)
+            call log_message(msg, this_module, this_procedure)
 
             ! Define the Jacobian
             sys%jacobian%X = X
@@ -490,14 +490,14 @@ contains
 
                 if (rnorm < target_tol) then
                     write(msg,'(A,I0,A)') 'Newton iteration converged after ',i,' iterations.'
-                    call logger%log_message(msg, this_module, this_procedure)
+                    call log_message(msg, this_module, this_procedure)
                     ! Save metadata
                     call newton_meta%record(rnorm, target_tol)
                     newton_meta%converged = .true.
                     exit newton
                 else
                     write(msg,'(A)') 'Dynamic tolerance but not target tolerance reached. Continue iteration.'
-                    call logger%log_warning(msg, this_module, this_procedure)
+                    call log_warning(msg, this_module, this_procedure)
                 end if
                 end if
             end if
@@ -506,7 +506,7 @@ contains
 
         if (.not.newton_meta%converged) then
             write(msg,'(A,I0,A)') 'Newton iteration did not converge within', maxiter, 'steps.'
-            call logger%log_warning(msg, this_module, this_procedure)
+            call log_warning(msg, this_module, this_procedure)
             info = -1
         endif
 
@@ -610,21 +610,21 @@ contains
         ! Check for lucky convergence.
         if (rnorm < target_tol) then
             write(msg,'(2(A,E11.4))') 'rnorm= ', rnorm, ', target= ', target_tol
-            call logger%log_warning(msg, this_module, this_procedure)
+            call log_warning(msg, this_module, this_procedure)
             write(msg,'(A)') 'Initial guess is a fixed point to tolerance!'
-            call logger%log_warning(msg, this_module, this_procedure)
+            call log_warning(msg, this_module, this_procedure)
             newton_meta%converged = .true.
             newton_meta%input_is_fixed_point = .true.
         end if
 
-        call logger%log_information('Starting Newton iteration ...', this_module, this_procedure)
+        call log_information('Starting Newton iteration ...', this_module, this_procedure)
         ! Newton iteration
         newton: do i = 1, maxiter
 
             ! Set dynamic tolerances for Newton iteration and linear solves.
             call tolerance_scheduler(tol, target_tol, rnorm, i, info)
             write(msg,"(A,I0,3(A,E11.4))") 'Start step ', i, ': rnorm= ', rnorm, ', tol= ', tol, ', target= ', target_tol
-            call logger%log_message(msg, this_module, this_procedure)
+            call log_message(msg, this_module, this_procedure)
 
             ! Define the Jacobian
             sys%jacobian%X = X
@@ -659,14 +659,14 @@ contains
 
                 if (rnorm < target_tol) then
                     write(msg,'(A,I0,A)') 'Newton iteration converged after ',i,' iterations.'
-                    call logger%log_message(msg, this_module, this_procedure)
+                    call log_message(msg, this_module, this_procedure)
                     ! Save metadata
                     call newton_meta%record(rnorm, target_tol)
                     newton_meta%converged = .true.
                     exit newton
                 else
                     write(msg,'(A)') 'Dynamic tolerance but not target tolerance reached. Continue iteration.'
-                    call logger%log_warning(msg, this_module, this_procedure)
+                    call log_warning(msg, this_module, this_procedure)
                 end if
                 end if
             end if
@@ -675,7 +675,7 @@ contains
 
         if (.not.newton_meta%converged) then
             write(msg,'(A,I0,A)') 'Newton iteration did not converge within', maxiter, 'steps.'
-            call logger%log_warning(msg, this_module, this_procedure)
+            call log_warning(msg, this_module, this_procedure)
             info = -1
         endif
 
@@ -779,21 +779,21 @@ contains
         ! Check for lucky convergence.
         if (rnorm < target_tol) then
             write(msg,'(2(A,E11.4))') 'rnorm= ', rnorm, ', target= ', target_tol
-            call logger%log_warning(msg, this_module, this_procedure)
+            call log_warning(msg, this_module, this_procedure)
             write(msg,'(A)') 'Initial guess is a fixed point to tolerance!'
-            call logger%log_warning(msg, this_module, this_procedure)
+            call log_warning(msg, this_module, this_procedure)
             newton_meta%converged = .true.
             newton_meta%input_is_fixed_point = .true.
         end if
 
-        call logger%log_information('Starting Newton iteration ...', this_module, this_procedure)
+        call log_information('Starting Newton iteration ...', this_module, this_procedure)
         ! Newton iteration
         newton: do i = 1, maxiter
 
             ! Set dynamic tolerances for Newton iteration and linear solves.
             call tolerance_scheduler(tol, target_tol, rnorm, i, info)
             write(msg,"(A,I0,3(A,E11.4))") 'Start step ', i, ': rnorm= ', rnorm, ', tol= ', tol, ', target= ', target_tol
-            call logger%log_message(msg, this_module, this_procedure)
+            call log_message(msg, this_module, this_procedure)
 
             ! Define the Jacobian
             sys%jacobian%X = X
@@ -828,14 +828,14 @@ contains
 
                 if (rnorm < target_tol) then
                     write(msg,'(A,I0,A)') 'Newton iteration converged after ',i,' iterations.'
-                    call logger%log_message(msg, this_module, this_procedure)
+                    call log_message(msg, this_module, this_procedure)
                     ! Save metadata
                     call newton_meta%record(rnorm, target_tol)
                     newton_meta%converged = .true.
                     exit newton
                 else
                     write(msg,'(A)') 'Dynamic tolerance but not target tolerance reached. Continue iteration.'
-                    call logger%log_warning(msg, this_module, this_procedure)
+                    call log_warning(msg, this_module, this_procedure)
                 end if
                 end if
             end if
@@ -844,7 +844,7 @@ contains
 
         if (.not.newton_meta%converged) then
             write(msg,'(A,I0,A)') 'Newton iteration did not converge within', maxiter, 'steps.'
-            call logger%log_warning(msg, this_module, this_procedure)
+            call log_warning(msg, this_module, this_procedure)
             info = -1
         endif
 
@@ -948,21 +948,21 @@ contains
         ! Check for lucky convergence.
         if (rnorm < target_tol) then
             write(msg,'(2(A,E11.4))') 'rnorm= ', rnorm, ', target= ', target_tol
-            call logger%log_warning(msg, this_module, this_procedure)
+            call log_warning(msg, this_module, this_procedure)
             write(msg,'(A)') 'Initial guess is a fixed point to tolerance!'
-            call logger%log_warning(msg, this_module, this_procedure)
+            call log_warning(msg, this_module, this_procedure)
             newton_meta%converged = .true.
             newton_meta%input_is_fixed_point = .true.
         end if
 
-        call logger%log_information('Starting Newton iteration ...', this_module, this_procedure)
+        call log_information('Starting Newton iteration ...', this_module, this_procedure)
         ! Newton iteration
         newton: do i = 1, maxiter
 
             ! Set dynamic tolerances for Newton iteration and linear solves.
             call tolerance_scheduler(tol, target_tol, rnorm, i, info)
             write(msg,"(A,I0,3(A,E11.4))") 'Start step ', i, ': rnorm= ', rnorm, ', tol= ', tol, ', target= ', target_tol
-            call logger%log_message(msg, this_module, this_procedure)
+            call log_message(msg, this_module, this_procedure)
 
             ! Define the Jacobian
             sys%jacobian%X = X
@@ -997,14 +997,14 @@ contains
 
                 if (rnorm < target_tol) then
                     write(msg,'(A,I0,A)') 'Newton iteration converged after ',i,' iterations.'
-                    call logger%log_message(msg, this_module, this_procedure)
+                    call log_message(msg, this_module, this_procedure)
                     ! Save metadata
                     call newton_meta%record(rnorm, target_tol)
                     newton_meta%converged = .true.
                     exit newton
                 else
                     write(msg,'(A)') 'Dynamic tolerance but not target tolerance reached. Continue iteration.'
-                    call logger%log_warning(msg, this_module, this_procedure)
+                    call log_warning(msg, this_module, this_procedure)
                 end if
                 end if
             end if
@@ -1013,7 +1013,7 @@ contains
 
         if (.not.newton_meta%converged) then
             write(msg,'(A,I0,A)') 'Newton iteration did not converge within', maxiter, 'steps.'
-            call logger%log_warning(msg, this_module, this_procedure)
+            call log_warning(msg, this_module, this_procedure)
             info = -1
         endif
 
@@ -1075,11 +1075,11 @@ contains
         call sys%eval(X, residual, tol)
         res(4) = residual%norm()
         write(msg,'(*(A,E11.4),A)') 'res_old= ', res(1), ', res_new= ', res(4), ' (full step)'
-        call logger%log_information(msg, this_module, this_procedure)
+        call log_information(msg, this_module, this_procedure)
 
         if (res(4) > rold) then
             write(msg,'(A)') 'Start Newton step bisection ... '
-            call logger%log_information(msg, this_module, this_procedure)
+            call log_information(msg, this_module, this_procedure)
             ! compute new trial solutions
             do j = 2, 3
                 call copy(X, Xin)
@@ -1091,7 +1091,7 @@ contains
             do i = 1, maxstep
                 step = step * invphi
                 write(msg,'(4X,I0,A,4(1X,F6.4),A,4(1X,E11.4))') i, ': alpha=', alpha, ': res=', res
-                call logger%log_information(msg, this_module, this_procedure)
+                call log_information(msg, this_module, this_procedure)
                 if (res(2) < res(3)) then
                 ! alphas
                 ! a1 is kept
@@ -1120,7 +1120,7 @@ contains
                 res(3) = residual%norm()
                 end if
                 write(msg,'(4X,I0,2(A,F6.4))') i, ': New interval: ', alpha(1), ' <= alpha <= ', alpha(4)
-                call logger%log_information(msg, this_module, this_procedure)
+                call log_information(msg, this_module, this_procedure)
             end do
             ! set new vector to optimal step
             idx = minloc(res)
@@ -1128,12 +1128,12 @@ contains
                 call stop_error('Residual does not decrease!',this_module,this_procedure)
             end if
             write(msg,'(A,F6.4)') 'Optimal damping: alpha= ', alpha(idx(1))
-            call logger%log_information(msg, this_module, this_procedure)
+            call log_information(msg, this_module, this_procedure)
             call copy(X, Xin)
             call X%axpby(one_rsp, increment, alpha(idx(1)))
         else
             write(msg,'(A)') 'Full Newton step reduces the residual. Skip bisection.'
-            call logger%log_information(msg, this_module, this_procedure)
+            call log_information(msg, this_module, this_procedure)
         end if
     end subroutine increment_bisection_rsp
 
@@ -1175,11 +1175,11 @@ contains
         call sys%eval(X, residual, tol)
         res(4) = residual%norm()
         write(msg,'(*(A,E11.4),A)') 'res_old= ', res(1), ', res_new= ', res(4), ' (full step)'
-        call logger%log_information(msg, this_module, this_procedure)
+        call log_information(msg, this_module, this_procedure)
 
         if (res(4) > rold) then
             write(msg,'(A)') 'Start Newton step bisection ... '
-            call logger%log_information(msg, this_module, this_procedure)
+            call log_information(msg, this_module, this_procedure)
             ! compute new trial solutions
             do j = 2, 3
                 call copy(X, Xin)
@@ -1191,7 +1191,7 @@ contains
             do i = 1, maxstep
                 step = step * invphi
                 write(msg,'(4X,I0,A,4(1X,F6.4),A,4(1X,E11.4))') i, ': alpha=', alpha, ': res=', res
-                call logger%log_information(msg, this_module, this_procedure)
+                call log_information(msg, this_module, this_procedure)
                 if (res(2) < res(3)) then
                 ! alphas
                 ! a1 is kept
@@ -1220,7 +1220,7 @@ contains
                 res(3) = residual%norm()
                 end if
                 write(msg,'(4X,I0,2(A,F6.4))') i, ': New interval: ', alpha(1), ' <= alpha <= ', alpha(4)
-                call logger%log_information(msg, this_module, this_procedure)
+                call log_information(msg, this_module, this_procedure)
             end do
             ! set new vector to optimal step
             idx = minloc(res)
@@ -1228,12 +1228,12 @@ contains
                 call stop_error('Residual does not decrease!',this_module,this_procedure)
             end if
             write(msg,'(A,F6.4)') 'Optimal damping: alpha= ', alpha(idx(1))
-            call logger%log_information(msg, this_module, this_procedure)
+            call log_information(msg, this_module, this_procedure)
             call copy(X, Xin)
             call X%axpby(one_rdp, increment, alpha(idx(1)))
         else
             write(msg,'(A)') 'Full Newton step reduces the residual. Skip bisection.'
-            call logger%log_information(msg, this_module, this_procedure)
+            call log_information(msg, this_module, this_procedure)
         end if
     end subroutine increment_bisection_rdp
 
@@ -1275,11 +1275,11 @@ contains
         call sys%eval(X, residual, tol)
         res(4) = residual%norm()
         write(msg,'(*(A,E11.4),A)') 'res_old= ', res(1), ', res_new= ', res(4), ' (full step)'
-        call logger%log_information(msg, this_module, this_procedure)
+        call log_information(msg, this_module, this_procedure)
 
         if (res(4) > rold) then
             write(msg,'(A)') 'Start Newton step bisection ... '
-            call logger%log_information(msg, this_module, this_procedure)
+            call log_information(msg, this_module, this_procedure)
             ! compute new trial solutions
             do j = 2, 3
                 call copy(X, Xin)
@@ -1291,7 +1291,7 @@ contains
             do i = 1, maxstep
                 step = step * invphi
                 write(msg,'(4X,I0,A,4(1X,F6.4),A,4(1X,E11.4))') i, ': alpha=', alpha, ': res=', res
-                call logger%log_information(msg, this_module, this_procedure)
+                call log_information(msg, this_module, this_procedure)
                 if (res(2) < res(3)) then
                 ! alphas
                 ! a1 is kept
@@ -1320,7 +1320,7 @@ contains
                 res(3) = residual%norm()
                 end if
                 write(msg,'(4X,I0,2(A,F6.4))') i, ': New interval: ', alpha(1), ' <= alpha <= ', alpha(4)
-                call logger%log_information(msg, this_module, this_procedure)
+                call log_information(msg, this_module, this_procedure)
             end do
             ! set new vector to optimal step
             idx = minloc(res)
@@ -1328,12 +1328,12 @@ contains
                 call stop_error('Residual does not decrease!',this_module,this_procedure)
             end if
             write(msg,'(A,F6.4)') 'Optimal damping: alpha= ', alpha(idx(1))
-            call logger%log_information(msg, this_module, this_procedure)
+            call log_information(msg, this_module, this_procedure)
             call copy(X, Xin)
             call X%axpby(one_csp, increment, alpha(idx(1)))
         else
             write(msg,'(A)') 'Full Newton step reduces the residual. Skip bisection.'
-            call logger%log_information(msg, this_module, this_procedure)
+            call log_information(msg, this_module, this_procedure)
         end if
     end subroutine increment_bisection_csp
 
@@ -1375,11 +1375,11 @@ contains
         call sys%eval(X, residual, tol)
         res(4) = residual%norm()
         write(msg,'(*(A,E11.4),A)') 'res_old= ', res(1), ', res_new= ', res(4), ' (full step)'
-        call logger%log_information(msg, this_module, this_procedure)
+        call log_information(msg, this_module, this_procedure)
 
         if (res(4) > rold) then
             write(msg,'(A)') 'Start Newton step bisection ... '
-            call logger%log_information(msg, this_module, this_procedure)
+            call log_information(msg, this_module, this_procedure)
             ! compute new trial solutions
             do j = 2, 3
                 call copy(X, Xin)
@@ -1391,7 +1391,7 @@ contains
             do i = 1, maxstep
                 step = step * invphi
                 write(msg,'(4X,I0,A,4(1X,F6.4),A,4(1X,E11.4))') i, ': alpha=', alpha, ': res=', res
-                call logger%log_information(msg, this_module, this_procedure)
+                call log_information(msg, this_module, this_procedure)
                 if (res(2) < res(3)) then
                 ! alphas
                 ! a1 is kept
@@ -1420,7 +1420,7 @@ contains
                 res(3) = residual%norm()
                 end if
                 write(msg,'(4X,I0,2(A,F6.4))') i, ': New interval: ', alpha(1), ' <= alpha <= ', alpha(4)
-                call logger%log_information(msg, this_module, this_procedure)
+                call log_information(msg, this_module, this_procedure)
             end do
             ! set new vector to optimal step
             idx = minloc(res)
@@ -1428,12 +1428,12 @@ contains
                 call stop_error('Residual does not decrease!',this_module,this_procedure)
             end if
             write(msg,'(A,F6.4)') 'Optimal damping: alpha= ', alpha(idx(1))
-            call logger%log_information(msg, this_module, this_procedure)
+            call log_information(msg, this_module, this_procedure)
             call copy(X, Xin)
             call X%axpby(one_cdp, increment, alpha(idx(1)))
         else
             write(msg,'(A)') 'Full Newton step reduces the residual. Skip bisection.'
-            call logger%log_information(msg, this_module, this_procedure)
+            call log_information(msg, this_module, this_procedure)
         end if
     end subroutine increment_bisection_cdp
 
@@ -1461,10 +1461,10 @@ contains
         if (target_tol < atol_sp) then
             tol = atol_sp
             write(msg,'(A,E9.2)') 'Input tolerance below atol! Resetting solver tolerance to atol= ', tol
-            call logger%log_warning(msg, this_module, this_procedure)
+            call log_warning(msg, this_module, this_procedure)
         else
             write(msg,'(A,E9.2)') 'Solver tolerance set to tol= ', tol
-            call logger%log_information(msg, this_module, this_procedure)
+            call log_information(msg, this_module, this_procedure)
         end if
     end subroutine constant_tol_sp
 
@@ -1488,7 +1488,7 @@ contains
         target_tol_ = max(target_tol, atol_sp)
         if (target_tol < atol_sp) then
             write(msg,'(A,E9.2)') 'Input target tolerance below atol! Resetting target to atol= ', target_tol_
-            call logger%log_warning(msg, this_module, this_procedure)
+            call log_warning(msg, this_module, this_procedure)
         end if
         
         tol_old = tol
@@ -1500,10 +1500,10 @@ contains
             else
                 write(msg,'(A,E9.2)') 'Solver tolerance set to tol= ', tol
             end if
-            call logger%log_information(msg, this_module, this_procedure)
+            call log_information(msg, this_module, this_procedure)
         else
             write(msg,'(A,E9.2)') 'solver tolerances unchanged at tol= ', tol_old
-            call logger%log_information(msg, this_module, this_procedure)
+            call log_information(msg, this_module, this_procedure)
         end if
     end subroutine dynamic_tol_sp
 
@@ -1530,10 +1530,10 @@ contains
         if (target_tol < atol_dp) then
             tol = atol_dp
             write(msg,'(A,E9.2)') 'Input tolerance below atol! Resetting solver tolerance to atol= ', tol
-            call logger%log_warning(msg, this_module, this_procedure)
+            call log_warning(msg, this_module, this_procedure)
         else
             write(msg,'(A,E9.2)') 'Solver tolerance set to tol= ', tol
-            call logger%log_information(msg, this_module, this_procedure)
+            call log_information(msg, this_module, this_procedure)
         end if
     end subroutine constant_tol_dp
 
@@ -1557,7 +1557,7 @@ contains
         target_tol_ = max(target_tol, atol_dp)
         if (target_tol < atol_dp) then
             write(msg,'(A,E9.2)') 'Input target tolerance below atol! Resetting target to atol= ', target_tol_
-            call logger%log_warning(msg, this_module, this_procedure)
+            call log_warning(msg, this_module, this_procedure)
         end if
         
         tol_old = tol
@@ -1569,10 +1569,10 @@ contains
             else
                 write(msg,'(A,E9.2)') 'Solver tolerance set to tol= ', tol
             end if
-            call logger%log_information(msg, this_module, this_procedure)
+            call log_information(msg, this_module, this_procedure)
         else
             write(msg,'(A,E9.2)') 'solver tolerances unchanged at tol= ', tol_old
-            call logger%log_information(msg, this_module, this_procedure)
+            call log_information(msg, this_module, this_procedure)
         end if
     end subroutine dynamic_tol_dp
 

--- a/src/Newton/NewtonKrylov.f90
+++ b/src/Newton/NewtonKrylov.f90
@@ -440,69 +440,73 @@ contains
 
         ! Check for lucky convergence.
         if (rnorm < target_tol) then
+
             write(msg,'(2(A,E11.4))') 'rnorm= ', rnorm, ', target= ', target_tol
             call log_warning(msg, this_module, this_procedure)
             write(msg,'(A)') 'Initial guess is a fixed point to tolerance!'
             call log_warning(msg, this_module, this_procedure)
             newton_meta%converged = .true.
             newton_meta%input_is_fixed_point = .true.
-        end if
 
-        call log_information('Starting Newton iteration ...', this_module, this_procedure)
-        ! Newton iteration
-        newton: do i = 1, maxiter
+        else
 
-            ! Set dynamic tolerances for Newton iteration and linear solves.
-            call tolerance_scheduler(tol, target_tol, rnorm, i, info)
-            write(msg,"(A,I0,3(A,E11.4))") 'Start step ', i, ': rnorm= ', rnorm, ', tol= ', tol, ', target= ', target_tol
-            call log_message(msg, this_module, this_procedure)
+            call log_information('Starting Newton iteration ...', this_module, this_procedure)
+            ! Newton iteration
+            newton: do i = 1, maxiter
 
-            ! Define the Jacobian
-            sys%jacobian%X = X
-            
-            ! Solve the linear system using GMRES.
-            call residual%chsgn(); call increment%zero()
-            call solver(sys%jacobian, residual, increment, info, atol=tol, &
-                & preconditioner=preconditioner, options=linear_solver_options, transpose=.false.)
-            call check_info(info, 'linear_solver', this_module, this_procedure)
+                ! Set dynamic tolerances for Newton iteration and linear solves.
+                call tolerance_scheduler(tol, target_tol, rnorm, i, info)
+                write(msg,"(A,I0,3(A,E11.4))") 'Start step ', i, ': rnorm= ', rnorm, ', tol= ', tol, ', target= ', target_tol
+                call log_message(msg, this_module, this_procedure)
 
-            ! Update the solution and overwrite X0
-            if (opts%ifbisect) then
-                call increment_bisection_rsp(X, sys, increment, rnorm, tol, maxstep_bisection)
-            else
-                call X%add(increment)
-            endif
+                ! Define the Jacobian
+                sys%jacobian%X = X
+                
+                ! Solve the linear system using GMRES.
+                call residual%chsgn(); call increment%zero()
+                call solver(sys%jacobian, residual, increment, info, atol=tol, &
+                    & preconditioner=preconditioner, options=linear_solver_options, transpose=.false.)
+                call check_info(info, 'linear_solver', this_module, this_procedure)
 
-            ! Evaluate new residual
-            call sys%eval(X, residual, tol)
-            rnorm = residual%norm()
+                ! Update the solution and overwrite X0
+                if (opts%ifbisect) then
+                    call increment_bisection_rsp(X, sys, increment, rnorm, tol, maxstep_bisection)
+                else
+                    call X%add(increment)
+                endif
 
-            ! Save metadata.
-            newton_meta%n_iter = newton_meta%n_iter + 1
-            call newton_meta%record(rnorm, tol)
-
-            ! Check for convergence.
-            if (rnorm < tol) then
-                if (tol >= target_tol .and. tol < 100.0_sp*target_tol) then
-                ! the tolerances are not at the target, check the accurate residual
-                call sys%eval(X, residual, target_tol)
+                ! Evaluate new residual
+                call sys%eval(X, residual, tol)
                 rnorm = residual%norm()
 
-                if (rnorm < target_tol) then
-                    write(msg,'(A,I0,A)') 'Newton iteration converged after ',i,' iterations.'
-                    call log_message(msg, this_module, this_procedure)
-                    ! Save metadata
-                    call newton_meta%record(rnorm, target_tol)
-                    newton_meta%converged = .true.
-                    exit newton
-                else
-                    write(msg,'(A)') 'Dynamic tolerance but not target tolerance reached. Continue iteration.'
-                    call log_warning(msg, this_module, this_procedure)
-                end if
-                end if
-            end if
+                ! Save metadata.
+                newton_meta%n_iter = newton_meta%n_iter + 1
+                call newton_meta%record(rnorm, tol)
 
-        enddo newton
+                ! Check for convergence.
+                if (rnorm < tol) then
+                    if (tol >= target_tol .and. tol < 100.0_sp*target_tol) then
+                        ! the tolerances are not at the target, check the accurate residual
+                        call sys%eval(X, residual, target_tol)
+                        rnorm = residual%norm()
+
+                        if (rnorm < target_tol) then
+                            write(msg,'(A,I0,A)') 'Newton iteration converged after ',i,' iterations.'
+                            call log_message(msg, this_module, this_procedure)
+                            ! Save metadata
+                            call newton_meta%record(rnorm, target_tol)
+                            newton_meta%converged = .true.
+                            exit newton
+                        else
+                            write(msg,'(A)') 'Dynamic tolerance but not target tolerance reached. Continue.'
+                            call log_warning(msg, this_module, this_procedure)
+                        end if
+                    end if
+                end if
+
+            enddo newton
+
+        end if ! lucky convergence
 
         if (.not.newton_meta%converged) then
             write(msg,'(A,I0,A)') 'Newton iteration did not converge within', maxiter, 'steps.'
@@ -609,69 +613,73 @@ contains
 
         ! Check for lucky convergence.
         if (rnorm < target_tol) then
+
             write(msg,'(2(A,E11.4))') 'rnorm= ', rnorm, ', target= ', target_tol
             call log_warning(msg, this_module, this_procedure)
             write(msg,'(A)') 'Initial guess is a fixed point to tolerance!'
             call log_warning(msg, this_module, this_procedure)
             newton_meta%converged = .true.
             newton_meta%input_is_fixed_point = .true.
-        end if
 
-        call log_information('Starting Newton iteration ...', this_module, this_procedure)
-        ! Newton iteration
-        newton: do i = 1, maxiter
+        else
 
-            ! Set dynamic tolerances for Newton iteration and linear solves.
-            call tolerance_scheduler(tol, target_tol, rnorm, i, info)
-            write(msg,"(A,I0,3(A,E11.4))") 'Start step ', i, ': rnorm= ', rnorm, ', tol= ', tol, ', target= ', target_tol
-            call log_message(msg, this_module, this_procedure)
+            call log_information('Starting Newton iteration ...', this_module, this_procedure)
+            ! Newton iteration
+            newton: do i = 1, maxiter
 
-            ! Define the Jacobian
-            sys%jacobian%X = X
-            
-            ! Solve the linear system using GMRES.
-            call residual%chsgn(); call increment%zero()
-            call solver(sys%jacobian, residual, increment, info, atol=tol, &
-                & preconditioner=preconditioner, options=linear_solver_options, transpose=.false.)
-            call check_info(info, 'linear_solver', this_module, this_procedure)
+                ! Set dynamic tolerances for Newton iteration and linear solves.
+                call tolerance_scheduler(tol, target_tol, rnorm, i, info)
+                write(msg,"(A,I0,3(A,E11.4))") 'Start step ', i, ': rnorm= ', rnorm, ', tol= ', tol, ', target= ', target_tol
+                call log_message(msg, this_module, this_procedure)
 
-            ! Update the solution and overwrite X0
-            if (opts%ifbisect) then
-                call increment_bisection_rdp(X, sys, increment, rnorm, tol, maxstep_bisection)
-            else
-                call X%add(increment)
-            endif
+                ! Define the Jacobian
+                sys%jacobian%X = X
+                
+                ! Solve the linear system using GMRES.
+                call residual%chsgn(); call increment%zero()
+                call solver(sys%jacobian, residual, increment, info, atol=tol, &
+                    & preconditioner=preconditioner, options=linear_solver_options, transpose=.false.)
+                call check_info(info, 'linear_solver', this_module, this_procedure)
 
-            ! Evaluate new residual
-            call sys%eval(X, residual, tol)
-            rnorm = residual%norm()
+                ! Update the solution and overwrite X0
+                if (opts%ifbisect) then
+                    call increment_bisection_rdp(X, sys, increment, rnorm, tol, maxstep_bisection)
+                else
+                    call X%add(increment)
+                endif
 
-            ! Save metadata.
-            newton_meta%n_iter = newton_meta%n_iter + 1
-            call newton_meta%record(rnorm, tol)
-
-            ! Check for convergence.
-            if (rnorm < tol) then
-                if (tol >= target_tol .and. tol < 100.0_dp*target_tol) then
-                ! the tolerances are not at the target, check the accurate residual
-                call sys%eval(X, residual, target_tol)
+                ! Evaluate new residual
+                call sys%eval(X, residual, tol)
                 rnorm = residual%norm()
 
-                if (rnorm < target_tol) then
-                    write(msg,'(A,I0,A)') 'Newton iteration converged after ',i,' iterations.'
-                    call log_message(msg, this_module, this_procedure)
-                    ! Save metadata
-                    call newton_meta%record(rnorm, target_tol)
-                    newton_meta%converged = .true.
-                    exit newton
-                else
-                    write(msg,'(A)') 'Dynamic tolerance but not target tolerance reached. Continue iteration.'
-                    call log_warning(msg, this_module, this_procedure)
-                end if
-                end if
-            end if
+                ! Save metadata.
+                newton_meta%n_iter = newton_meta%n_iter + 1
+                call newton_meta%record(rnorm, tol)
 
-        enddo newton
+                ! Check for convergence.
+                if (rnorm < tol) then
+                    if (tol >= target_tol .and. tol < 100.0_dp*target_tol) then
+                        ! the tolerances are not at the target, check the accurate residual
+                        call sys%eval(X, residual, target_tol)
+                        rnorm = residual%norm()
+
+                        if (rnorm < target_tol) then
+                            write(msg,'(A,I0,A)') 'Newton iteration converged after ',i,' iterations.'
+                            call log_message(msg, this_module, this_procedure)
+                            ! Save metadata
+                            call newton_meta%record(rnorm, target_tol)
+                            newton_meta%converged = .true.
+                            exit newton
+                        else
+                            write(msg,'(A)') 'Dynamic tolerance but not target tolerance reached. Continue.'
+                            call log_warning(msg, this_module, this_procedure)
+                        end if
+                    end if
+                end if
+
+            enddo newton
+
+        end if ! lucky convergence
 
         if (.not.newton_meta%converged) then
             write(msg,'(A,I0,A)') 'Newton iteration did not converge within', maxiter, 'steps.'
@@ -778,69 +786,73 @@ contains
 
         ! Check for lucky convergence.
         if (rnorm < target_tol) then
+
             write(msg,'(2(A,E11.4))') 'rnorm= ', rnorm, ', target= ', target_tol
             call log_warning(msg, this_module, this_procedure)
             write(msg,'(A)') 'Initial guess is a fixed point to tolerance!'
             call log_warning(msg, this_module, this_procedure)
             newton_meta%converged = .true.
             newton_meta%input_is_fixed_point = .true.
-        end if
 
-        call log_information('Starting Newton iteration ...', this_module, this_procedure)
-        ! Newton iteration
-        newton: do i = 1, maxiter
+        else
 
-            ! Set dynamic tolerances for Newton iteration and linear solves.
-            call tolerance_scheduler(tol, target_tol, rnorm, i, info)
-            write(msg,"(A,I0,3(A,E11.4))") 'Start step ', i, ': rnorm= ', rnorm, ', tol= ', tol, ', target= ', target_tol
-            call log_message(msg, this_module, this_procedure)
+            call log_information('Starting Newton iteration ...', this_module, this_procedure)
+            ! Newton iteration
+            newton: do i = 1, maxiter
 
-            ! Define the Jacobian
-            sys%jacobian%X = X
-            
-            ! Solve the linear system using GMRES.
-            call residual%chsgn(); call increment%zero()
-            call solver(sys%jacobian, residual, increment, info, atol=tol, &
-                & preconditioner=preconditioner, options=linear_solver_options, transpose=.false.)
-            call check_info(info, 'linear_solver', this_module, this_procedure)
+                ! Set dynamic tolerances for Newton iteration and linear solves.
+                call tolerance_scheduler(tol, target_tol, rnorm, i, info)
+                write(msg,"(A,I0,3(A,E11.4))") 'Start step ', i, ': rnorm= ', rnorm, ', tol= ', tol, ', target= ', target_tol
+                call log_message(msg, this_module, this_procedure)
 
-            ! Update the solution and overwrite X0
-            if (opts%ifbisect) then
-                call increment_bisection_csp(X, sys, increment, rnorm, tol, maxstep_bisection)
-            else
-                call X%add(increment)
-            endif
+                ! Define the Jacobian
+                sys%jacobian%X = X
+                
+                ! Solve the linear system using GMRES.
+                call residual%chsgn(); call increment%zero()
+                call solver(sys%jacobian, residual, increment, info, atol=tol, &
+                    & preconditioner=preconditioner, options=linear_solver_options, transpose=.false.)
+                call check_info(info, 'linear_solver', this_module, this_procedure)
 
-            ! Evaluate new residual
-            call sys%eval(X, residual, tol)
-            rnorm = residual%norm()
+                ! Update the solution and overwrite X0
+                if (opts%ifbisect) then
+                    call increment_bisection_csp(X, sys, increment, rnorm, tol, maxstep_bisection)
+                else
+                    call X%add(increment)
+                endif
 
-            ! Save metadata.
-            newton_meta%n_iter = newton_meta%n_iter + 1
-            call newton_meta%record(rnorm, tol)
-
-            ! Check for convergence.
-            if (rnorm < tol) then
-                if (tol >= target_tol .and. tol < 100.0_sp*target_tol) then
-                ! the tolerances are not at the target, check the accurate residual
-                call sys%eval(X, residual, target_tol)
+                ! Evaluate new residual
+                call sys%eval(X, residual, tol)
                 rnorm = residual%norm()
 
-                if (rnorm < target_tol) then
-                    write(msg,'(A,I0,A)') 'Newton iteration converged after ',i,' iterations.'
-                    call log_message(msg, this_module, this_procedure)
-                    ! Save metadata
-                    call newton_meta%record(rnorm, target_tol)
-                    newton_meta%converged = .true.
-                    exit newton
-                else
-                    write(msg,'(A)') 'Dynamic tolerance but not target tolerance reached. Continue iteration.'
-                    call log_warning(msg, this_module, this_procedure)
-                end if
-                end if
-            end if
+                ! Save metadata.
+                newton_meta%n_iter = newton_meta%n_iter + 1
+                call newton_meta%record(rnorm, tol)
 
-        enddo newton
+                ! Check for convergence.
+                if (rnorm < tol) then
+                    if (tol >= target_tol .and. tol < 100.0_sp*target_tol) then
+                        ! the tolerances are not at the target, check the accurate residual
+                        call sys%eval(X, residual, target_tol)
+                        rnorm = residual%norm()
+
+                        if (rnorm < target_tol) then
+                            write(msg,'(A,I0,A)') 'Newton iteration converged after ',i,' iterations.'
+                            call log_message(msg, this_module, this_procedure)
+                            ! Save metadata
+                            call newton_meta%record(rnorm, target_tol)
+                            newton_meta%converged = .true.
+                            exit newton
+                        else
+                            write(msg,'(A)') 'Dynamic tolerance but not target tolerance reached. Continue.'
+                            call log_warning(msg, this_module, this_procedure)
+                        end if
+                    end if
+                end if
+
+            enddo newton
+
+        end if ! lucky convergence
 
         if (.not.newton_meta%converged) then
             write(msg,'(A,I0,A)') 'Newton iteration did not converge within', maxiter, 'steps.'
@@ -947,69 +959,73 @@ contains
 
         ! Check for lucky convergence.
         if (rnorm < target_tol) then
+
             write(msg,'(2(A,E11.4))') 'rnorm= ', rnorm, ', target= ', target_tol
             call log_warning(msg, this_module, this_procedure)
             write(msg,'(A)') 'Initial guess is a fixed point to tolerance!'
             call log_warning(msg, this_module, this_procedure)
             newton_meta%converged = .true.
             newton_meta%input_is_fixed_point = .true.
-        end if
 
-        call log_information('Starting Newton iteration ...', this_module, this_procedure)
-        ! Newton iteration
-        newton: do i = 1, maxiter
+        else
 
-            ! Set dynamic tolerances for Newton iteration and linear solves.
-            call tolerance_scheduler(tol, target_tol, rnorm, i, info)
-            write(msg,"(A,I0,3(A,E11.4))") 'Start step ', i, ': rnorm= ', rnorm, ', tol= ', tol, ', target= ', target_tol
-            call log_message(msg, this_module, this_procedure)
+            call log_information('Starting Newton iteration ...', this_module, this_procedure)
+            ! Newton iteration
+            newton: do i = 1, maxiter
 
-            ! Define the Jacobian
-            sys%jacobian%X = X
-            
-            ! Solve the linear system using GMRES.
-            call residual%chsgn(); call increment%zero()
-            call solver(sys%jacobian, residual, increment, info, atol=tol, &
-                & preconditioner=preconditioner, options=linear_solver_options, transpose=.false.)
-            call check_info(info, 'linear_solver', this_module, this_procedure)
+                ! Set dynamic tolerances for Newton iteration and linear solves.
+                call tolerance_scheduler(tol, target_tol, rnorm, i, info)
+                write(msg,"(A,I0,3(A,E11.4))") 'Start step ', i, ': rnorm= ', rnorm, ', tol= ', tol, ', target= ', target_tol
+                call log_message(msg, this_module, this_procedure)
 
-            ! Update the solution and overwrite X0
-            if (opts%ifbisect) then
-                call increment_bisection_cdp(X, sys, increment, rnorm, tol, maxstep_bisection)
-            else
-                call X%add(increment)
-            endif
+                ! Define the Jacobian
+                sys%jacobian%X = X
+                
+                ! Solve the linear system using GMRES.
+                call residual%chsgn(); call increment%zero()
+                call solver(sys%jacobian, residual, increment, info, atol=tol, &
+                    & preconditioner=preconditioner, options=linear_solver_options, transpose=.false.)
+                call check_info(info, 'linear_solver', this_module, this_procedure)
 
-            ! Evaluate new residual
-            call sys%eval(X, residual, tol)
-            rnorm = residual%norm()
+                ! Update the solution and overwrite X0
+                if (opts%ifbisect) then
+                    call increment_bisection_cdp(X, sys, increment, rnorm, tol, maxstep_bisection)
+                else
+                    call X%add(increment)
+                endif
 
-            ! Save metadata.
-            newton_meta%n_iter = newton_meta%n_iter + 1
-            call newton_meta%record(rnorm, tol)
-
-            ! Check for convergence.
-            if (rnorm < tol) then
-                if (tol >= target_tol .and. tol < 100.0_dp*target_tol) then
-                ! the tolerances are not at the target, check the accurate residual
-                call sys%eval(X, residual, target_tol)
+                ! Evaluate new residual
+                call sys%eval(X, residual, tol)
                 rnorm = residual%norm()
 
-                if (rnorm < target_tol) then
-                    write(msg,'(A,I0,A)') 'Newton iteration converged after ',i,' iterations.'
-                    call log_message(msg, this_module, this_procedure)
-                    ! Save metadata
-                    call newton_meta%record(rnorm, target_tol)
-                    newton_meta%converged = .true.
-                    exit newton
-                else
-                    write(msg,'(A)') 'Dynamic tolerance but not target tolerance reached. Continue iteration.'
-                    call log_warning(msg, this_module, this_procedure)
-                end if
-                end if
-            end if
+                ! Save metadata.
+                newton_meta%n_iter = newton_meta%n_iter + 1
+                call newton_meta%record(rnorm, tol)
 
-        enddo newton
+                ! Check for convergence.
+                if (rnorm < tol) then
+                    if (tol >= target_tol .and. tol < 100.0_dp*target_tol) then
+                        ! the tolerances are not at the target, check the accurate residual
+                        call sys%eval(X, residual, target_tol)
+                        rnorm = residual%norm()
+
+                        if (rnorm < target_tol) then
+                            write(msg,'(A,I0,A)') 'Newton iteration converged after ',i,' iterations.'
+                            call log_message(msg, this_module, this_procedure)
+                            ! Save metadata
+                            call newton_meta%record(rnorm, target_tol)
+                            newton_meta%converged = .true.
+                            exit newton
+                        else
+                            write(msg,'(A)') 'Dynamic tolerance but not target tolerance reached. Continue.'
+                            call log_warning(msg, this_module, this_procedure)
+                        end if
+                    end if
+                end if
+
+            enddo newton
+
+        end if ! lucky convergence
 
         if (.not.newton_meta%converged) then
             write(msg,'(A,I0,A)') 'Newton iteration did not converge within', maxiter, 'steps.'

--- a/src/Newton/NewtonKrylov.fypp
+++ b/src/Newton/NewtonKrylov.fypp
@@ -323,69 +323,73 @@ contains
 
         ! Check for lucky convergence.
         if (rnorm < target_tol) then
+
             write(msg,'(2(A,E11.4))') 'rnorm= ', rnorm, ', target= ', target_tol
             call log_warning(msg, this_module, this_procedure)
             write(msg,'(A)') 'Initial guess is a fixed point to tolerance!'
             call log_warning(msg, this_module, this_procedure)
             newton_meta%converged = .true.
             newton_meta%input_is_fixed_point = .true.
-        end if
 
-        call log_information('Starting Newton iteration ...', this_module, this_procedure)
-        ! Newton iteration
-        newton: do i = 1, maxiter
+        else
 
-            ! Set dynamic tolerances for Newton iteration and linear solves.
-            call tolerance_scheduler(tol, target_tol, rnorm, i, info)
-            write(msg,"(A,I0,3(A,E11.4))") 'Start step ', i, ': rnorm= ', rnorm, ', tol= ', tol, ', target= ', target_tol
-            call log_message(msg, this_module, this_procedure)
+            call log_information('Starting Newton iteration ...', this_module, this_procedure)
+            ! Newton iteration
+            newton: do i = 1, maxiter
 
-            ! Define the Jacobian
-            sys%jacobian%X = X
-            
-            ! Solve the linear system using GMRES.
-            call residual%chsgn(); call increment%zero()
-            call solver(sys%jacobian, residual, increment, info, atol=tol, &
-                & preconditioner=preconditioner, options=linear_solver_options, transpose=.false.)
-            call check_info(info, 'linear_solver', this_module, this_procedure)
+                ! Set dynamic tolerances for Newton iteration and linear solves.
+                call tolerance_scheduler(tol, target_tol, rnorm, i, info)
+                write(msg,"(A,I0,3(A,E11.4))") 'Start step ', i, ': rnorm= ', rnorm, ', tol= ', tol, ', target= ', target_tol
+                call log_message(msg, this_module, this_procedure)
 
-            ! Update the solution and overwrite X0
-            if (opts%ifbisect) then
-                call increment_bisection_${type[0]}$${kind}$(X, sys, increment, rnorm, tol, maxstep_bisection)
-            else
-                call X%add(increment)
-            endif
+                ! Define the Jacobian
+                sys%jacobian%X = X
+                
+                ! Solve the linear system using GMRES.
+                call residual%chsgn(); call increment%zero()
+                call solver(sys%jacobian, residual, increment, info, atol=tol, &
+                    & preconditioner=preconditioner, options=linear_solver_options, transpose=.false.)
+                call check_info(info, 'linear_solver', this_module, this_procedure)
 
-            ! Evaluate new residual
-            call sys%eval(X, residual, tol)
-            rnorm = residual%norm()
+                ! Update the solution and overwrite X0
+                if (opts%ifbisect) then
+                    call increment_bisection_${type[0]}$${kind}$(X, sys, increment, rnorm, tol, maxstep_bisection)
+                else
+                    call X%add(increment)
+                endif
 
-            ! Save metadata.
-            newton_meta%n_iter = newton_meta%n_iter + 1
-            call newton_meta%record(rnorm, tol)
-
-            ! Check for convergence.
-            if (rnorm < tol) then
-                if (tol >= target_tol .and. tol < 100.0_${kind}$*target_tol) then
-                ! the tolerances are not at the target, check the accurate residual
-                call sys%eval(X, residual, target_tol)
+                ! Evaluate new residual
+                call sys%eval(X, residual, tol)
                 rnorm = residual%norm()
 
-                if (rnorm < target_tol) then
-                    write(msg,'(A,I0,A)') 'Newton iteration converged after ',i,' iterations.'
-                    call log_message(msg, this_module, this_procedure)
-                    ! Save metadata
-                    call newton_meta%record(rnorm, target_tol)
-                    newton_meta%converged = .true.
-                    exit newton
-                else
-                    write(msg,'(A)') 'Dynamic tolerance but not target tolerance reached. Continue iteration.'
-                    call log_warning(msg, this_module, this_procedure)
-                end if
-                end if
-            end if
+                ! Save metadata.
+                newton_meta%n_iter = newton_meta%n_iter + 1
+                call newton_meta%record(rnorm, tol)
 
-        enddo newton
+                ! Check for convergence.
+                if (rnorm < tol) then
+                    if (tol >= target_tol .and. tol < 100.0_${kind}$*target_tol) then
+                        ! the tolerances are not at the target, check the accurate residual
+                        call sys%eval(X, residual, target_tol)
+                        rnorm = residual%norm()
+
+                        if (rnorm < target_tol) then
+                            write(msg,'(A,I0,A)') 'Newton iteration converged after ',i,' iterations.'
+                            call log_message(msg, this_module, this_procedure)
+                            ! Save metadata
+                            call newton_meta%record(rnorm, target_tol)
+                            newton_meta%converged = .true.
+                            exit newton
+                        else
+                            write(msg,'(A)') 'Dynamic tolerance but not target tolerance reached. Continue.'
+                            call log_warning(msg, this_module, this_procedure)
+                        end if
+                    end if
+                end if
+
+            enddo newton
+
+        end if ! lucky convergence
 
         if (.not.newton_meta%converged) then
             write(msg,'(A,I0,A)') 'Newton iteration did not converge within', maxiter, 'steps.'

--- a/src/Newton/NewtonKrylov.fypp
+++ b/src/Newton/NewtonKrylov.fypp
@@ -183,27 +183,27 @@ contains
         ifverbose = optval(verbose, .false.)
 
         write(msg,'(A30,I20)') padr('Iterations: ', 30), self%n_iter
-        call logger%log_message(msg, this_module, this_procedure)
+        call log_message(msg, this_module, this_procedure)
         if (ifverbose) then
             write(msg,'(14X,A15,2X,A15)') 'Residual', 'Tolerance'
-            call logger%log_message(msg, this_module, this_procedure)
+            call log_message(msg, this_module, this_procedure)
             write(msg,'(A14,E15.8,2X,E15.8)') '   INIT:', self%res(1), self%tol(1)
-            call logger%log_message(msg, this_module, this_procedure)
+            call log_message(msg, this_module, this_procedure)
             do i = 2, size(self%res) - 1
                write(msg,'(A,I4,A,E15.8,2X,E15.8)') '   Step ', i-1, ': ', self%res(i), self%tol(i)
-               call logger%log_message(msg, this_module, this_procedure)
+               call log_message(msg, this_module, this_procedure)
             end do
             i = size(self%res)
             write(msg,'(A14,E15.8,2X,E15.8)') '   FINAL:', self%res(i), self%tol(i)
-            call logger%log_message(msg, this_module, this_procedure)
+            call log_message(msg, this_module, this_procedure)
         else
             write(msg,'(A30,E20.8)') padr('Residual: ', 30), self%res(size(self%res))
-            call logger%log_message(msg, this_module, this_procedure)
+            call log_message(msg, this_module, this_procedure)
         end if
         if (self%converged) then
-            call logger%log_message('Status: CONVERGED', this_module, this_procedure)
+            call log_message('Status: CONVERGED', this_module, this_procedure)
         else
-            call logger%log_message('Status: NOT CONVERGED', this_module, this_procedure)
+            call log_message('Status: NOT CONVERGED', this_module, this_procedure)
         end if
         if (ifreset) call self%reset()
     end subroutine print_newton_${kind}$
@@ -324,21 +324,21 @@ contains
         ! Check for lucky convergence.
         if (rnorm < target_tol) then
             write(msg,'(2(A,E11.4))') 'rnorm= ', rnorm, ', target= ', target_tol
-            call logger%log_warning(msg, this_module, this_procedure)
+            call log_warning(msg, this_module, this_procedure)
             write(msg,'(A)') 'Initial guess is a fixed point to tolerance!'
-            call logger%log_warning(msg, this_module, this_procedure)
+            call log_warning(msg, this_module, this_procedure)
             newton_meta%converged = .true.
             newton_meta%input_is_fixed_point = .true.
         end if
 
-        call logger%log_information('Starting Newton iteration ...', this_module, this_procedure)
+        call log_information('Starting Newton iteration ...', this_module, this_procedure)
         ! Newton iteration
         newton: do i = 1, maxiter
 
             ! Set dynamic tolerances for Newton iteration and linear solves.
             call tolerance_scheduler(tol, target_tol, rnorm, i, info)
             write(msg,"(A,I0,3(A,E11.4))") 'Start step ', i, ': rnorm= ', rnorm, ', tol= ', tol, ', target= ', target_tol
-            call logger%log_message(msg, this_module, this_procedure)
+            call log_message(msg, this_module, this_procedure)
 
             ! Define the Jacobian
             sys%jacobian%X = X
@@ -373,14 +373,14 @@ contains
 
                 if (rnorm < target_tol) then
                     write(msg,'(A,I0,A)') 'Newton iteration converged after ',i,' iterations.'
-                    call logger%log_message(msg, this_module, this_procedure)
+                    call log_message(msg, this_module, this_procedure)
                     ! Save metadata
                     call newton_meta%record(rnorm, target_tol)
                     newton_meta%converged = .true.
                     exit newton
                 else
                     write(msg,'(A)') 'Dynamic tolerance but not target tolerance reached. Continue iteration.'
-                    call logger%log_warning(msg, this_module, this_procedure)
+                    call log_warning(msg, this_module, this_procedure)
                 end if
                 end if
             end if
@@ -389,7 +389,7 @@ contains
 
         if (.not.newton_meta%converged) then
             write(msg,'(A,I0,A)') 'Newton iteration did not converge within', maxiter, 'steps.'
-            call logger%log_warning(msg, this_module, this_procedure)
+            call log_warning(msg, this_module, this_procedure)
             info = -1
         endif
 
@@ -457,11 +457,11 @@ contains
         call sys%eval(X, residual, tol)
         res(4) = residual%norm()
         write(msg,'(*(A,E11.4),A)') 'res_old= ', res(1), ', res_new= ', res(4), ' (full step)'
-        call logger%log_information(msg, this_module, this_procedure)
+        call log_information(msg, this_module, this_procedure)
 
         if (res(4) > rold) then
             write(msg,'(A)') 'Start Newton step bisection ... '
-            call logger%log_information(msg, this_module, this_procedure)
+            call log_information(msg, this_module, this_procedure)
             ! compute new trial solutions
             do j = 2, 3
                 call copy(X, Xin)
@@ -473,7 +473,7 @@ contains
             do i = 1, maxstep
                 step = step * invphi
                 write(msg,'(4X,I0,A,4(1X,F6.4),A,4(1X,E11.4))') i, ': alpha=', alpha, ': res=', res
-                call logger%log_information(msg, this_module, this_procedure)
+                call log_information(msg, this_module, this_procedure)
                 if (res(2) < res(3)) then
                 ! alphas
                 ! a1 is kept
@@ -502,7 +502,7 @@ contains
                 res(3) = residual%norm()
                 end if
                 write(msg,'(4X,I0,2(A,F6.4))') i, ': New interval: ', alpha(1), ' <= alpha <= ', alpha(4)
-                call logger%log_information(msg, this_module, this_procedure)
+                call log_information(msg, this_module, this_procedure)
             end do
             ! set new vector to optimal step
             idx = minloc(res)
@@ -510,12 +510,12 @@ contains
                 call stop_error('Residual does not decrease!',this_module,this_procedure)
             end if
             write(msg,'(A,F6.4)') 'Optimal damping: alpha= ', alpha(idx(1))
-            call logger%log_information(msg, this_module, this_procedure)
+            call log_information(msg, this_module, this_procedure)
             call copy(X, Xin)
             call X%axpby(one_${type[0]}$${kind}$, increment, alpha(idx(1)))
         else
             write(msg,'(A)') 'Full Newton step reduces the residual. Skip bisection.'
-            call logger%log_information(msg, this_module, this_procedure)
+            call log_information(msg, this_module, this_procedure)
         end if
     end subroutine increment_bisection_${type[0]}$${kind}$
 
@@ -545,10 +545,10 @@ contains
         if (target_tol < atol_${kind}$) then
             tol = atol_${kind}$
             write(msg,'(A,E9.2)') 'Input tolerance below atol! Resetting solver tolerance to atol= ', tol
-            call logger%log_warning(msg, this_module, this_procedure)
+            call log_warning(msg, this_module, this_procedure)
         else
             write(msg,'(A,E9.2)') 'Solver tolerance set to tol= ', tol
-            call logger%log_information(msg, this_module, this_procedure)
+            call log_information(msg, this_module, this_procedure)
         end if
     end subroutine constant_tol_${kind}$
 
@@ -572,7 +572,7 @@ contains
         target_tol_ = max(target_tol, atol_${kind}$)
         if (target_tol < atol_${kind}$) then
             write(msg,'(A,E9.2)') 'Input target tolerance below atol! Resetting target to atol= ', target_tol_
-            call logger%log_warning(msg, this_module, this_procedure)
+            call log_warning(msg, this_module, this_procedure)
         end if
         
         tol_old = tol
@@ -584,10 +584,10 @@ contains
             else
                 write(msg,'(A,E9.2)') 'Solver tolerance set to tol= ', tol
             end if
-            call logger%log_information(msg, this_module, this_procedure)
+            call log_information(msg, this_module, this_procedure)
         else
             write(msg,'(A,E9.2)') 'solver tolerances unchanged at tol= ', tol_old
-            call logger%log_information(msg, this_module, this_procedure)
+            call log_information(msg, this_module, this_procedure)
         end if
     end subroutine dynamic_tol_${kind}$
 

--- a/src/Utilities/Logger.f90
+++ b/src/Utilities/Logger.f90
@@ -66,6 +66,7 @@ contains
       logical                       :: close_old_
       integer                       :: iunit_
       ! misc
+      character(len=128) :: msg
       integer :: stat
 
       logfile_ = optval(logfile, 'lightkrylov.log')
@@ -76,11 +77,15 @@ contains
       log_timestamp_ = optval(log_timestamp, .true.)
       close_old_ = optval(close_old, .true.)
 
-      ! Set I/O rank
-      if (nio_ /= 0) call set_io_rank(nio_)
-      
       ! Set up comms
       call comm_setup()
+      
+      ! Set I/O rank
+      if (nio_ /= 0) call set_io_rank(nio_)
+      if (io_rank()) then
+         write (msg, '(A,I0,A,I0)') 'IO rank = ', get_rank()
+         call logger%log_message(trim(msg), this_module, this_procedure)
+      end if
       
       if (io_rank()) then
          ! Flush log units
@@ -100,12 +105,12 @@ contains
             if (stat /= 0) call stop_error('Unable to add stdout to logger.', this_module, this_procedure)
          end if
 
-         ! mark that logger is active
-         logger_is_active = .true.
-
          ! return unit if requested
          if (present(iunit)) iunit = iunit_
       end if
+
+      ! mark that logger is active
+      logger_is_active = .true.
    end subroutine logger_setup
 
    subroutine log_message(msg, module, procedure, flush_log)
@@ -160,7 +165,7 @@ contains
       character(len=*), optional, intent(in)  :: procedure
       !! The name of the procedure in which the call happens
       if (logger_is_active) then
-         if (io_rank())  then
+         if (io_rank()) then
             call logger%log_warning(msg, module=module, procedure=procedure)
             call flush_log_units()
          end if
@@ -242,26 +247,30 @@ contains
       character(len=*), parameter :: this_procedure = 'comm_setup'
       character(len=128) :: msg
 #ifdef MPI
-      integer :: ierr, nid, comm_size
+      integer :: ierr, rank_local, size_local
       logical :: mpi_is_initialized
-      ! check if MPI has already been initialized and if not, initialize
+
       call MPI_Initialized(mpi_is_initialized, ierr)
       if (.not. mpi_is_initialized) then
-         if (io_rank()) call logger%log_message('Set up parallel run with MPI.', this_module, this_procedure)
          call MPI_Init(ierr)
          if (ierr /= MPI_SUCCESS) call stop_error("Error initializing MPI", this_module, this_procedure)
-      else
-         if (io_rank()) call logger%log_message('MPI already initialized.', this_module, this_procedure)
       end if
-      call MPI_Comm_rank(MPI_COMM_WORLD, nid, ierr); call set_rank(nid)
-      call MPI_Comm_size(MPI_COMM_WORLD, comm_size, ierr); call set_comm_size(comm_size)
-      write (msg, '(A,I0,A,I0)') 'IO rank = ', nid, ', comm_size = ', comm_size
-      if (io_rank()) call logger%log_message(trim(msg), this_module, this_procedure)
+
+      call MPI_Comm_rank(MPI_COMM_WORLD, rank_local, ierr)
+      call MPI_Comm_size(MPI_COMM_WORLD, size_local, ierr)
+      
+      call set_rank(rank_local)
+      call set_comm_size(size_local)
+
+      if (rank_local==0) then
+         call logger%log_message('Setup parallel run', this_module, this_procedure)
+         write (msg, '(A,I0,A,I0)') 'comm_size = ', size_local
+         call logger%log_message(trim(msg), this_module, this_procedure)
+      end if
 #else
-      write (msg, '(A)') 'Setup serial run'
       call set_rank(0)
       call set_comm_size(1)
-      call logger%log_message(trim(msg), this_module, this_procedure)
+      call logger%log_message('Setup serial run', this_module, this_procedure)
 #endif
    end subroutine comm_setup
 

--- a/src/Utilities/Timer_Utils.f90
+++ b/src/Utilities/Timer_Utils.f90
@@ -277,13 +277,13 @@ contains
       print_info = optval(verbose, .false.)
       if (self%running) then
          write (msg, '(A)') 'Timer "'//trim(self%name)//'" is curently running. Timer not reset.'
-         call logger%log_message(msg, this_module, 'reset_timer')
+         call log_message(msg, this_module, 'reset_timer')
       else
          write (msg, '(A,L1,3X,A,L1)') 'soft reset: ', save_data, 'flush timers: ', flush_timer
          if (print_info) then
-            call logger%log_message(msg, this_module, self%name)
+            call log_message(msg, this_module, self%name)
          else
-            call logger%log_debug(msg, this_module, self%name)
+            call log_debug(msg, this_module, self%name)
          end if
          if (save_data .and. .not. flush_timer) then
             if (self%local_count > 0) then
@@ -382,10 +382,10 @@ contains
       class(lightkrylov_timer), intent(inout) :: self
       ! internal
       character(len=128) :: msg
-      call logger%log_message('#########        Timer info        ##########', this_module)
+      call log_message('#########        Timer info        ##########', this_module)
       if (self%count == 0) then
          write (msg, '(A)') 'No timing data available for "'//trim(self%name)//'": Timer not called.'
-         call logger%log_message(msg, this_module)
+         call log_message(msg, this_module)
       else
          call print_summary_header('Summary', self%name)
          if (.not. self%is_finalized) then
@@ -413,7 +413,7 @@ contains
       self%is_finalized = .true.
       if (.not. silent) then
          write (msg, '(*(A))') trim(self%name), ' finalization complete.'
-         call logger%log_message(msg, this_module)
+         call log_message(msg, this_module)
          call self%print_info()
       end if
    end subroutine finalize_timer
@@ -445,7 +445,7 @@ contains
          if (self%user_mode) self%user_count = self%user_count + 1
       end if
       write (msg, '(A,I0)') 'Timer "'//trim(tname)//'" added: timer_count: ', self%timer_count
-      call logger%log_debug(msg, this_module)
+      call log_debug(msg, this_module)
       if (present(count)) count = self%timer_count
       if (start_) call self%start(tname)
    end subroutine add_timer
@@ -465,7 +465,7 @@ contains
       if (id == 0) call timer_not_found(tname, 'remove_timer')
       if (id <= self%private_count) then
          write (msg, '(A)') 'Cannot remove private timer "'//trim(tname)//'". Do nothing.'
-         call logger%log_message(msg, this_module, 'remove_timer')
+         call log_message(msg, this_module, 'remove_timer')
       else
          self%timer_count = self%timer_count - 1
          allocate (new_timers(self%timer_count))
@@ -474,7 +474,7 @@ contains
          deallocate (self%timers)
          self%timers = new_timers
          write (msg, '(A,I0)') 'Timer "'//trim(tname)//'" removed: timer_count: ', self%timer_count
-         call logger%log_debug(msg, this_module, 'remove_timer')
+         call log_debug(msg, this_module, 'remove_timer')
       end if
       if (present(count)) count = self%timer_count
    end subroutine remove_timer
@@ -509,7 +509,7 @@ contains
          self%group_count = self%group_count + 1
       end if
       write (msg, '(A,I0)') 'Timer group "'//trim(gname)//'" added: group_count: ', self%group_count
-      call logger%log_debug(msg, this_module)
+      call log_debug(msg, this_module)
       if (present(count)) count = self%group_count
    end subroutine add_group
 
@@ -559,7 +559,7 @@ contains
       id = self%get_timer_id(tname)
       if (id == 0) call timer_not_found(tname, 'start_timer_by_name')
       call self%timers(id)%start()
-      call logger%log_debug('Timer "'//trim(tname)//'" started.', this_module, self%name)
+      call log_debug('Timer "'//trim(tname)//'" started.', this_module, self%name)
    end subroutine start_timer_by_name
 
    subroutine stop_timer_by_name(self, name)
@@ -574,7 +574,7 @@ contains
       id = self%get_timer_id(tname)
       if (id == 0) call timer_not_found(tname, 'stop_timer_by_name')
       call self%timers(id)%stop()
-      call logger%log_debug('Timer "'//trim(tname)//'" stopped.', this_module, self%name)
+      call log_debug('Timer "'//trim(tname)//'" stopped.', this_module, self%name)
    end subroutine stop_timer_by_name
 
    subroutine pause_timer_by_name(self, name)
@@ -589,7 +589,7 @@ contains
       id = self%get_timer_id(tname)
       if (id == 0) call timer_not_found(tname, 'pause_timer_by_name')
       call self%timers(id)%pause()
-      call logger%log_debug('Timer "'//trim(tname)//'" paused.', this_module, self%name)
+      call log_debug('Timer "'//trim(tname)//'" paused.', this_module, self%name)
    end subroutine pause_timer_by_name
 
    subroutine reset_timer_by_name(self, name, soft, clean)
@@ -707,9 +707,9 @@ contains
       end do
       write (msg, '(A,2(A,I0))') 'All timers reset: ', 'private: ', self%private_count, &
             & ', user: ', self%user_count
-      call logger%log_message(msg, this_module, self%name)
+      call log_message(msg, this_module, self%name)
       write (msg, '(A,L,3X,A,L)') 'soft reset: ', soft_, 'flush timers: ', clean_
-      call logger%log_message(msg, this_module, self%name)
+      call log_message(msg, this_module, self%name)
    end subroutine reset_all
 
    subroutine enumerate(self, only_user)
@@ -724,23 +724,23 @@ contains
       fmt_e = '(2X,I3,A50," :",3(1X,I0))'
       only_user_ = optval(only_user, .false.)
       if (.not. only_user_) then
-         call logger%log_message('Registered timers: all', this_module, self%name)
+         call log_message('Registered timers: all', this_module, self%name)
          do i = 1, self%group_count
-            call logger%log_message(trim(self%groups(i)%name)//":", this_module)
+            call log_message(trim(self%groups(i)%name)//":", this_module)
             do j = self%groups(i)%istart, self%groups(i)%iend
                associate (t => self%timers(j))
                   write (msg, fmt_e) j, trim(t%name), t%count, t%local_count, t%reset_count
-                  call logger%log_message(msg, this_module)
+                  call log_message(msg, this_module)
                end associate
             end do
          end do
       end if
       if (self%user_count > 0) then
-         call logger%log_message('Registered timers: user', this_module, self%name)
+         call log_message('Registered timers: user', this_module, self%name)
          do i = self%private_count + 1, self%timer_count
             associate (t => self%timers(i))
                write (msg, fmt_e) i, trim(t%name), t%count, t%local_count, t%reset_count
-               call logger%log_message(msg, this_module)
+               call log_message(msg, this_module)
             end associate
          end do
       end if
@@ -804,26 +804,26 @@ contains
          call self%set_private_timers_and_name()
          self%private_count = self%timer_count
          write (msg, '(2(I0,A))') self%private_count, ' private timers registered in ', self%group_count, ' groups:'
-         call logger%log_information(msg, this_module, self%name)
+         call log_information(msg, this_module, self%name)
          do i = 1, self%group_count
             count = self%groups(i)%iend - self%groups(i)%istart + 1
             write (msg, '(3X,A20," : ",I3," timers.")') self%groups(i)%name, count
-            call logger%log_information(msg, this_module, self%name)
+            call log_information(msg, this_module, self%name)
          end do
          self%is_initialized = .true.
       else
          ! If the system timers have already been defined, we want to flush the data.
          call self%reset_all(soft=.false.)
          write (msg, '(3X,I4,A)') self%private_count, ' private timers registered and fully reset.'
-         call logger%log_information(msg, this_module, self%name)
+         call log_information(msg, this_module, self%name)
          if (self%user_count > 0) then
             write (msg, '(3X,I4,A)') self%user_count, ' user defined timers registered and fully reset.'
-            call logger%log_information(msg, this_module, self%name)
+            call log_information(msg, this_module, self%name)
          end if
       end if
       ! All subsequent timers that are added are user defined.
       self%user_mode = .true.
-      call logger%log_message('Private timer initialization complete.', this_module, self%name)
+      call log_message('Private timer initialization complete.', this_module, self%name)
    end subroutine initialize
 
    subroutine finalize(self, write_to_file)
@@ -854,15 +854,15 @@ contains
          end do
       end do
       ic_user = icalled
-      call logger%log_message('Timer finalization complete.', this_module, self%name)
-      call logger%log_message('#########   Global timer summary   ##########', this_module)
-      call logger%log_message('Overview:', this_module, self%name)
+      call log_message('Timer finalization complete.', this_module, self%name)
+      call log_message('#########   Global timer summary   ##########', this_module)
+      call log_message('Overview:', this_module, self%name)
       write (msg, '(2X,A60,I5)') 'Total active timers:', self%timer_count
-      call logger%log_message(msg, this_module)
+      call log_message(msg, this_module)
       write (msg, '(2X,A60,I5)') 'User defined:', self%user_count
-      call logger%log_message(msg, this_module)
+      call log_message(msg, this_module)
       write (msg, '(2X,A60,I5)') 'Called timers:', sum(ic) + ic_user
-      call logger%log_message(msg, this_module)
+      call log_message(msg, this_module)
       do i = 1, self%group_count
          if (ic(i) > 0) then
             associate (g => self%groups(i))
@@ -893,10 +893,10 @@ contains
       character(len=*), intent(in) :: watch_name
       ! internal
       character(len=128) :: msg
-      call logger%log_message(trim(section_name)//':', this_module, watch_name)
+      call log_message(trim(section_name)//':', this_module, watch_name)
       write (msg, fmt_h) 'name', 'calls', 'total (s)', 'avg (s)', 'min (s)', 'max (s)'
-      call logger%log_message(msg, this_module)
-      call logger%log_message('_____________________________________________', this_module)
+      call log_message(msg, this_module)
+      call log_message('_____________________________________________', this_module)
    end subroutine print_summary_header
 
    subroutine print_summary(t)
@@ -919,12 +919,12 @@ contains
       end do
       if (count == 1) then
          write (msg, fmt_1) trim(t%name), 'total', count, t%etime_data(1), '-', '-', '-'
-         call logger%log_message(msg, this_module)
+         call log_message(msg, this_module)
       else if (count > 1) then
          etime = sum(t%etime_data)
          etavg = sum(t%etavg_data)/count2
          write (msg, fmt_t) trim(t%name), 'total', count, etime, etavg, etmin, etmax
-         call logger%log_message(msg, this_module)
+         call log_message(msg, this_module)
          if (t%reset_count > 1) then
             do i = 1, t%reset_count
                etime = t%etime_data(i)
@@ -937,7 +937,7 @@ contains
                else
                   write (msg, fmt_n) 'reset', i, count, 'not called'
                end if
-               call logger%log_message(msg, this_module)
+               call log_message(msg, this_module)
             end do
          end if
       end if


### PR DESCRIPTION
Small updates
- [x] : Fix of the warning for rand_basis --> included in fypp file.
- [x] : Change the behaviour of the Newton solver if the initial guess is already a fixed point. The new version skips all computation instead of entering the newton loop and performing at least a linear solves (single GMRES step to convergence) and a non-linear eval to acertain convergence.  In the new version, these unnecessary steps are skipped.

**NOTE** 
I did not pay attention and created the branch off of the last PR. So only merge this PR after #243 for a clean log.