### PR TITLE
Saunders-Simon-Yip process

### DIFF
--- a/src/Krylov/BaseKrylov.f90
+++ b/src/Krylov/BaseKrylov.f90
@@ -490,10 +490,10 @@ module LightKrylov_BaseKrylov
         !! Linear operator to be factorized.
         class(abstract_vector_rsp), intent(inout) :: U(:)
         !! Orthonormal basis for the column span of \(\mathbf{A}\). On entry, `U(1)` needs to
-        !! be set to the starting Krylov vector b (with unit norm).
+        !! be set to the starting Krylov vector b (non-normalized).
         class(abstract_vector_rsp), intent(inout) :: V(:)
         !! Orthonormal basis for the row span of \(\mathbf{A}\). On entry, `V(1)` needs to
-        !! be set to the starting Krylov vector c (with unit norm).
+        !! be set to the starting Krylov vector c (non-normalized).
         real(sp), intent(inout) :: T(:, :)
         !! Tridiagonal matrix.
         integer, intent(out) :: info
@@ -511,10 +511,10 @@ module LightKrylov_BaseKrylov
         !! Linear operator to be factorized.
         class(abstract_vector_rdp), intent(inout) :: U(:)
         !! Orthonormal basis for the column span of \(\mathbf{A}\). On entry, `U(1)` needs to
-        !! be set to the starting Krylov vector b (with unit norm).
+        !! be set to the starting Krylov vector b (non-normalized).
         class(abstract_vector_rdp), intent(inout) :: V(:)
         !! Orthonormal basis for the row span of \(\mathbf{A}\). On entry, `V(1)` needs to
-        !! be set to the starting Krylov vector c (with unit norm).
+        !! be set to the starting Krylov vector c (non-normalized).
         real(dp), intent(inout) :: T(:, :)
         !! Tridiagonal matrix.
         integer, intent(out) :: info
@@ -532,10 +532,10 @@ module LightKrylov_BaseKrylov
         !! Linear operator to be factorized.
         class(abstract_vector_csp), intent(inout) :: U(:)
         !! Orthonormal basis for the column span of \(\mathbf{A}\). On entry, `U(1)` needs to
-        !! be set to the starting Krylov vector b (with unit norm).
+        !! be set to the starting Krylov vector b (non-normalized).
         class(abstract_vector_csp), intent(inout) :: V(:)
         !! Orthonormal basis for the row span of \(\mathbf{A}\). On entry, `V(1)` needs to
-        !! be set to the starting Krylov vector c (with unit norm).
+        !! be set to the starting Krylov vector c (non-normalized).
         complex(sp), intent(inout) :: T(:, :)
         !! Tridiagonal matrix.
         integer, intent(out) :: info
@@ -553,10 +553,10 @@ module LightKrylov_BaseKrylov
         !! Linear operator to be factorized.
         class(abstract_vector_cdp), intent(inout) :: U(:)
         !! Orthonormal basis for the column span of \(\mathbf{A}\). On entry, `U(1)` needs to
-        !! be set to the starting Krylov vector b (with unit norm).
+        !! be set to the starting Krylov vector b (non-normalized).
         class(abstract_vector_cdp), intent(inout) :: V(:)
         !! Orthonormal basis for the row span of \(\mathbf{A}\). On entry, `V(1)` needs to
-        !! be set to the starting Krylov vector c (with unit norm).
+        !! be set to the starting Krylov vector c (non-normalized).
         complex(dp), intent(inout) :: T(:, :)
         !! Tridiagonal matrix.
         integer, intent(out) :: info

--- a/src/Krylov/BaseKrylov.f90
+++ b/src/Krylov/BaseKrylov.f90
@@ -35,6 +35,7 @@ module LightKrylov_BaseKrylov
     public :: arnoldi
     public :: bidiagonalization
     public :: lanczos
+    public :: ssy
 
     !----- Utility functions ------
     public :: qr
@@ -479,6 +480,94 @@ module LightKrylov_BaseKrylov
             !! Tolerance to determine whether invariant subspaces have been computed or not.
         end subroutine lanczos_bidiagonalization_cdp
 
+    end interface
+
+
+    interface ssy
+    module subroutine ssy_rsp(A, U, V, T, info, kstart, kend, tol)
+        implicit none (type, external)
+        class(abstract_linop_rsp), intent(inout) :: A
+        !! Linear operator to be factorized.
+        class(abstract_vector_rsp), intent(inout) :: U(:)
+        !! Orthonormal basis for the column span of \(\mathbf{A}\). On entry, `U(1)` needs to
+        !! be set to the starting Krylov vector b (with unit norm).
+        class(abstract_vector_rsp), intent(inout) :: V(:)
+        !! Orthonormal basis for the row span of \(\mathbf{A}\). On entry, `V(1)` needs to
+        !! be set to the starting Krylov vector c (with unit norm).
+        real(sp), intent(inout) :: T(:, :)
+        !! Tridiagonal matrix.
+        integer, intent(out) :: info
+        !! Information flag.
+        integer, optional, intent(in) :: kstart
+        !! Starting index for the SSY factorization (default 1)
+        integer, optional, intent(in) :: kend
+        !! Final index for the SSY factorization (default size(U)).
+        real(sp), optional, intent(in) :: tol
+        !! Tolerance to determine whether invariant subspaces have been computed or not.
+    end subroutine ssy_rsp
+    module subroutine ssy_rdp(A, U, V, T, info, kstart, kend, tol)
+        implicit none (type, external)
+        class(abstract_linop_rdp), intent(inout) :: A
+        !! Linear operator to be factorized.
+        class(abstract_vector_rdp), intent(inout) :: U(:)
+        !! Orthonormal basis for the column span of \(\mathbf{A}\). On entry, `U(1)` needs to
+        !! be set to the starting Krylov vector b (with unit norm).
+        class(abstract_vector_rdp), intent(inout) :: V(:)
+        !! Orthonormal basis for the row span of \(\mathbf{A}\). On entry, `V(1)` needs to
+        !! be set to the starting Krylov vector c (with unit norm).
+        real(dp), intent(inout) :: T(:, :)
+        !! Tridiagonal matrix.
+        integer, intent(out) :: info
+        !! Information flag.
+        integer, optional, intent(in) :: kstart
+        !! Starting index for the SSY factorization (default 1)
+        integer, optional, intent(in) :: kend
+        !! Final index for the SSY factorization (default size(U)).
+        real(dp), optional, intent(in) :: tol
+        !! Tolerance to determine whether invariant subspaces have been computed or not.
+    end subroutine ssy_rdp
+    module subroutine ssy_csp(A, U, V, T, info, kstart, kend, tol)
+        implicit none (type, external)
+        class(abstract_linop_csp), intent(inout) :: A
+        !! Linear operator to be factorized.
+        class(abstract_vector_csp), intent(inout) :: U(:)
+        !! Orthonormal basis for the column span of \(\mathbf{A}\). On entry, `U(1)` needs to
+        !! be set to the starting Krylov vector b (with unit norm).
+        class(abstract_vector_csp), intent(inout) :: V(:)
+        !! Orthonormal basis for the row span of \(\mathbf{A}\). On entry, `V(1)` needs to
+        !! be set to the starting Krylov vector c (with unit norm).
+        complex(sp), intent(inout) :: T(:, :)
+        !! Tridiagonal matrix.
+        integer, intent(out) :: info
+        !! Information flag.
+        integer, optional, intent(in) :: kstart
+        !! Starting index for the SSY factorization (default 1)
+        integer, optional, intent(in) :: kend
+        !! Final index for the SSY factorization (default size(U)).
+        real(sp), optional, intent(in) :: tol
+        !! Tolerance to determine whether invariant subspaces have been computed or not.
+    end subroutine ssy_csp
+    module subroutine ssy_cdp(A, U, V, T, info, kstart, kend, tol)
+        implicit none (type, external)
+        class(abstract_linop_cdp), intent(inout) :: A
+        !! Linear operator to be factorized.
+        class(abstract_vector_cdp), intent(inout) :: U(:)
+        !! Orthonormal basis for the column span of \(\mathbf{A}\). On entry, `U(1)` needs to
+        !! be set to the starting Krylov vector b (with unit norm).
+        class(abstract_vector_cdp), intent(inout) :: V(:)
+        !! Orthonormal basis for the row span of \(\mathbf{A}\). On entry, `V(1)` needs to
+        !! be set to the starting Krylov vector c (with unit norm).
+        complex(dp), intent(inout) :: T(:, :)
+        !! Tridiagonal matrix.
+        integer, intent(out) :: info
+        !! Information flag.
+        integer, optional, intent(in) :: kstart
+        !! Starting index for the SSY factorization (default 1)
+        integer, optional, intent(in) :: kend
+        !! Final index for the SSY factorization (default size(U)).
+        real(dp), optional, intent(in) :: tol
+        !! Tolerance to determine whether invariant subspaces have been computed or not.
+    end subroutine ssy_cdp
     end interface
 
     !-------------------------------------

--- a/src/Krylov/BaseKrylov.f90
+++ b/src/Krylov/BaseKrylov.f90
@@ -412,7 +412,7 @@ module LightKrylov_BaseKrylov
             integer, optional, intent(in) :: kstart
             !! Starting index for the Lanczos factorization (default 1).
             integer, optional, intent(in) :: kend
-            !! Final index for the Lanczos factorization (default 1).
+            !! Final index for the Lanczos factorization (default size(U) - 1).
             real(sp), optional, intent(in) :: tol
             !! Tolerance to determine whether invariant subspaces have been computed or not.
         end subroutine lanczos_bidiagonalization_rsp
@@ -433,7 +433,7 @@ module LightKrylov_BaseKrylov
             integer, optional, intent(in) :: kstart
             !! Starting index for the Lanczos factorization (default 1).
             integer, optional, intent(in) :: kend
-            !! Final index for the Lanczos factorization (default 1).
+            !! Final index for the Lanczos factorization (default size(U) - 1).
             real(dp), optional, intent(in) :: tol
             !! Tolerance to determine whether invariant subspaces have been computed or not.
         end subroutine lanczos_bidiagonalization_rdp
@@ -454,7 +454,7 @@ module LightKrylov_BaseKrylov
             integer, optional, intent(in) :: kstart
             !! Starting index for the Lanczos factorization (default 1).
             integer, optional, intent(in) :: kend
-            !! Final index for the Lanczos factorization (default 1).
+            !! Final index for the Lanczos factorization (default size(U) - 1).
             real(sp), optional, intent(in) :: tol
             !! Tolerance to determine whether invariant subspaces have been computed or not.
         end subroutine lanczos_bidiagonalization_csp
@@ -475,7 +475,7 @@ module LightKrylov_BaseKrylov
             integer, optional, intent(in) :: kstart
             !! Starting index for the Lanczos factorization (default 1).
             integer, optional, intent(in) :: kend
-            !! Final index for the Lanczos factorization (default 1).
+            !! Final index for the Lanczos factorization (default size(U) - 1).
             real(dp), optional, intent(in) :: tol
             !! Tolerance to determine whether invariant subspaces have been computed or not.
         end subroutine lanczos_bidiagonalization_cdp
@@ -484,15 +484,92 @@ module LightKrylov_BaseKrylov
 
 
     interface ssy
+        !! ### Description
+        !!
+        !!  Given a linear operator \( A \) with full column rank and the associated saddle-point problem
+        !!
+        !!  \[
+        !!      \begin{bmatrix}
+        !!          I & A \\
+        !!          A^\top &
+        !!      \end{bmatrix}
+        !!      \begin{bmatrix}
+        !!          x \\ y
+        !!      \end{bmatrix}
+        !!      =
+        !!      \begin{bmatrix}
+        !!          b \\ c
+        !!      \end{bmatrix},
+        !!  \]
+        !!
+        !!  the Saunders-Simon-Yip factorization computes orthonormal bases \( U \) and \( V \) for the column-span
+        !!  and of \( AA^\top \) and \( A^\top A \), respectively, and a tridiagonal matrix \( T \) such that
+        !!
+        !!  \[
+        !!      U^\top A V = T.
+        !!  \]
+        !!
+        !!  with \( \beta u_1 = b \) and \( \gamma v_1 = c \).
+        !!
+        !!  **Algorithmic Features**
+        !!
+        !!  - The operator \(A\) only needs to be accessed through matrix-vector products.
+        !!  - Constructs an orthonormal basis for the Krylov subspace \(\mathcal{K} = \left( b, AA^\top b, \cdots \right)\).
+        !!  - Constructs an orthonormal basis for the Krylov subspace \(\mathcal{K} = \left( c, A^\top A c, \cdots, \right)\).
+        !!  - Constructs a tridiagonal matrix \( T \) such that \( U^\top A V = T \).
+        !!  - Checks for convergence and invariant subspaces.
+        !!
+        !!  **References**
+        !!
+        !!  - A. Buttari, D. Orban, D. Ruiz, and D. Titly-Peloquin. "A tridiagonalization method for
+        !!   symmetric saddle-point systems". SIAM Journal on Scientific Computing, 41(5), 2019.
+        !!  [(PDF)](https://hal.science/hal-02343661/file/A_Tridiagonalization_Method_for_Symmetric_Saddle_Point_and_Quasi_Definite_Systems_.pdf)
+        !!
+        !!  ### Syntax
+        !!
+        !!  ```fortran
+        !!      call ssy(A, U, V, T, info [, kstart] [, kend] [, tol])
+        !!  ```
+        !!
+        !!  ### Arguments
+        !!
+        !!  - `A`   :   Linear operator derived from one the base types provided by the
+        !!              `AbstractLinops` module. It is an `intent(inout)` argument.
+        !!
+        !!  - `U`   :   Arrays of types derived from one the base types provided by the `AbstractVectors`
+        !!              module. It needs to be consistent with the type of `A`. On entry, `U(1) = b`.
+        !!              On exit, it contains an orthonormal basis for \(\mathcal{K} = \left(b, A A^\top b, \cdots \right)\).
+        !!              It is an `intent(inout)` argument.
+        !!
+        !!  - `V`   :   Arrays of types derived from one the base types provided by the `AbstractVectors`
+        !!              module. It needs to be consistent with the type o f`A`. On entry, `V(1) = c`.
+        !!              On exit, it contains an orthonormal basis for \(\mathcal{K} = \left(c, A^\top A c, \cdots \right)\).
+        !!              It is an `intent(inout)` argument.
+        !!
+        !!  - `T`   :   `real` or `complex` rank-2 array. On exit, it contains the \((k+1) \times (k+1)\)
+        !!              tridiagonal matrix computed from the SSY factorization. It is an `intent(inout)` argument.
+        !!
+        !!  - `info`    :   `integer` variable. It is the `LightKrylov` information flag. On exit, if `info > 0`
+        !!                  the SSY process experienced a lucky breakdown.
+        !!
+        !!  - `kstart` (*optional*) :   `integer` value determining the index of the first SSY step to be
+        !!                              computed. It is an optional `intent(in)` argument. By default, `kstart = 1`.
+        !!
+        !!  - `kend` (*optional*)   :   `integer` value determining the index of the last SSY step to be computed.
+        !!                              It is an optional `intent(in)` argument. By default, `kend = size(U) - 1`.
+        !!
+        !!  - `tol` (*optional*)    :   Numerical tolerance below which a subspace is considered to be \(A\)-invariant.
+        !!                              It is an optional `intent(in)` argument. By default `tol = atol_sp` or
+        !!                              `tol = atol_dp` depending on the kind of `A`.
     module subroutine ssy_rsp(A, U, V, T, info, kstart, kend, tol)
         implicit none (type, external)
         class(abstract_linop_rsp), intent(inout) :: A
         !! Linear operator to be factorized.
         class(abstract_vector_rsp), intent(inout) :: U(:)
-        !! Orthonormal basis for the column span of \(\mathbf{A}\). On entry, `U(1)` needs to
+        !! Orthonormal basis for the span of \(AA^\top\). On entry, `U(1)` needs to
         !! be set to the starting Krylov vector b (non-normalized).
         class(abstract_vector_rsp), intent(inout) :: V(:)
-        !! Orthonormal basis for the row span of \(\mathbf{A}\). On entry, `V(1)` needs to
+        !! Orthonormal basis for the row span of \(A^\top A\). On entry, `V(1)` needs to
         !! be set to the starting Krylov vector c (non-normalized).
         real(sp), intent(inout) :: T(:, :)
         !! Tridiagonal matrix.
@@ -501,7 +578,7 @@ module LightKrylov_BaseKrylov
         integer, optional, intent(in) :: kstart
         !! Starting index for the SSY factorization (default 1)
         integer, optional, intent(in) :: kend
-        !! Final index for the SSY factorization (default size(U)).
+        !! Final index for the SSY factorization (default size(U)-1).
         real(sp), optional, intent(in) :: tol
         !! Tolerance to determine whether invariant subspaces have been computed or not.
     end subroutine ssy_rsp
@@ -510,10 +587,10 @@ module LightKrylov_BaseKrylov
         class(abstract_linop_rdp), intent(inout) :: A
         !! Linear operator to be factorized.
         class(abstract_vector_rdp), intent(inout) :: U(:)
-        !! Orthonormal basis for the column span of \(\mathbf{A}\). On entry, `U(1)` needs to
+        !! Orthonormal basis for the span of \(AA^\top\). On entry, `U(1)` needs to
         !! be set to the starting Krylov vector b (non-normalized).
         class(abstract_vector_rdp), intent(inout) :: V(:)
-        !! Orthonormal basis for the row span of \(\mathbf{A}\). On entry, `V(1)` needs to
+        !! Orthonormal basis for the row span of \(A^\top A\). On entry, `V(1)` needs to
         !! be set to the starting Krylov vector c (non-normalized).
         real(dp), intent(inout) :: T(:, :)
         !! Tridiagonal matrix.
@@ -522,7 +599,7 @@ module LightKrylov_BaseKrylov
         integer, optional, intent(in) :: kstart
         !! Starting index for the SSY factorization (default 1)
         integer, optional, intent(in) :: kend
-        !! Final index for the SSY factorization (default size(U)).
+        !! Final index for the SSY factorization (default size(U)-1).
         real(dp), optional, intent(in) :: tol
         !! Tolerance to determine whether invariant subspaces have been computed or not.
     end subroutine ssy_rdp
@@ -531,10 +608,10 @@ module LightKrylov_BaseKrylov
         class(abstract_linop_csp), intent(inout) :: A
         !! Linear operator to be factorized.
         class(abstract_vector_csp), intent(inout) :: U(:)
-        !! Orthonormal basis for the column span of \(\mathbf{A}\). On entry, `U(1)` needs to
+        !! Orthonormal basis for the span of \(AA^\top\). On entry, `U(1)` needs to
         !! be set to the starting Krylov vector b (non-normalized).
         class(abstract_vector_csp), intent(inout) :: V(:)
-        !! Orthonormal basis for the row span of \(\mathbf{A}\). On entry, `V(1)` needs to
+        !! Orthonormal basis for the row span of \(A^\top A\). On entry, `V(1)` needs to
         !! be set to the starting Krylov vector c (non-normalized).
         complex(sp), intent(inout) :: T(:, :)
         !! Tridiagonal matrix.
@@ -543,7 +620,7 @@ module LightKrylov_BaseKrylov
         integer, optional, intent(in) :: kstart
         !! Starting index for the SSY factorization (default 1)
         integer, optional, intent(in) :: kend
-        !! Final index for the SSY factorization (default size(U)).
+        !! Final index for the SSY factorization (default size(U)-1).
         real(sp), optional, intent(in) :: tol
         !! Tolerance to determine whether invariant subspaces have been computed or not.
     end subroutine ssy_csp
@@ -552,10 +629,10 @@ module LightKrylov_BaseKrylov
         class(abstract_linop_cdp), intent(inout) :: A
         !! Linear operator to be factorized.
         class(abstract_vector_cdp), intent(inout) :: U(:)
-        !! Orthonormal basis for the column span of \(\mathbf{A}\). On entry, `U(1)` needs to
+        !! Orthonormal basis for the span of \(AA^\top\). On entry, `U(1)` needs to
         !! be set to the starting Krylov vector b (non-normalized).
         class(abstract_vector_cdp), intent(inout) :: V(:)
-        !! Orthonormal basis for the row span of \(\mathbf{A}\). On entry, `V(1)` needs to
+        !! Orthonormal basis for the row span of \(A^\top A\). On entry, `V(1)` needs to
         !! be set to the starting Krylov vector c (non-normalized).
         complex(dp), intent(inout) :: T(:, :)
         !! Tridiagonal matrix.
@@ -564,7 +641,7 @@ module LightKrylov_BaseKrylov
         integer, optional, intent(in) :: kstart
         !! Starting index for the SSY factorization (default 1)
         integer, optional, intent(in) :: kend
-        !! Final index for the SSY factorization (default size(U)).
+        !! Final index for the SSY factorization (default size(U)-1).
         real(dp), optional, intent(in) :: tol
         !! Tolerance to determine whether invariant subspaces have been computed or not.
     end subroutine ssy_cdp

--- a/src/Krylov/BaseKrylov.fypp
+++ b/src/Krylov/BaseKrylov.fypp
@@ -37,6 +37,7 @@ module LightKrylov_BaseKrylov
     public :: arnoldi
     public :: bidiagonalization
     public :: lanczos
+    public :: ssy
 
     !----- Utility functions ------
     public :: qr
@@ -329,6 +330,33 @@ module LightKrylov_BaseKrylov
         end subroutine lanczos_bidiagonalization_${type[0]}$${kind}$
 
         #:endfor
+    end interface
+
+
+    interface ssy
+    #:for kind, type in RC_KINDS_TYPES
+    module subroutine ssy_${type[0]}$${kind}$(A, U, V, T, info, kstart, kend, tol)
+        implicit none (type, external)
+        class(abstract_linop_${type[0]}$${kind}$), intent(inout) :: A
+        !! Linear operator to be factorized.
+        class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: U(:)
+        !! Orthonormal basis for the column span of \(\mathbf{A}\). On entry, `U(1)` needs to
+        !! be set to the starting Krylov vector b (with unit norm).
+        class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: V(:)
+        !! Orthonormal basis for the row span of \(\mathbf{A}\). On entry, `V(1)` needs to
+        !! be set to the starting Krylov vector c (with unit norm).
+        ${type}$, intent(inout) :: T(:, :)
+        !! Tridiagonal matrix.
+        integer, intent(out) :: info
+        !! Information flag.
+        integer, optional, intent(in) :: kstart
+        !! Starting index for the SSY factorization (default 1)
+        integer, optional, intent(in) :: kend
+        !! Final index for the SSY factorization (default size(U)).
+        real(${kind}$), optional, intent(in) :: tol
+        !! Tolerance to determine whether invariant subspaces have been computed or not.
+    end subroutine ssy_${type[0]}$${kind}$
+    #:endfor
     end interface
 
     !-------------------------------------

--- a/src/Krylov/BaseKrylov.fypp
+++ b/src/Krylov/BaseKrylov.fypp
@@ -341,10 +341,10 @@ module LightKrylov_BaseKrylov
         !! Linear operator to be factorized.
         class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: U(:)
         !! Orthonormal basis for the column span of \(\mathbf{A}\). On entry, `U(1)` needs to
-        !! be set to the starting Krylov vector b (with unit norm).
+        !! be set to the starting Krylov vector b (non-normalized).
         class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: V(:)
         !! Orthonormal basis for the row span of \(\mathbf{A}\). On entry, `V(1)` needs to
-        !! be set to the starting Krylov vector c (with unit norm).
+        !! be set to the starting Krylov vector c (non-normalized).
         ${type}$, intent(inout) :: T(:, :)
         !! Tridiagonal matrix.
         integer, intent(out) :: info

--- a/src/Krylov/BaseKrylov.fypp
+++ b/src/Krylov/BaseKrylov.fypp
@@ -324,7 +324,7 @@ module LightKrylov_BaseKrylov
             integer, optional, intent(in) :: kstart
             !! Starting index for the Lanczos factorization (default 1).
             integer, optional, intent(in) :: kend
-            !! Final index for the Lanczos factorization (default 1).
+            !! Final index for the Lanczos factorization (default size(U) - 1).
             real(${kind}$), optional, intent(in) :: tol
             !! Tolerance to determine whether invariant subspaces have been computed or not.
         end subroutine lanczos_bidiagonalization_${type[0]}$${kind}$
@@ -334,16 +334,93 @@ module LightKrylov_BaseKrylov
 
 
     interface ssy
+        !! ### Description
+        !!
+        !!  Given a linear operator \( A \) with full column rank and the associated saddle-point problem
+        !!
+        !!  \[
+        !!      \begin{bmatrix}
+        !!          I & A \\
+        !!          A^\top &
+        !!      \end{bmatrix}
+        !!      \begin{bmatrix}
+        !!          x \\ y
+        !!      \end{bmatrix}
+        !!      =
+        !!      \begin{bmatrix}
+        !!          b \\ c
+        !!      \end{bmatrix},
+        !!  \]
+        !!
+        !!  the Saunders-Simon-Yip factorization computes orthonormal bases \( U \) and \( V \) for the column-span
+        !!  and of \( AA^\top \) and \( A^\top A \), respectively, and a tridiagonal matrix \( T \) such that
+        !!
+        !!  \[
+        !!      U^\top A V = T.
+        !!  \]
+        !!
+        !!  with \( \beta u_1 = b \) and \( \gamma v_1 = c \).
+        !!
+        !!  **Algorithmic Features**
+        !!
+        !!  - The operator \(A\) only needs to be accessed through matrix-vector products.
+        !!  - Constructs an orthonormal basis for the Krylov subspace \(\mathcal{K} = \left( b, AA^\top b, \cdots \right)\).
+        !!  - Constructs an orthonormal basis for the Krylov subspace \( \mathcal{K} = \left( c, A^\top A c, \cdots, \right)\).
+        !!  - Constructs a tridiagonal matrix \( T \) such that \( U^\top A V = T \).
+        !!  - Checks for convergence and invariant subspaces.
+        !!
+        !!  **References**
+        !!
+        !!  - A. Buttari, D. Orban, D. Ruiz, and D. Titly-Peloquin. "A tridiagonalization method for
+        !!   symmetric saddle-point systems". SIAM Journal on Scientific Computing, 41(5), 2019.
+        !!  [(PDF)](https://hal.science/hal-02343661/file/A_Tridiagonalization_Method_for_Symmetric_Saddle_Point_and_Quasi_Definite_Systems_.pdf)
+        !!
+        !!  ### Syntax
+        !!
+        !!  ```fortran
+        !!      call ssy(A, U, V, T, info [, kstart] [, kend] [, tol])
+        !!  ```
+        !!
+        !!  ### Arguments
+        !!
+        !!  - `A`   :   Linear operator derived from one the base types provided by the
+        !!              `AbstractLinops` module. It is an `intent(inout)` argument.
+        !!
+        !!  - `U`   :   Arrays of types derived from one the base types provided by the `AbstractVectors`
+        !!              module. It needs to be consistent with the type of `A`. On entry, `U(1) = b`.
+        !!              On exit, it contains an orthonormal basis for \(\mathcal{K} = \left( b, AA^\top b, \cdots \right)\).
+        !!              It is an `intent(inout)` argument.
+        !!
+        !!  - `V`   :   Arrays of types derived from one the base types provided by the `AbstractVectors`
+        !!              module. It needs to be consistent with the type o f`A`. On entry, `V(1) = c`.
+        !!              On exit, it contains an orthonormal basis for \(\mathcal{K}=\left(c, A^\top Ac, \cdots \right)\).
+        !!              It is an `intent(inout)` argument.
+        !!
+        !!  - `T`   :   `real` or `complex` rank-2 array. On exit, it contains the \((k+1) \times (k+1)\)
+        !!              tridiagonal matrix computed from the SSY factorization. It is an `intent(inout)` argument.
+        !!
+        !!  - `info`    :   `integer` variable. It is the `LightKrylov` information flag. On exit, if `info > 0`
+        !!                  the SSY process experienced a lucky breakdown.
+        !!
+        !!  - `kstart` (*optional*) :   `integer` value determining the index of the first SSY step to be
+        !!                              computed. It is an optional `intent(in)` argument. By default, `kstart = 1`.
+        !!
+        !!  - `kend` (*optional*)   :   `integer` value determining the index of the last SSY step to be computed.
+        !!                              It is an optional `intent(in)` argument. By default, `kend = size(U) - 1`.
+        !!
+        !!  - `tol` (*optional*)    :   Numerical tolerance below which a subspace is considered to be \(A\)-invariant.
+        !!                              It is an optional `intent(in)` argument. By default `tol = atol_sp` or
+        !!                              `tol = atol_dp` depending on the kind of `A`.
     #:for kind, type in RC_KINDS_TYPES
     module subroutine ssy_${type[0]}$${kind}$(A, U, V, T, info, kstart, kend, tol)
         implicit none (type, external)
         class(abstract_linop_${type[0]}$${kind}$), intent(inout) :: A
         !! Linear operator to be factorized.
         class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: U(:)
-        !! Orthonormal basis for the column span of \(\mathbf{A}\). On entry, `U(1)` needs to
+        !! Orthonormal basis for the span of \(AA^\top\). On entry, `U(1)` needs to
         !! be set to the starting Krylov vector b (non-normalized).
         class(abstract_vector_${type[0]}$${kind}$), intent(inout) :: V(:)
-        !! Orthonormal basis for the row span of \(\mathbf{A}\). On entry, `V(1)` needs to
+        !! Orthonormal basis for the row span of \(A^\top A\). On entry, `V(1)` needs to
         !! be set to the starting Krylov vector c (non-normalized).
         ${type}$, intent(inout) :: T(:, :)
         !! Tridiagonal matrix.
@@ -352,7 +429,7 @@ module LightKrylov_BaseKrylov
         integer, optional, intent(in) :: kstart
         !! Starting index for the SSY factorization (default 1)
         integer, optional, intent(in) :: kend
-        !! Final index for the SSY factorization (default size(U)).
+        !! Final index for the SSY factorization (default size(U)-1).
         real(${kind}$), optional, intent(in) :: tol
         !! Tolerance to determine whether invariant subspaces have been computed or not.
     end subroutine ssy_${type[0]}$${kind}$

--- a/src/Krylov/BaseKrylov.fypp
+++ b/src/Krylov/BaseKrylov.fypp
@@ -365,7 +365,7 @@ module LightKrylov_BaseKrylov
         !!
         !!  - The operator \(A\) only needs to be accessed through matrix-vector products.
         !!  - Constructs an orthonormal basis for the Krylov subspace \(\mathcal{K} = \left( b, AA^\top b, \cdots \right)\).
-        !!  - Constructs an orthonormal basis for the Krylov subspace \( \mathcal{K} = \left( c, A^\top A c, \cdots, \right)\).
+        !!  - Constructs an orthonormal basis for the Krylov subspace \(\mathcal{K} = \left( c, A^\top A c, \cdots, \right)\).
         !!  - Constructs a tridiagonal matrix \( T \) such that \( U^\top A V = T \).
         !!  - Checks for convergence and invariant subspaces.
         !!
@@ -388,12 +388,12 @@ module LightKrylov_BaseKrylov
         !!
         !!  - `U`   :   Arrays of types derived from one the base types provided by the `AbstractVectors`
         !!              module. It needs to be consistent with the type of `A`. On entry, `U(1) = b`.
-        !!              On exit, it contains an orthonormal basis for \(\mathcal{K} = \left( b, AA^\top b, \cdots \right)\).
+        !!              On exit, it contains an orthonormal basis for \(\mathcal{K} = \left(b, A A^\top b, \cdots \right)\).
         !!              It is an `intent(inout)` argument.
         !!
         !!  - `V`   :   Arrays of types derived from one the base types provided by the `AbstractVectors`
         !!              module. It needs to be consistent with the type o f`A`. On entry, `V(1) = c`.
-        !!              On exit, it contains an orthonormal basis for \(\mathcal{K}=\left(c, A^\top Ac, \cdots \right)\).
+        !!              On exit, it contains an orthonormal basis for \(\mathcal{K} = \left(c, A^\top A c, \cdots \right)\).
         !!              It is an `intent(inout)` argument.
         !!
         !!  - `T`   :   `real` or `complex` rank-2 array. On exit, it contains the \((k+1) \times (k+1)\)

--- a/src/Krylov/ssy.f90
+++ b/src/Krylov/ssy.f90
@@ -1,0 +1,240 @@
+submodule (lightkrylov_basekrylov) ssy_method
+    implicit none (type, external)
+contains
+    module procedure ssy_rsp
+        character(len=*), parameter :: this_procedure = "ssy_rsp"
+        character(len=100) :: errmsg
+        integer :: k_start, k_end, i, k
+        real(sp) :: tolerance
+        real(sp) :: alpha, beta, gamma
+
+        if (time_lightkrylov()) call timer%start(this_procedure)
+        associate(kdim => size(U)-1)
+
+            ! Deals with optional arguments.
+            k_start = optval(kstart, 1) ; k_end = optval(kend, kdim)
+            tolerance = optval(tol, atol_sp)
+
+            ! Saunders-Simon-Yip tridiagonalization.
+            if (k_start == 1) then
+                beta = U(1)%norm()
+                call U(1)%scal(one_rsp / beta)
+
+                gamma = V(1)%norm()
+                call V(1)%scal(one_rsp / gamma)
+            endif
+
+            do k = k_start, k_end
+                ! Compute q = A @ v[k] - gamma[k]*u[k-1]
+                call A%matvec(V(k), U(k+1))
+                if (k > 1) call U(k+1)%axpby(-gamma, U(k-1), one_rsp)
+
+                ! Compute alpha[k] = dot(u[k], q)
+                alpha = U(k)%dot(U(k+1))
+                T(k, k) = alpha
+
+                ! Compute beta[k+1] * u[k+1] = q - alpha[k]*u[k]
+                call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.false.)
+                beta = U(k+1)%norm() ; T(k+1, k) = beta
+                if (abs(beta) > tolerance) then
+                    call U(k+1)%scal(one_rsp / beta)
+                else
+                    info = k
+                    exit
+                endif
+
+                ! Compute gamma[k+1]*v[k+1] = hermitian(A) @ u[k] - beta[k]*v[k-1] - alpah[k]*v[k]
+                call A%rmatvec(U(k), V(k+1))
+                call double_gram_schmidt_step(V(k+1), V(:k), info, if_chk_orthonormal=.false.)
+                ! if (k > 1) call V(k+1)%axpby(-T(k, k-1), V(k-1), one_rsp)
+                ! call V(k+1)%axpby(-T(k, k), V(k), one_rsp)
+                gamma = V(k+1)%norm() ; T(k, k+1) = gamma
+                if (abs(gamma) > tolerance) then
+                    call V(k+1)%scal(one_rsp / gamma)
+                else
+                    info = k
+                    exit
+                endif
+            enddo
+
+        end associate
+        if (time_lightkrylov()) call timer%stop(this_procedure)
+    end procedure ssy_rsp
+    module procedure ssy_rdp
+        character(len=*), parameter :: this_procedure = "ssy_rdp"
+        character(len=100) :: errmsg
+        integer :: k_start, k_end, i, k
+        real(dp) :: tolerance
+        real(dp) :: alpha, beta, gamma
+
+        if (time_lightkrylov()) call timer%start(this_procedure)
+        associate(kdim => size(U)-1)
+
+            ! Deals with optional arguments.
+            k_start = optval(kstart, 1) ; k_end = optval(kend, kdim)
+            tolerance = optval(tol, atol_dp)
+
+            ! Saunders-Simon-Yip tridiagonalization.
+            if (k_start == 1) then
+                beta = U(1)%norm()
+                call U(1)%scal(one_rdp / beta)
+
+                gamma = V(1)%norm()
+                call V(1)%scal(one_rdp / gamma)
+            endif
+
+            do k = k_start, k_end
+                ! Compute q = A @ v[k] - gamma[k]*u[k-1]
+                call A%matvec(V(k), U(k+1))
+                if (k > 1) call U(k+1)%axpby(-gamma, U(k-1), one_rdp)
+
+                ! Compute alpha[k] = dot(u[k], q)
+                alpha = U(k)%dot(U(k+1))
+                T(k, k) = alpha
+
+                ! Compute beta[k+1] * u[k+1] = q - alpha[k]*u[k]
+                call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.false.)
+                beta = U(k+1)%norm() ; T(k+1, k) = beta
+                if (abs(beta) > tolerance) then
+                    call U(k+1)%scal(one_rdp / beta)
+                else
+                    info = k
+                    exit
+                endif
+
+                ! Compute gamma[k+1]*v[k+1] = hermitian(A) @ u[k] - beta[k]*v[k-1] - alpah[k]*v[k]
+                call A%rmatvec(U(k), V(k+1))
+                call double_gram_schmidt_step(V(k+1), V(:k), info, if_chk_orthonormal=.false.)
+                ! if (k > 1) call V(k+1)%axpby(-T(k, k-1), V(k-1), one_rdp)
+                ! call V(k+1)%axpby(-T(k, k), V(k), one_rdp)
+                gamma = V(k+1)%norm() ; T(k, k+1) = gamma
+                if (abs(gamma) > tolerance) then
+                    call V(k+1)%scal(one_rdp / gamma)
+                else
+                    info = k
+                    exit
+                endif
+            enddo
+
+        end associate
+        if (time_lightkrylov()) call timer%stop(this_procedure)
+    end procedure ssy_rdp
+    module procedure ssy_csp
+        character(len=*), parameter :: this_procedure = "ssy_csp"
+        character(len=100) :: errmsg
+        integer :: k_start, k_end, i, k
+        real(sp) :: tolerance
+        complex(sp) :: alpha, beta, gamma
+
+        if (time_lightkrylov()) call timer%start(this_procedure)
+        associate(kdim => size(U)-1)
+
+            ! Deals with optional arguments.
+            k_start = optval(kstart, 1) ; k_end = optval(kend, kdim)
+            tolerance = optval(tol, atol_sp)
+
+            ! Saunders-Simon-Yip tridiagonalization.
+            if (k_start == 1) then
+                beta = U(1)%norm()
+                call U(1)%scal(one_csp / beta)
+
+                gamma = V(1)%norm()
+                call V(1)%scal(one_csp / gamma)
+            endif
+
+            do k = k_start, k_end
+                ! Compute q = A @ v[k] - gamma[k]*u[k-1]
+                call A%matvec(V(k), U(k+1))
+                if (k > 1) call U(k+1)%axpby(-gamma, U(k-1), one_csp)
+
+                ! Compute alpha[k] = dot(u[k], q)
+                alpha = U(k)%dot(U(k+1))
+                T(k, k) = alpha
+
+                ! Compute beta[k+1] * u[k+1] = q - alpha[k]*u[k]
+                call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.false.)
+                beta = U(k+1)%norm() ; T(k+1, k) = beta
+                if (abs(beta) > tolerance) then
+                    call U(k+1)%scal(one_csp / beta)
+                else
+                    info = k
+                    exit
+                endif
+
+                ! Compute gamma[k+1]*v[k+1] = hermitian(A) @ u[k] - beta[k]*v[k-1] - alpah[k]*v[k]
+                call A%rmatvec(U(k), V(k+1))
+                call double_gram_schmidt_step(V(k+1), V(:k), info, if_chk_orthonormal=.false.)
+                ! if (k > 1) call V(k+1)%axpby(-T(k, k-1), V(k-1), one_csp)
+                ! call V(k+1)%axpby(-T(k, k), V(k), one_csp)
+                gamma = V(k+1)%norm() ; T(k, k+1) = gamma
+                if (abs(gamma) > tolerance) then
+                    call V(k+1)%scal(one_csp / gamma)
+                else
+                    info = k
+                    exit
+                endif
+            enddo
+
+        end associate
+        if (time_lightkrylov()) call timer%stop(this_procedure)
+    end procedure ssy_csp
+    module procedure ssy_cdp
+        character(len=*), parameter :: this_procedure = "ssy_cdp"
+        character(len=100) :: errmsg
+        integer :: k_start, k_end, i, k
+        real(dp) :: tolerance
+        complex(dp) :: alpha, beta, gamma
+
+        if (time_lightkrylov()) call timer%start(this_procedure)
+        associate(kdim => size(U)-1)
+
+            ! Deals with optional arguments.
+            k_start = optval(kstart, 1) ; k_end = optval(kend, kdim)
+            tolerance = optval(tol, atol_dp)
+
+            ! Saunders-Simon-Yip tridiagonalization.
+            if (k_start == 1) then
+                beta = U(1)%norm()
+                call U(1)%scal(one_cdp / beta)
+
+                gamma = V(1)%norm()
+                call V(1)%scal(one_cdp / gamma)
+            endif
+
+            do k = k_start, k_end
+                ! Compute q = A @ v[k] - gamma[k]*u[k-1]
+                call A%matvec(V(k), U(k+1))
+                if (k > 1) call U(k+1)%axpby(-gamma, U(k-1), one_cdp)
+
+                ! Compute alpha[k] = dot(u[k], q)
+                alpha = U(k)%dot(U(k+1))
+                T(k, k) = alpha
+
+                ! Compute beta[k+1] * u[k+1] = q - alpha[k]*u[k]
+                call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.false.)
+                beta = U(k+1)%norm() ; T(k+1, k) = beta
+                if (abs(beta) > tolerance) then
+                    call U(k+1)%scal(one_cdp / beta)
+                else
+                    info = k
+                    exit
+                endif
+
+                ! Compute gamma[k+1]*v[k+1] = hermitian(A) @ u[k] - beta[k]*v[k-1] - alpah[k]*v[k]
+                call A%rmatvec(U(k), V(k+1))
+                call double_gram_schmidt_step(V(k+1), V(:k), info, if_chk_orthonormal=.false.)
+                ! if (k > 1) call V(k+1)%axpby(-T(k, k-1), V(k-1), one_cdp)
+                ! call V(k+1)%axpby(-T(k, k), V(k), one_cdp)
+                gamma = V(k+1)%norm() ; T(k, k+1) = gamma
+                if (abs(gamma) > tolerance) then
+                    call V(k+1)%scal(one_cdp / gamma)
+                else
+                    info = k
+                    exit
+                endif
+            enddo
+
+        end associate
+        if (time_lightkrylov()) call timer%stop(this_procedure)
+    end procedure ssy_cdp
+end submodule ssy_method

--- a/src/Krylov/ssy.f90
+++ b/src/Krylov/ssy.f90
@@ -43,7 +43,7 @@ contains
                     exit
                 endif
 
-                ! Compute gamma[k+1]*v[k+1] = hermitian(A) @ u[k] - beta[k]*v[k-1] - alpah[k]*v[k]
+                ! Compute gamma[k+1]*v[k+1] = hermitian(A) @ u[k] - beta[k]*v[k-1] - alpha[k]*v[k]
                 call A%rmatvec(U(k), V(k+1))
                 call double_gram_schmidt_step(V(k+1), V(:k), info, if_chk_orthonormal=.false.)
                 ! if (k > 1) call V(k+1)%axpby(-T(k, k-1), V(k-1), one_rsp)
@@ -102,7 +102,7 @@ contains
                     exit
                 endif
 
-                ! Compute gamma[k+1]*v[k+1] = hermitian(A) @ u[k] - beta[k]*v[k-1] - alpah[k]*v[k]
+                ! Compute gamma[k+1]*v[k+1] = hermitian(A) @ u[k] - beta[k]*v[k-1] - alpha[k]*v[k]
                 call A%rmatvec(U(k), V(k+1))
                 call double_gram_schmidt_step(V(k+1), V(:k), info, if_chk_orthonormal=.false.)
                 ! if (k > 1) call V(k+1)%axpby(-T(k, k-1), V(k-1), one_rdp)
@@ -161,7 +161,7 @@ contains
                     exit
                 endif
 
-                ! Compute gamma[k+1]*v[k+1] = hermitian(A) @ u[k] - beta[k]*v[k-1] - alpah[k]*v[k]
+                ! Compute gamma[k+1]*v[k+1] = hermitian(A) @ u[k] - beta[k]*v[k-1] - alpha[k]*v[k]
                 call A%rmatvec(U(k), V(k+1))
                 call double_gram_schmidt_step(V(k+1), V(:k), info, if_chk_orthonormal=.false.)
                 ! if (k > 1) call V(k+1)%axpby(-T(k, k-1), V(k-1), one_csp)
@@ -220,7 +220,7 @@ contains
                     exit
                 endif
 
-                ! Compute gamma[k+1]*v[k+1] = hermitian(A) @ u[k] - beta[k]*v[k-1] - alpah[k]*v[k]
+                ! Compute gamma[k+1]*v[k+1] = hermitian(A) @ u[k] - beta[k]*v[k-1] - alpha[k]*v[k]
                 call A%rmatvec(U(k), V(k+1))
                 call double_gram_schmidt_step(V(k+1), V(:k), info, if_chk_orthonormal=.false.)
                 ! if (k > 1) call V(k+1)%axpby(-T(k, k-1), V(k-1), one_cdp)

--- a/src/Krylov/ssy.f90
+++ b/src/Krylov/ssy.f90
@@ -6,7 +6,7 @@ contains
         character(len=100) :: errmsg
         integer :: k_start, k_end, i, k
         real(sp) :: tolerance
-        real(sp) :: alpha, beta, gamma
+        real(sp) :: beta, gamma
 
         if (time_lightkrylov()) call timer%start(this_procedure)
         associate(kdim => size(U)-1)
@@ -30,8 +30,7 @@ contains
                 if (k > 1) call U(k+1)%axpby(-gamma, U(k-1), one_rsp)
 
                 ! Compute alpha[k] = dot(u[k], q)
-                alpha = U(k)%dot(U(k+1))
-                T(k, k) = alpha
+                T(k, k) = U(k)%dot(U(k+1))
 
                 ! Compute beta[k+1] * u[k+1] = q - alpha[k]*u[k]
                 call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.false.)
@@ -65,7 +64,7 @@ contains
         character(len=100) :: errmsg
         integer :: k_start, k_end, i, k
         real(dp) :: tolerance
-        real(dp) :: alpha, beta, gamma
+        real(dp) :: beta, gamma
 
         if (time_lightkrylov()) call timer%start(this_procedure)
         associate(kdim => size(U)-1)
@@ -89,8 +88,7 @@ contains
                 if (k > 1) call U(k+1)%axpby(-gamma, U(k-1), one_rdp)
 
                 ! Compute alpha[k] = dot(u[k], q)
-                alpha = U(k)%dot(U(k+1))
-                T(k, k) = alpha
+                T(k, k) = U(k)%dot(U(k+1))
 
                 ! Compute beta[k+1] * u[k+1] = q - alpha[k]*u[k]
                 call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.false.)
@@ -124,7 +122,7 @@ contains
         character(len=100) :: errmsg
         integer :: k_start, k_end, i, k
         real(sp) :: tolerance
-        complex(sp) :: alpha, beta, gamma
+        complex(sp) :: beta, gamma
 
         if (time_lightkrylov()) call timer%start(this_procedure)
         associate(kdim => size(U)-1)
@@ -148,8 +146,7 @@ contains
                 if (k > 1) call U(k+1)%axpby(-gamma, U(k-1), one_csp)
 
                 ! Compute alpha[k] = dot(u[k], q)
-                alpha = U(k)%dot(U(k+1))
-                T(k, k) = alpha
+                T(k, k) = U(k)%dot(U(k+1))
 
                 ! Compute beta[k+1] * u[k+1] = q - alpha[k]*u[k]
                 call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.false.)
@@ -183,7 +180,7 @@ contains
         character(len=100) :: errmsg
         integer :: k_start, k_end, i, k
         real(dp) :: tolerance
-        complex(dp) :: alpha, beta, gamma
+        complex(dp) :: beta, gamma
 
         if (time_lightkrylov()) call timer%start(this_procedure)
         associate(kdim => size(U)-1)
@@ -207,8 +204,7 @@ contains
                 if (k > 1) call U(k+1)%axpby(-gamma, U(k-1), one_cdp)
 
                 ! Compute alpha[k] = dot(u[k], q)
-                alpha = U(k)%dot(U(k+1))
-                T(k, k) = alpha
+                T(k, k) = U(k)%dot(U(k+1))
 
                 ! Compute beta[k+1] * u[k+1] = q - alpha[k]*u[k]
                 call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.false.)

--- a/src/Krylov/ssy.fypp
+++ b/src/Krylov/ssy.fypp
@@ -1,0 +1,67 @@
+#:include "../../include/common.fypp"
+#:set RC_KINDS_TYPES = REAL_KINDS_TYPES + CMPLX_KINDS_TYPES
+submodule (lightkrylov_basekrylov) ssy_method
+    implicit none (type, external)
+contains
+    #:for kind, type in RC_KINDS_TYPES
+    module procedure ssy_${type[0]}$${kind}$
+        character(len=*), parameter :: this_procedure = "ssy_${type[0]}$${kind}$"
+        character(len=100) :: errmsg
+        integer :: k_start, k_end, i, k
+        real(${kind}$) :: tolerance
+        ${type}$ :: alpha, beta, gamma
+
+        if (time_lightkrylov()) call timer%start(this_procedure)
+        associate(kdim => size(U)-1)
+
+            ! Deals with optional arguments.
+            k_start = optval(kstart, 1) ; k_end = optval(kend, kdim)
+            tolerance = optval(tol, atol_${kind}$)
+
+            ! Saunders-Simon-Yip tridiagonalization.
+            if (k_start == 1) then
+                beta = U(1)%norm()
+                call U(1)%scal(one_${type[0]}$${kind}$ / beta)
+
+                gamma = V(1)%norm()
+                call V(1)%scal(one_${type[0]}$${kind}$ / gamma)
+            endif
+
+            do k = k_start, k_end
+                ! Compute q = A @ v[k] - gamma[k]*u[k-1]
+                call A%matvec(V(k), U(k+1))
+                if (k > 1) call U(k+1)%axpby(-gamma, U(k-1), one_${type[0]}$${kind}$)
+
+                ! Compute alpha[k] = dot(u[k], q)
+                alpha = U(k)%dot(U(k+1))
+                T(k, k) = alpha
+
+                ! Compute beta[k+1] * u[k+1] = q - alpha[k]*u[k]
+                call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.false.)
+                beta = U(k+1)%norm() ; T(k+1, k) = beta
+                if (abs(beta) > tolerance) then
+                    call U(k+1)%scal(one_${type[0]}$${kind}$ / beta)
+                else
+                    info = k
+                    exit
+                endif
+
+                ! Compute gamma[k+1]*v[k+1] = hermitian(A) @ u[k] - beta[k]*v[k-1] - alpah[k]*v[k]
+                call A%rmatvec(U(k), V(k+1))
+                call double_gram_schmidt_step(V(k+1), V(:k), info, if_chk_orthonormal=.false.)
+                ! if (k > 1) call V(k+1)%axpby(-T(k, k-1), V(k-1), one_${type[0]}$${kind}$)
+                ! call V(k+1)%axpby(-T(k, k), V(k), one_${type[0]}$${kind}$)
+                gamma = V(k+1)%norm() ; T(k, k+1) = gamma
+                if (abs(gamma) > tolerance) then
+                    call V(k+1)%scal(one_${type[0]}$${kind}$ / gamma)
+                else
+                    info = k
+                    exit
+                endif
+            enddo
+
+        end associate
+        if (time_lightkrylov()) call timer%stop(this_procedure)
+    end procedure ssy_${type[0]}$${kind}$
+    #:endfor
+end submodule ssy_method

--- a/src/Krylov/ssy.fypp
+++ b/src/Krylov/ssy.fypp
@@ -46,7 +46,7 @@ contains
                     exit
                 endif
 
-                ! Compute gamma[k+1]*v[k+1] = hermitian(A) @ u[k] - beta[k]*v[k-1] - alpah[k]*v[k]
+                ! Compute gamma[k+1]*v[k+1] = hermitian(A) @ u[k] - beta[k]*v[k-1] - alpha[k]*v[k]
                 call A%rmatvec(U(k), V(k+1))
                 call double_gram_schmidt_step(V(k+1), V(:k), info, if_chk_orthonormal=.false.)
                 ! if (k > 1) call V(k+1)%axpby(-T(k, k-1), V(k-1), one_${type[0]}$${kind}$)

--- a/src/Krylov/ssy.fypp
+++ b/src/Krylov/ssy.fypp
@@ -9,7 +9,7 @@ contains
         character(len=100) :: errmsg
         integer :: k_start, k_end, i, k
         real(${kind}$) :: tolerance
-        ${type}$ :: alpha, beta, gamma
+        ${type}$ :: beta, gamma
 
         if (time_lightkrylov()) call timer%start(this_procedure)
         associate(kdim => size(U)-1)
@@ -33,8 +33,7 @@ contains
                 if (k > 1) call U(k+1)%axpby(-gamma, U(k-1), one_${type[0]}$${kind}$)
 
                 ! Compute alpha[k] = dot(u[k], q)
-                alpha = U(k)%dot(U(k+1))
-                T(k, k) = alpha
+                T(k, k) = U(k)%dot(U(k+1))
 
                 ! Compute beta[k+1] * u[k+1] = q - alpha[k]*u[k]
                 call double_gram_schmidt_step(U(k+1), U(:k), info, if_chk_orthonormal=.false.)

--- a/src/LightKrylov.f90
+++ b/src/LightKrylov.f90
@@ -124,6 +124,7 @@ module LightKrylov
     public :: bidiagonalization
     public :: lanczos
     public :: krylov_schur
+    public :: ssy
 
     ! IterativeSolvers exports.
     public :: abstract_precond_rsp

--- a/src/LightKrylov.fypp
+++ b/src/LightKrylov.fypp
@@ -96,6 +96,7 @@ module LightKrylov
     public :: bidiagonalization
     public :: lanczos
     public :: krylov_schur
+    public :: ssy
 
     ! IterativeSolvers exports.
     #:for kind, type in RC_KINDS_TYPES

--- a/src/Utilities/Logger.f90
+++ b/src/Utilities/Logger.f90
@@ -583,7 +583,7 @@ contains
          else if (trim(to_lower(origin)) == 'ssy') then
             ! ssy_tridiagonalization
             if (info > 0) then
-               write (msg, '(A, I0, A)') 'Saunders-Simon-Yop Tridiagonalisation: Invariant subspace found after ', info, 'steps.'
+               write (msg, '(A, I0, A)') 'Saunders-Simon-Yip Tridiagonalisation: Invariant subspace found after ', info, 'steps.'
                call log_debug(trim(msg), module=module, procedure=procedure)
             else
                write (msg, '(A)') "Undocumented error. "//trim(str)

--- a/src/Utilities/Logger.f90
+++ b/src/Utilities/Logger.f90
@@ -79,14 +79,14 @@ contains
 
       ! Set up comms
       call comm_setup()
-      
+
       ! Set I/O rank
       if (nio_ /= 0) call set_io_rank(nio_)
       if (io_rank()) then
          write (msg, '(A,I0,A,I0)') 'IO rank = ', get_rank()
          call logger%log_message(trim(msg), this_module, this_procedure)
       end if
-      
+
       if (io_rank()) then
          ! Flush log units
          if (close_old_) call reset_log_units()
@@ -97,7 +97,6 @@ contains
          ! set up LightKrylov log file
          call logger%add_log_file(logfile_, unit=iunit_, stat=stat)
          if (stat /= 0) call stop_error('Unable to open logfile '//trim(logfile_)//'.', this_module, this_procedure)
-
 
          ! log to stdout
          if (log_stdout_) then
@@ -258,11 +257,11 @@ contains
 
       call MPI_Comm_rank(MPI_COMM_WORLD, rank_local, ierr)
       call MPI_Comm_size(MPI_COMM_WORLD, size_local, ierr)
-      
+
       call set_rank(rank_local)
       call set_comm_size(size_local)
 
-      if (rank_local==0) then
+      if (rank_local == 0) then
          call logger%log_message('Setup parallel run', this_module, this_procedure)
          write (msg, '(A,I0,A,I0)') 'comm_size = ', size_local
          call logger%log_message(trim(msg), this_module, this_procedure)
@@ -581,6 +580,16 @@ contains
                call log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
                ierr = -1
             end if
+         else if (trim(to_lower(origin)) == 'ssy') then
+            ! ssy_tridiagonalization
+            if (info > 0) then
+               write (msg, '(A, I0, A)') 'Saunders-Simon-Yop Tridiagonalisation: Invariant subspace found after ', info, 'steps.'
+               call log_debug(trim(msg), module=module, procedure=procedure)
+            else
+               write (msg, '(A)') "Undocumented error. "//trim(str)
+               call log_error(origin, module=module, procedure=procedure, stat=info, errmsg=trim(msg))
+               ierr = -1
+            end if
             !
             !   LightKrylov_IterativeSolvers
             !
@@ -620,7 +629,7 @@ contains
                write (msg, '(A,I0,A)') 'GMRES iteration converged after ', info, ' iterations'
                call log_message(trim(msg), module=module, procedure=procedure)
             else if (info < 0) then
-               write(msg,'(A,I0,A)') 'Maximum number of GMRES iterations reached (', abs(info), &
+               write (msg, '(A,I0,A)') 'Maximum number of GMRES iterations reached (', abs(info), &
                            & '). Solution tolerance not achieved.'
                call log_message(trim(msg), module=module, procedure=procedure)
             else
@@ -644,7 +653,7 @@ contains
                write (msg, '(A,I0,A)') 'CG iteration converged after ', info, ' iterations'
                call log_message(trim(msg), module=module, procedure=procedure)
             else if (info < 0) then
-               write(msg,'(A,I0,A)') 'Maximum number of CG iterations reached (', abs(info), &
+               write (msg, '(A,I0,A)') 'Maximum number of CG iterations reached (', abs(info), &
                            & '). Solution tolerance not achieved.'
                call log_message(trim(msg), module=module, procedure=procedure)
             else
@@ -658,7 +667,7 @@ contains
                write (msg, '(A,I0,A)') 'The linear solver converged after ', info, ' iterations'
                call log_message(trim(msg), module=module, procedure=procedure)
             else if (info < 0) then
-               write(msg,'(A,I0,A)') 'Maximum number of iterations reached (', abs(info), &
+               write (msg, '(A,I0,A)') 'Maximum number of iterations reached (', abs(info), &
                            & '). Solution tolerance not achieved.'
                call log_message(trim(msg), module=module, procedure=procedure)
             else
@@ -713,7 +722,7 @@ contains
             write (*, *) 'A fatal error was encountered. Aborting calculation as per user directive.'
             write (*, *)
             if (logger_is_active) then
-                write (*,*) 'Details on the error have been written to the lightkrylov logfile.'
+               write (*, *) 'Details on the error have been written to the lightkrylov logfile.'
             end if
             STOP 1
          end if

--- a/src/Utilities/Timer.f90
+++ b/src/Utilities/Timer.f90
@@ -106,6 +106,7 @@ contains
       call self%add_timer('lanczos_bidiagonalization_rsp')
       call self%add_timer('lanczos_tridiagonalization_rsp')
       call self%add_timer('krylov_schur_rsp')
+      call self%add_timer('ssy_rsp')
       ! rdp
       call self%add_timer('qr_with_pivoting_rdp')
       call self%add_timer('qr_no_pivoting_rdp')
@@ -119,6 +120,7 @@ contains
       call self%add_timer('lanczos_bidiagonalization_rdp')
       call self%add_timer('lanczos_tridiagonalization_rdp')
       call self%add_timer('krylov_schur_rdp')
+      call self%add_timer('ssy_rdp')
       ! csp
       call self%add_timer('qr_with_pivoting_csp')
       call self%add_timer('qr_no_pivoting_csp')
@@ -132,6 +134,7 @@ contains
       call self%add_timer('lanczos_bidiagonalization_csp')
       call self%add_timer('lanczos_tridiagonalization_csp')
       call self%add_timer('krylov_schur_csp')
+      call self%add_timer('ssy_csp')
       ! cdp
       call self%add_timer('qr_with_pivoting_cdp')
       call self%add_timer('qr_no_pivoting_cdp')
@@ -144,7 +147,8 @@ contains
       call self%add_timer('arnoldi_cdp')
       call self%add_timer('lanczos_bidiagonalization_cdp')
       call self%add_timer('lanczos_tridiagonalization_cdp')
-      call self%add_timer('krylov_schur_cdp', count=iend)
+      call self%add_timer('krylov_schur_cdp')
+      call self%add_timer('ssy_cdp', count=iend)
       ! Define BaseKrylov group
       call self%add_group('BaseKrylov', istart=istart, iend=iend)
 

--- a/src/Utilities/Timer.fypp
+++ b/src/Utilities/Timer.fypp
@@ -73,7 +73,7 @@ contains
 
       #:set LAPACK           = { 'name': 'LAPACK','routines': [ 'eig', 'eigh', 'svd', 'trsen' ], 'expand': False }
       #:set Utils            = { 'name': 'Utils',            'routines': [ 'sqrtm', 'expm', ], 'expand': True }
-      #:set BaseKrylov       = { 'name': 'BaseKrylov',       'routines': [ 'qr_with_pivoting', 'qr_no_pivoting', 'orthonormalize_basis','orthogonalize_vector_against_basis','orthogonalize_basis_against_basis','biorthonormalize_bases','dgs_vector_against_basis','dgs_basis_against_basis','arnoldi','lanczos_bidiagonalization','lanczos_tridiagonalization','krylov_schur'], 'expand': True }
+      #:set BaseKrylov       = { 'name': 'BaseKrylov',       'routines': [ 'qr_with_pivoting','qr_no_pivoting','orthonormalize_basis','orthogonalize_vector_against_basis','orthogonalize_basis_against_basis','biorthonormalize_bases','dgs_vector_against_basis','dgs_basis_against_basis','arnoldi','lanczos_bidiagonalization','lanczos_tridiagonalization','krylov_schur','ssy'], 'expand': True }
       #:set IterativeSolvers = { 'name': 'IterativeSolvers', 'routines': [ 'eigs', 'eighs', 'svds', 'gmres', 'fgmres', 'cg' ], 'expand': True }
       #:set Newton           = { 'name': 'NewtonKrylov',     'routines': [ 'newton' ], 'expand': True }
       #:set groups = [ LAPACK, Utils, BaseKrylov, IterativeSolvers, Newton ]

--- a/test/TestKrylov.f90
+++ b/test/TestKrylov.f90
@@ -2,7 +2,7 @@ module TestKrylov
     ! Fortran Standard Library.
     use iso_fortran_env, only: output_unit
     use stdlib_math, only: is_close, all_close
-    use stdlib_linalg, only: eye
+    use stdlib_linalg, only: eye, hermitian
     use stdlib_stats, only: median
     ! Testdrive
     use testdrive, only: new_unittest, unittest_type, error_type, check
@@ -14,6 +14,7 @@ module TestKrylov
     ! Test Utilities
     use LightKrylov_TestUtils
     use TestUtils
+    use stdlib_io_npy, only: save_npy
 
     implicit none (type, external)
 
@@ -26,21 +27,25 @@ module TestKrylov
     public :: collect_arnoldi_rsp_testsuite
     public :: collect_lanczos_bidiag_rsp_testsuite
     public :: collect_lanczos_tridiag_rsp_testsuite
+    public :: collect_ssy_tridiag_rsp_testsuite
 
     public :: collect_qr_rdp_testsuite
     public :: collect_arnoldi_rdp_testsuite
     public :: collect_lanczos_bidiag_rdp_testsuite
     public :: collect_lanczos_tridiag_rdp_testsuite
+    public :: collect_ssy_tridiag_rdp_testsuite
 
     public :: collect_qr_csp_testsuite
     public :: collect_arnoldi_csp_testsuite
     public :: collect_lanczos_bidiag_csp_testsuite
     public :: collect_lanczos_tridiag_csp_testsuite
+    public :: collect_ssy_tridiag_csp_testsuite
 
     public :: collect_qr_cdp_testsuite
     public :: collect_arnoldi_cdp_testsuite
     public :: collect_lanczos_bidiag_cdp_testsuite
     public :: collect_lanczos_tridiag_cdp_testsuite
+    public :: collect_ssy_tridiag_cdp_testsuite
 
 
 contains
@@ -1844,4 +1849,341 @@ contains
         return
     end subroutine test_lanczos_tridiag_factorization_cdp
 
+
+    !-----------------------------------------------------------------------------------------
+    !-----     DEFINITION OF THE UNIT TESTS FOR SAUNDER-SIMON-YIP TRIDIAGONALIZATION     -----
+    !-----------------------------------------------------------------------------------------
+
+    subroutine collect_ssy_tridiag_rsp_testsuite(testsuite)
+        ! Collection of unit tests.
+        type(unittest_type), allocatable, intent(out) :: testsuite(:)
+
+        testsuite = [ &
+             new_unittest("Saunder-Simon-Yip Tridiagonalization", test_ssy_tridiag_factorization_rsp) &
+            ]
+
+        return
+    end subroutine collect_ssy_tridiag_rsp_testsuite
+
+     subroutine test_ssy_tridiag_factorization_rsp(error)
+        ! Error type to be returned.
+        type(error_type), allocatable, intent(out) :: error
+        ! Test matrix.
+        type(linop_rsp), allocatable :: A
+        ! Krylov subspace.
+        type(vector_rsp), allocatable :: U(:), V(:)
+        ! Krylov subspace dimension.
+        integer, parameter :: kdim = test_size
+        ! Tridiagonal matrix.
+        real(sp), allocatable :: T(:, :)
+        ! Information flag.
+        integer :: info
+
+        ! Internal variables.
+        real(sp), allocatable :: Udata(:, :), Vdata(:, :)
+        real(sp), allocatable :: G(:, :)
+        real(sp) :: err
+        character(len=256) :: msg
+
+        ! Initialize tridiagonal matrix.
+        allocate(T(kdim+1, kdim+1)) ; T = zero_rsp
+
+        ! Initialize operator.
+        A = linop_rsp()
+        call init_rand(A)
+
+        ! Initialize Krylov subspace.
+        allocate(U(kdim+1)); call zero_basis(U); call U(1)%rand(ifnorm = .false.)
+        allocate(V(kdim+1)); call zero_basis(V); call V(1)%rand(ifnorm = .false.)
+
+        ! Saunders-Simon-Yip tridiagonalization.
+        call ssy(A, U, V, T, info, tol=atol_sp)
+        call check_info(info, "ssy", module=this_module_long, &
+                        procedure="test_ssy_tridiag_factorization_rsp")
+
+        ! Orthogonality of the column-span basis.
+        G = Gram(U(:kdim)) ; call save_npy("UG_matrix.npy", G)
+        err = maxval(abs(G - eye(kdim, mold=1.0_sp)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_sp)
+        call check_test(error, 'test_ssy_tridiag_factorization_rsp', &
+                                 & info='Orthonomality', eq='U.H @ U = I', context=msg)
+
+        ! Orthogonality of the row-span basis.
+        G = Gram(V(:kdim))
+        err = maxval(abs(G - eye(kdim, mold=1.0_sp)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_sp)
+        call check_test(error, 'test_ssy_tridiag_factorization_rsp', &
+                                 & info='Orthonomality', eq='V.H @ V = I', context=msg)
+
+        ! Check correctness.
+        allocate(Udata(test_size, kdim+1)) ; call get_data(Udata, U)
+        allocate(Vdata(test_size, kdim+1)) ; call get_data(Vdata, V)
+
+        ! Infinity-norm check.
+        err = maxval(abs(matmul(A%data, Vdata(:, :kdim)) - matmul(Udata, T(:kdim+1, :kdim))))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_sp)
+        call check_test(error, 'test_ssy_tridiag_factorization_rsp', &
+                                 & info='Factorization', eq='A @ V = U_ @ T_', context=msg)
+
+        err = maxval(abs(matmul(hermitian(A%data), Udata(:, :kdim)) - matmul(Vdata, hermitian(T(:kdim, :kdim+1)))))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_sp)
+        call check_test(error, 'test_ssy_tridiag_factorization_rsp', &
+                                 & info='Factorization', eq='A.H @ U = V_ @ T_.H', context=msg)
+        return
+    end subroutine test_ssy_tridiag_factorization_rsp
+
+   
+    subroutine collect_ssy_tridiag_rdp_testsuite(testsuite)
+        ! Collection of unit tests.
+        type(unittest_type), allocatable, intent(out) :: testsuite(:)
+
+        testsuite = [ &
+             new_unittest("Saunder-Simon-Yip Tridiagonalization", test_ssy_tridiag_factorization_rdp) &
+            ]
+
+        return
+    end subroutine collect_ssy_tridiag_rdp_testsuite
+
+     subroutine test_ssy_tridiag_factorization_rdp(error)
+        ! Error type to be returned.
+        type(error_type), allocatable, intent(out) :: error
+        ! Test matrix.
+        type(linop_rdp), allocatable :: A
+        ! Krylov subspace.
+        type(vector_rdp), allocatable :: U(:), V(:)
+        ! Krylov subspace dimension.
+        integer, parameter :: kdim = test_size
+        ! Tridiagonal matrix.
+        real(dp), allocatable :: T(:, :)
+        ! Information flag.
+        integer :: info
+
+        ! Internal variables.
+        real(dp), allocatable :: Udata(:, :), Vdata(:, :)
+        real(dp), allocatable :: G(:, :)
+        real(dp) :: err
+        character(len=256) :: msg
+
+        ! Initialize tridiagonal matrix.
+        allocate(T(kdim+1, kdim+1)) ; T = zero_rdp
+
+        ! Initialize operator.
+        A = linop_rdp()
+        call init_rand(A)
+
+        ! Initialize Krylov subspace.
+        allocate(U(kdim+1)); call zero_basis(U); call U(1)%rand(ifnorm = .false.)
+        allocate(V(kdim+1)); call zero_basis(V); call V(1)%rand(ifnorm = .false.)
+
+        ! Saunders-Simon-Yip tridiagonalization.
+        call ssy(A, U, V, T, info, tol=atol_dp)
+        call check_info(info, "ssy", module=this_module_long, &
+                        procedure="test_ssy_tridiag_factorization_rdp")
+
+        ! Orthogonality of the column-span basis.
+        G = Gram(U(:kdim)) ; call save_npy("UG_matrix.npy", G)
+        err = maxval(abs(G - eye(kdim, mold=1.0_dp)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_dp)
+        call check_test(error, 'test_ssy_tridiag_factorization_rdp', &
+                                 & info='Orthonomality', eq='U.H @ U = I', context=msg)
+
+        ! Orthogonality of the row-span basis.
+        G = Gram(V(:kdim))
+        err = maxval(abs(G - eye(kdim, mold=1.0_dp)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_dp)
+        call check_test(error, 'test_ssy_tridiag_factorization_rdp', &
+                                 & info='Orthonomality', eq='V.H @ V = I', context=msg)
+
+        ! Check correctness.
+        allocate(Udata(test_size, kdim+1)) ; call get_data(Udata, U)
+        allocate(Vdata(test_size, kdim+1)) ; call get_data(Vdata, V)
+
+        ! Infinity-norm check.
+        err = maxval(abs(matmul(A%data, Vdata(:, :kdim)) - matmul(Udata, T(:kdim+1, :kdim))))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_dp)
+        call check_test(error, 'test_ssy_tridiag_factorization_rdp', &
+                                 & info='Factorization', eq='A @ V = U_ @ T_', context=msg)
+
+        err = maxval(abs(matmul(hermitian(A%data), Udata(:, :kdim)) - matmul(Vdata, hermitian(T(:kdim, :kdim+1)))))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_dp)
+        call check_test(error, 'test_ssy_tridiag_factorization_rdp', &
+                                 & info='Factorization', eq='A.H @ U = V_ @ T_.H', context=msg)
+        return
+    end subroutine test_ssy_tridiag_factorization_rdp
+
+   
+    subroutine collect_ssy_tridiag_csp_testsuite(testsuite)
+        ! Collection of unit tests.
+        type(unittest_type), allocatable, intent(out) :: testsuite(:)
+
+        testsuite = [ &
+             new_unittest("Saunder-Simon-Yip Tridiagonalization", test_ssy_tridiag_factorization_csp) &
+            ]
+
+        return
+    end subroutine collect_ssy_tridiag_csp_testsuite
+
+     subroutine test_ssy_tridiag_factorization_csp(error)
+        ! Error type to be returned.
+        type(error_type), allocatable, intent(out) :: error
+        ! Test matrix.
+        type(linop_csp), allocatable :: A
+        ! Krylov subspace.
+        type(vector_csp), allocatable :: U(:), V(:)
+        ! Krylov subspace dimension.
+        integer, parameter :: kdim = test_size
+        ! Tridiagonal matrix.
+        complex(sp), allocatable :: T(:, :)
+        ! Information flag.
+        integer :: info
+
+        ! Internal variables.
+        complex(sp), allocatable :: Udata(:, :), Vdata(:, :)
+        complex(sp), allocatable :: G(:, :)
+        real(sp) :: err
+        character(len=256) :: msg
+
+        ! Initialize tridiagonal matrix.
+        allocate(T(kdim+1, kdim+1)) ; T = zero_csp
+
+        ! Initialize operator.
+        A = linop_csp()
+        call init_rand(A)
+
+        ! Initialize Krylov subspace.
+        allocate(U(kdim+1)); call zero_basis(U); call U(1)%rand(ifnorm = .false.)
+        allocate(V(kdim+1)); call zero_basis(V); call V(1)%rand(ifnorm = .false.)
+
+        ! Saunders-Simon-Yip tridiagonalization.
+        call ssy(A, U, V, T, info, tol=atol_sp)
+        call check_info(info, "ssy", module=this_module_long, &
+                        procedure="test_ssy_tridiag_factorization_csp")
+
+        ! Orthogonality of the column-span basis.
+        G = Gram(U(:kdim)) ; call save_npy("UG_matrix.npy", G)
+        err = maxval(abs(G - eye(kdim, mold=1.0_sp)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_sp)
+        call check_test(error, 'test_ssy_tridiag_factorization_csp', &
+                                 & info='Orthonomality', eq='U.H @ U = I', context=msg)
+
+        ! Orthogonality of the row-span basis.
+        G = Gram(V(:kdim))
+        err = maxval(abs(G - eye(kdim, mold=1.0_sp)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_sp)
+        call check_test(error, 'test_ssy_tridiag_factorization_csp', &
+                                 & info='Orthonomality', eq='V.H @ V = I', context=msg)
+
+        ! Check correctness.
+        allocate(Udata(test_size, kdim+1)) ; call get_data(Udata, U)
+        allocate(Vdata(test_size, kdim+1)) ; call get_data(Vdata, V)
+
+        ! Infinity-norm check.
+        err = maxval(abs(matmul(A%data, Vdata(:, :kdim)) - matmul(Udata, T(:kdim+1, :kdim))))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_sp)
+        call check_test(error, 'test_ssy_tridiag_factorization_csp', &
+                                 & info='Factorization', eq='A @ V = U_ @ T_', context=msg)
+
+        err = maxval(abs(matmul(hermitian(A%data), Udata(:, :kdim)) - matmul(Vdata, hermitian(T(:kdim, :kdim+1)))))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_sp)
+        call check_test(error, 'test_ssy_tridiag_factorization_csp', &
+                                 & info='Factorization', eq='A.H @ U = V_ @ T_.H', context=msg)
+        return
+    end subroutine test_ssy_tridiag_factorization_csp
+
+   
+    subroutine collect_ssy_tridiag_cdp_testsuite(testsuite)
+        ! Collection of unit tests.
+        type(unittest_type), allocatable, intent(out) :: testsuite(:)
+
+        testsuite = [ &
+             new_unittest("Saunder-Simon-Yip Tridiagonalization", test_ssy_tridiag_factorization_cdp) &
+            ]
+
+        return
+    end subroutine collect_ssy_tridiag_cdp_testsuite
+
+     subroutine test_ssy_tridiag_factorization_cdp(error)
+        ! Error type to be returned.
+        type(error_type), allocatable, intent(out) :: error
+        ! Test matrix.
+        type(linop_cdp), allocatable :: A
+        ! Krylov subspace.
+        type(vector_cdp), allocatable :: U(:), V(:)
+        ! Krylov subspace dimension.
+        integer, parameter :: kdim = test_size
+        ! Tridiagonal matrix.
+        complex(dp), allocatable :: T(:, :)
+        ! Information flag.
+        integer :: info
+
+        ! Internal variables.
+        complex(dp), allocatable :: Udata(:, :), Vdata(:, :)
+        complex(dp), allocatable :: G(:, :)
+        real(dp) :: err
+        character(len=256) :: msg
+
+        ! Initialize tridiagonal matrix.
+        allocate(T(kdim+1, kdim+1)) ; T = zero_cdp
+
+        ! Initialize operator.
+        A = linop_cdp()
+        call init_rand(A)
+
+        ! Initialize Krylov subspace.
+        allocate(U(kdim+1)); call zero_basis(U); call U(1)%rand(ifnorm = .false.)
+        allocate(V(kdim+1)); call zero_basis(V); call V(1)%rand(ifnorm = .false.)
+
+        ! Saunders-Simon-Yip tridiagonalization.
+        call ssy(A, U, V, T, info, tol=atol_dp)
+        call check_info(info, "ssy", module=this_module_long, &
+                        procedure="test_ssy_tridiag_factorization_cdp")
+
+        ! Orthogonality of the column-span basis.
+        G = Gram(U(:kdim)) ; call save_npy("UG_matrix.npy", G)
+        err = maxval(abs(G - eye(kdim, mold=1.0_dp)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_dp)
+        call check_test(error, 'test_ssy_tridiag_factorization_cdp', &
+                                 & info='Orthonomality', eq='U.H @ U = I', context=msg)
+
+        ! Orthogonality of the row-span basis.
+        G = Gram(V(:kdim))
+        err = maxval(abs(G - eye(kdim, mold=1.0_dp)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_dp)
+        call check_test(error, 'test_ssy_tridiag_factorization_cdp', &
+                                 & info='Orthonomality', eq='V.H @ V = I', context=msg)
+
+        ! Check correctness.
+        allocate(Udata(test_size, kdim+1)) ; call get_data(Udata, U)
+        allocate(Vdata(test_size, kdim+1)) ; call get_data(Vdata, V)
+
+        ! Infinity-norm check.
+        err = maxval(abs(matmul(A%data, Vdata(:, :kdim)) - matmul(Udata, T(:kdim+1, :kdim))))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_dp)
+        call check_test(error, 'test_ssy_tridiag_factorization_cdp', &
+                                 & info='Factorization', eq='A @ V = U_ @ T_', context=msg)
+
+        err = maxval(abs(matmul(hermitian(A%data), Udata(:, :kdim)) - matmul(Vdata, hermitian(T(:kdim, :kdim+1)))))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_dp)
+        call check_test(error, 'test_ssy_tridiag_factorization_cdp', &
+                                 & info='Factorization', eq='A.H @ U = V_ @ T_.H', context=msg)
+        return
+    end subroutine test_ssy_tridiag_factorization_cdp
+
+   
 end module TestKrylov

--- a/test/TestKrylov.f90
+++ b/test/TestKrylov.f90
@@ -1939,8 +1939,6 @@ contains
                                  & info='Factorization', eq='A.H @ U = V_ @ T_.H', context=msg)
         return
     end subroutine test_ssy_tridiag_factorization_rsp
-
-   
     subroutine collect_ssy_tridiag_rdp_testsuite(testsuite)
         ! Collection of unit tests.
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
@@ -2022,8 +2020,6 @@ contains
                                  & info='Factorization', eq='A.H @ U = V_ @ T_.H', context=msg)
         return
     end subroutine test_ssy_tridiag_factorization_rdp
-
-   
     subroutine collect_ssy_tridiag_csp_testsuite(testsuite)
         ! Collection of unit tests.
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
@@ -2105,8 +2101,6 @@ contains
                                  & info='Factorization', eq='A.H @ U = V_ @ T_.H', context=msg)
         return
     end subroutine test_ssy_tridiag_factorization_csp
-
-   
     subroutine collect_ssy_tridiag_cdp_testsuite(testsuite)
         ! Collection of unit tests.
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
@@ -2188,7 +2182,6 @@ contains
                                  & info='Factorization', eq='A.H @ U = V_ @ T_.H', context=msg)
         return
     end subroutine test_ssy_tridiag_factorization_cdp
-
    
     !-----------------------------------------------------------------------
     !-----     DEFINITIONS OF THE VARIOUS UNIT TESTS FOR UTILITIES     -----

--- a/test/TestKrylov.f90
+++ b/test/TestKrylov.f90
@@ -2182,7 +2182,7 @@ contains
                                  & info='Factorization', eq='A.H @ U = V_ @ T_.H', context=msg)
         return
     end subroutine test_ssy_tridiag_factorization_cdp
-   
+
     !-----------------------------------------------------------------------
     !-----     DEFINITIONS OF THE VARIOUS UNIT TESTS FOR UTILITIES     -----
     !-----------------------------------------------------------------------

--- a/test/TestKrylov.fypp
+++ b/test/TestKrylov.fypp
@@ -4,7 +4,7 @@ module TestKrylov
     ! Fortran Standard Library.
     use iso_fortran_env, only: output_unit
     use stdlib_math, only: is_close, all_close
-    use stdlib_linalg, only: eye
+    use stdlib_linalg, only: eye, hermitian
     use stdlib_stats, only: median
     ! Testdrive
     use testdrive, only: new_unittest, unittest_type, error_type, check
@@ -16,6 +16,7 @@ module TestKrylov
     ! Test Utilities
     use LightKrylov_TestUtils
     use TestUtils
+    use stdlib_io_npy, only: save_npy
 
     implicit none (type, external)
 
@@ -29,6 +30,7 @@ module TestKrylov
     public :: collect_arnoldi_${type[0]}$${kind}$_testsuite
     public :: collect_lanczos_bidiag_${type[0]}$${kind}$_testsuite
     public :: collect_lanczos_tridiag_${type[0]}$${kind}$_testsuite
+    public :: collect_ssy_tridiag_${type[0]}$${kind}$_testsuite
 
     #:endfor
 
@@ -513,5 +515,95 @@ contains
         return
     end subroutine test_lanczos_tridiag_factorization_${type[0]}$${kind}$
 
+    #:endfor
+
+    !-----------------------------------------------------------------------------------------
+    !-----     DEFINITION OF THE UNIT TESTS FOR SAUNDER-SIMON-YIP TRIDIAGONALIZATION     -----
+    !-----------------------------------------------------------------------------------------
+
+    #:for kind, type in RC_KINDS_TYPES
+    subroutine collect_ssy_tridiag_${type[0]}$${kind}$_testsuite(testsuite)
+        ! Collection of unit tests.
+        type(unittest_type), allocatable, intent(out) :: testsuite(:)
+
+        testsuite = [ &
+             new_unittest("Saunder-Simon-Yip Tridiagonalization", test_ssy_tridiag_factorization_${type[0]}$${kind}$) &
+            ]
+
+        return
+    end subroutine collect_ssy_tridiag_${type[0]}$${kind}$_testsuite
+
+     subroutine test_ssy_tridiag_factorization_${type[0]}$${kind}$(error)
+        ! Error type to be returned.
+        type(error_type), allocatable, intent(out) :: error
+        ! Test matrix.
+        type(linop_${type[0]}$${kind}$), allocatable :: A
+        ! Krylov subspace.
+        type(vector_${type[0]}$${kind}$), allocatable :: U(:), V(:)
+        ! Krylov subspace dimension.
+        integer, parameter :: kdim = test_size
+        ! Tridiagonal matrix.
+        ${type}$, allocatable :: T(:, :)
+        ! Information flag.
+        integer :: info
+
+        ! Internal variables.
+        ${type}$, allocatable :: Udata(:, :), Vdata(:, :)
+        ${type}$, allocatable :: G(:, :)
+        real(${kind}$) :: err
+        character(len=256) :: msg
+
+        ! Initialize tridiagonal matrix.
+        allocate(T(kdim+1, kdim+1)) ; T = zero_${type[0]}$${kind}$
+
+        ! Initialize operator.
+        A = linop_${type[0]}$${kind}$()
+        call init_rand(A)
+
+        ! Initialize Krylov subspace.
+        allocate(U(kdim+1)); call zero_basis(U); call U(1)%rand(ifnorm = .false.)
+        allocate(V(kdim+1)); call zero_basis(V); call V(1)%rand(ifnorm = .false.)
+
+        ! Saunders-Simon-Yip tridiagonalization.
+        call ssy(A, U, V, T, info, tol=atol_${kind}$)
+        call check_info(info, "ssy", module=this_module_long, &
+                        procedure="test_ssy_tridiag_factorization_${type[0]}$${kind}$")
+
+        ! Orthogonality of the column-span basis.
+        G = Gram(U(:kdim)) ; call save_npy("UG_matrix.npy", G)
+        err = maxval(abs(G - eye(kdim, mold=1.0_${kind}$)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_${kind}$)
+        call check_test(error, 'test_ssy_tridiag_factorization_${type[0]}$${kind}$', &
+                                 & info='Orthonomality', eq='U.H @ U = I', context=msg)
+
+        ! Orthogonality of the row-span basis.
+        G = Gram(V(:kdim))
+        err = maxval(abs(G - eye(kdim, mold=1.0_${kind}$)))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_${kind}$)
+        call check_test(error, 'test_ssy_tridiag_factorization_${type[0]}$${kind}$', &
+                                 & info='Orthonomality', eq='V.H @ V = I', context=msg)
+
+        ! Check correctness.
+        allocate(Udata(test_size, kdim+1)) ; call get_data(Udata, U)
+        allocate(Vdata(test_size, kdim+1)) ; call get_data(Vdata, V)
+
+        ! Infinity-norm check.
+        err = maxval(abs(matmul(A%data, Vdata(:, :kdim)) - matmul(Udata, T(:kdim+1, :kdim))))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_${kind}$)
+        call check_test(error, 'test_ssy_tridiag_factorization_${type[0]}$${kind}$', &
+                                 & info='Factorization', eq='A @ V = U_ @ T_', context=msg)
+
+        err = maxval(abs(matmul(hermitian(A%data), Udata(:, :kdim)) - matmul(Vdata, hermitian(T(:kdim, :kdim+1)))))
+        call get_err_str(msg, "max err: ", err)
+        call check(error, err < rtol_${kind}$)
+        call check_test(error, 'test_ssy_tridiag_factorization_${type[0]}$${kind}$', &
+                                 & info='Factorization', eq='A.H @ U = V_ @ T_.H', context=msg)
+        return
+    end subroutine test_ssy_tridiag_factorization_${type[0]}$${kind}$
+
+   
     #:endfor
 end module TestKrylov

--- a/test/TestKrylov.fypp
+++ b/test/TestKrylov.fypp
@@ -604,8 +604,8 @@ contains
                                  & info='Factorization', eq='A.H @ U = V_ @ T_.H', context=msg)
         return
     end subroutine test_ssy_tridiag_factorization_${type[0]}$${kind}$
+    #:endfor
 
-   
     !-----------------------------------------------------------------------
     !-----     DEFINITIONS OF THE VARIOUS UNIT TESTS FOR UTILITIES     -----
     !-----------------------------------------------------------------------

--- a/test/Tests.f90
+++ b/test/Tests.f90
@@ -43,6 +43,7 @@ program Tester
                 new_testsuite("Real Arnoldi (sp) Test Suite", collect_arnoldi_rsp_testsuite), &
                 new_testsuite("Real Lanczos bidiagonalization (sp) Test Suite", collect_lanczos_bidiag_rsp_testsuite), &
                 new_testsuite("Real Lanczos tridiagonalization (sp) Test Suite", collect_lanczos_tridiag_rsp_testsuite), &
+                new_testsuite("Real Saunders-Simon-Yip tridiagonalization (sp) Test Suite", collect_ssy_tridiag_rsp_testsuite), &
                 new_testsuite("Real EVP (sp) Test Suite", collect_eig_rsp_testsuite), &
                 new_testsuite("Real SVD (sp) Test Suite", collect_svd_rsp_testsuite), &
                 new_testsuite("Real GMRES (sp) Test Suite", collect_gmres_rsp_testsuite), &
@@ -88,6 +89,7 @@ program Tester
                 new_testsuite("Real Arnoldi (dp) Test Suite", collect_arnoldi_rdp_testsuite), &
                 new_testsuite("Real Lanczos bidiagonalization (dp) Test Suite", collect_lanczos_bidiag_rdp_testsuite), &
                 new_testsuite("Real Lanczos tridiagonalization (dp) Test Suite", collect_lanczos_tridiag_rdp_testsuite), &
+                new_testsuite("Real Saunders-Simon-Yip tridiagonalization (dp) Test Suite", collect_ssy_tridiag_rdp_testsuite), &
                 new_testsuite("Real EVP (dp) Test Suite", collect_eig_rdp_testsuite), &
                 new_testsuite("Real SVD (dp) Test Suite", collect_svd_rdp_testsuite), &
                 new_testsuite("Real GMRES (dp) Test Suite", collect_gmres_rdp_testsuite), &
@@ -134,6 +136,7 @@ program Tester
                 new_testsuite("Complex Arnoldi (sp) Test Suite", collect_arnoldi_csp_testsuite), &
                 ! new_testsuite("Complex Lanczos bidiagonalization (sp) Test Suite", collect_lanczos_bidiag_csp_testsuite), &
                 new_testsuite("Complex Lanczos tridiagonalization (sp) Test Suite", collect_lanczos_tridiag_csp_testsuite), &
+                new_testsuite("Complex Saunders-Simon-Yip tridiagonalization (sp) Test Suite", collect_ssy_tridiag_csp_testsuite), &
                 new_testsuite("Complex EVP (sp) Test Suite", collect_eig_csp_testsuite), &
                 new_testsuite("Complex SVD (dp) Test Suite", collect_svd_csp_testsuite), &
                 new_testsuite("Complex GMRES (sp) Test Suite", collect_gmres_csp_testsuite), &
@@ -179,6 +182,7 @@ program Tester
                 new_testsuite("Complex Arnoldi (dp) Test Suite", collect_arnoldi_cdp_testsuite), &
                 ! new_testsuite("Complex Lanczos bidiagonalization (dp) Test Suite", collect_lanczos_bidiag_cdp_testsuite), &
                 new_testsuite("Complex Lanczos tridiagonalization (dp) Test Suite", collect_lanczos_tridiag_cdp_testsuite), &
+                new_testsuite("Complex Saunders-Simon-Yip tridiagonalization (dp) Test Suite", collect_ssy_tridiag_cdp_testsuite), &
                 new_testsuite("Complex EVP (dp) Test Suite", collect_eig_cdp_testsuite), &
                 new_testsuite("Complex SVD (dp) Test Suite", collect_svd_cdp_testsuite), &
                 new_testsuite("Complex GMRES (dp) Test Suite", collect_gmres_cdp_testsuite), &


### PR DESCRIPTION
This PR implements the Saunders-Simon-Yop tridiagonalization process. Given a linear system of the form

$$
    \begin{bmatrix}
        I & A \\
        A^\top &
    \end{bmatrix}
    \begin{bmatrix}
        x \\
        y
    \end{bmatrix}
    =
    \begin{bmatrix}
        b \\
        c
    \end{bmatrix}
$$

it constructs two orthonormal Krylov bases for the column span and row span of $A$ and a tridiagonal matrix such that $U^\top A V = T$.

### Proposed interface

```fortran
call ssy(A, U, V, T, info, [kstart, kend, tol])
```

### Progress

- [x] Interfaces
- [x] Base implementation
- [x] Tests
- [x] Documentation