### PR TITLE
Verification

### DIFF
--- a/src/AbstractTypes/AbstractVectors.f90
+++ b/src/AbstractTypes/AbstractVectors.f90
@@ -1481,7 +1481,6 @@ contains
                 call w%add(wrk2)    ! (u + v) + w
 
                 call u%sub(w)
-                print *, u%norm(), tol
                 success = merge(.true., .false., u%norm() <= tol)
                 if (.not. success) exit verification
             end block addition_distributivity
@@ -1818,7 +1817,6 @@ contains
                 call w%add(wrk2)    ! (u + v) + w
 
                 call u%sub(w)
-                print *, u%norm(), tol
                 success = merge(.true., .false., u%norm() <= tol)
                 if (.not. success) exit verification
             end block addition_distributivity
@@ -2155,7 +2153,6 @@ contains
                 call w%add(wrk2)    ! (u + v) + w
 
                 call u%sub(w)
-                print *, u%norm(), tol
                 success = merge(.true., .false., u%norm() <= tol)
                 if (.not. success) exit verification
             end block addition_distributivity
@@ -2500,7 +2497,6 @@ contains
                 call w%add(wrk2)    ! (u + v) + w
 
                 call u%sub(w)
-                print *, u%norm(), tol
                 success = merge(.true., .false., u%norm() <= tol)
                 if (.not. success) exit verification
             end block addition_distributivity

--- a/src/AbstractTypes/AbstractVectors.f90
+++ b/src/AbstractTypes/AbstractVectors.f90
@@ -18,7 +18,7 @@ module LightKrylov_AbstractVectors
     !! - `dot(self, vec)`               :   A function computing the inner product \( \alpha = \langle \mathbf{x} \vert \mathbf{y} \rangle \).
     !! - `get_size(self)`               :   A function returning the dimension \( n \) of the vector \( \mathbf{x} \).
     !!
-    !! Once these type-bound procedures have been implemented by the user, they will automatically 
+    !! Once these type-bound procedures have been implemented by the user, they will automatically
     !! be used to define:
     !!
     !! - vector addition    :   `add(self, vec) = axpby(1, vec, 1, self)`
@@ -62,7 +62,7 @@ module LightKrylov_AbstractVectors
         !!  ### Description
         !!
         !!  This interface provides methods for computing the inner products between a basis
-        !!  of `real` or `complex` vectors \( \mathbf{X} \) and a single vector 
+        !!  of `real` or `complex` vectors \( \mathbf{X} \) and a single vector
         !!  \( \mathbf{y} \) or another basis \( \mathbf{Y} \). Depending on the case, it
         !!  returns a one-dimensional array \( \mathbf{v} \) or a two-dimensional array
         !!  \( \mathbf{M} \) with the same type as \( \mathbf{X} \).
@@ -112,7 +112,7 @@ module LightKrylov_AbstractVectors
         !!
         !!  ### Description
         !!
-        !!  This interface provides methods for computing the Gram matrix associated to a basis of 
+        !!  This interface provides methods for computing the Gram matrix associated to a basis of
         !!  `abstract_vector` \( \mathbf{X} \).
         !!
         !!  ### Example
@@ -182,7 +182,7 @@ module LightKrylov_AbstractVectors
 
     interface axpby_basis
         !!  In-place addition of two arrays of extended `abstract_vector`.
-        !!  
+        !!
         !!  ### Description
         !!
         !!  This interface provides methods to add in-place two arrays of
@@ -921,7 +921,7 @@ contains
     !--------------------------------------------------------------------------------
     !-----     TYPE-BOUND PROCEDURES FOR THE CONVENIENCE DENSE VECTOR TYPES     -----
     !--------------------------------------------------------------------------------
-    
+
     function initialize_dense_vector_from_array_rsp(x) result(vec)
         implicit none(type, external)
         real(sp), intent(in) :: x(:)
@@ -1262,7 +1262,7 @@ contains
         n = size(self%data)
     end function dense_get_size_cdp
 
-    
+
     !--------------------------------------
     !-----      UTILITY FUNCTIONS     -----
     !--------------------------------------
@@ -1315,7 +1315,7 @@ contains
         ! Internal variables.
         integer :: i, j, iostat
         character(len=100) :: errmsg
-    
+
         ! Check sizes.
         if (size(X) /= size(B, 1)) then
             call stop_error("Krylov basis X and combination matrix B have incompatible sizes.", &
@@ -1476,7 +1476,7 @@ contains
         ! Internal variables.
         integer :: i, j, iostat
         character(len=100) :: errmsg
-    
+
         ! Check sizes.
         if (size(X) /= size(B, 1)) then
             call stop_error("Krylov basis X and combination matrix B have incompatible sizes.", &
@@ -1637,7 +1637,7 @@ contains
         ! Internal variables.
         integer :: i, j, iostat
         character(len=100) :: errmsg
-    
+
         ! Check sizes.
         if (size(X) /= size(B, 1)) then
             call stop_error("Krylov basis X and combination matrix B have incompatible sizes.", &
@@ -1798,7 +1798,7 @@ contains
         ! Internal variables.
         integer :: i, j, iostat
         character(len=100) :: errmsg
-    
+
         ! Check sizes.
         if (size(X) /= size(B, 1)) then
             call stop_error("Krylov basis X and combination matrix B have incompatible sizes.", &

--- a/src/AbstractTypes/AbstractVectors.f90
+++ b/src/AbstractTypes/AbstractVectors.f90
@@ -54,6 +54,7 @@ module LightKrylov_AbstractVectors
     public :: zero_basis
     public :: copy
     public :: rand_basis
+    public :: verify_vector_axioms
 
     interface innerprod
         !!  Compute the inner product vector \( \mathbf{v} = \mathbf{X}^H \mathbf{y} \) or matrix
@@ -283,6 +284,14 @@ module LightKrylov_AbstractVectors
         module procedure rand_basis_csp
         module procedure rand_basis_cdp
     end interface
+
+    interface verify_vector_axioms
+        module procedure verify_vector_axioms_rsp
+        module procedure verify_vector_axioms_rdp
+        module procedure verify_vector_axioms_csp
+        module procedure verify_vector_axioms_cdp
+    end interface
+
 
     type, abstract, public :: abstract_vector
         !!  Base abstract type from which all other types of vectors used in `LightKrylov`
@@ -1428,6 +1437,182 @@ contains
         call X%rand(ifnorm=ifnorm)
     end subroutine rand_basis_rsp
 
+
+    logical function verify_vector_axioms_rsp(x, ntrials, tolerance) result(success)
+        implicit none(type, external)
+        class(abstract_vector_rsp), intent(in) :: x
+        !! Derived-type whose implementation needs to be tested.
+        integer, optional, intent(in) :: ntrials
+        !! Number of random samples generated for the tests.
+        real(sp), optional, intent(in) :: tolerance
+
+        integer :: ntrials_, i
+        real(sp) :: tol
+
+        !> Deals with optional argument.
+        ntrials_ = optval(ntrials, 100)
+        tol = optval(tolerance, 10.0_sp**(-(precision(1.0_sp)-1)))
+
+        !> Run all tests to verify axioms.
+        success = .false.
+        verification: do i = 1, ntrials_
+
+            !-----------------------------------
+            !-----     VECTOR ADDITION     -----
+            !-----------------------------------
+
+            addition_distributivity: block
+                class(abstract_vector_rsp), allocatable :: u, v, w
+                class(abstract_vector_rsp), allocatable :: wrk1, wrk2
+
+                !> Generate random vectors.
+                allocate(u, v, w, wrk1, wrk2, source=x)
+                call u%rand()
+                call v%rand()
+                call w%rand()
+
+                !> Check distributivity.
+                wrk1 = v
+                wrk2 = v
+                call wrk1%add(w)    ! v + w
+                call wrk2%add(u)    ! u + v
+
+                call u%add(wrk1)    ! u + (v + w)
+                call w%add(wrk2)    ! (u + v) + w
+
+                call u%sub(w)
+                print *, u%norm(), tol
+                success = merge(.true., .false., u%norm() <= tol)
+                if (.not. success) exit verification
+            end block addition_distributivity
+
+            addition_commutativity: block
+                class(abstract_vector_rsp), allocatable :: u, v, w
+
+                !> Generate random vectors.
+                allocate(u, v, source=x)
+                call u%rand()
+                call v%rand()
+                w = v
+
+                !> Check commutativity.
+                call v%add(u)
+                call u%add(w)
+
+                call u%sub(v)
+                success = merge(.true., .false., u%norm() <= tol)
+                if (.not. success) exit verification
+            end block addition_commutativity
+
+            addition_zero: block
+                class(abstract_vector_rsp), allocatable :: u, v, z
+
+                !> Generate random vector.
+                allocate(u, v, z, source=x)
+                v = u
+                call z%zero()
+
+                !> Check zero element.
+                call u%add(z)
+                call u%sub(v)
+                success = merge(.true., .false., u%norm() <= tol)
+                if (.not. success) exit verification
+            end block addition_zero
+
+            additive_inverse: block
+                class(abstract_vector_rsp), allocatable :: u, v
+                allocate(u, source=x)
+                call u%rand()
+                v = u
+                call u%sub(v)
+                success = merge(.true., .false., u%norm() <= tol)
+                if (.not. success) exit verification
+            end block additive_inverse
+
+            !-----------------------------------------
+            !-----     SCALAR MULTIPLICATION     -----
+            !-----------------------------------------
+            scaling_identity: block
+                class(abstract_vector_rsp), allocatable :: u, v
+                real(sp), parameter :: one = 1.0_sp
+
+                !> Generate random vector.
+                allocate(u, v, source=x)
+                call u%rand()
+                v = u
+                !> Check identity.
+                call v%scal(one)
+                call u%sub(v)
+                success = merge(.true., .false., u%norm() <= tol)
+                if (.not. success) exit verification
+            end block scaling_identity
+
+            scaling_compatibility: block
+                class(abstract_vector_rsp), allocatable :: u, v
+                real(sp) :: a, b
+                call random_number(a)
+                call random_number(b)
+
+                !> Generate random vectors.
+                allocate(u, v, source=x)
+                call u%rand(ifnorm=.true.)
+                v = u
+
+                !> Check associativity.
+                call v%scal(b)
+                call v%scal(a)
+                call u%scal(a*b)
+                call u%sub(v)
+                success = merge(.true., .false., u%norm() <= tol)
+                if (.not. success) exit verification
+            end block scaling_compatibility
+
+            scaling_distributivity: block
+                class(abstract_vector_rsp), allocatable :: u, v, w
+                real(sp) :: a
+                call random_number(a)
+
+                !> Generate random vectors.
+                allocate(u, v, w, source=x)
+                call u%rand()
+                call v%rand()
+                w = u
+
+                !> Check distributivity.
+                call w%add(v)
+                call w%scal(a)
+
+                call u%scal(a)
+                call v%scal(a)
+                call v%add(u)
+
+                call v%sub(w)
+                success = merge(.true., .false., v%norm() <= tol)
+                if (.not. success) exit verification
+            end block scaling_distributivity
+
+            scaling_distributivity_bis: block
+                class(abstract_vector_rsp), allocatable :: u, v
+                real(sp) :: a, b
+                call random_number(a)
+                call random_number(b)
+
+                !> Generate random vector.
+                allocate(u, source=x)
+                call u%rand()
+                v = u
+
+                !> Check distributivity.
+                call v%axpby(a, u, b)
+                call u%scal(a+b)
+
+                call v%sub(u)
+                success = merge(.true., .false., v%norm() <= tol)
+                if (.not. success) exit verification
+            end block scaling_distributivity_bis
+        enddo verification
+    end function verify_vector_axioms_rsp
+
     subroutine linear_combination_vector_rdp(y, X, v)
         !! Given `X` and `v`, this function return \( \mathbf{y} = \mathbf{Xv} \) where
         !! `y` is an `abstract_vector`, `X` an array of `abstract_vector` and `v` a
@@ -1588,6 +1773,182 @@ contains
         logical, optional, intent(in) :: ifnorm
         call X%rand(ifnorm=ifnorm)
     end subroutine rand_basis_rdp
+
+
+    logical function verify_vector_axioms_rdp(x, ntrials, tolerance) result(success)
+        implicit none(type, external)
+        class(abstract_vector_rdp), intent(in) :: x
+        !! Derived-type whose implementation needs to be tested.
+        integer, optional, intent(in) :: ntrials
+        !! Number of random samples generated for the tests.
+        real(dp), optional, intent(in) :: tolerance
+
+        integer :: ntrials_, i
+        real(dp) :: tol
+
+        !> Deals with optional argument.
+        ntrials_ = optval(ntrials, 100)
+        tol = optval(tolerance, 10.0_dp**(-(precision(1.0_dp)-1)))
+
+        !> Run all tests to verify axioms.
+        success = .false.
+        verification: do i = 1, ntrials_
+
+            !-----------------------------------
+            !-----     VECTOR ADDITION     -----
+            !-----------------------------------
+
+            addition_distributivity: block
+                class(abstract_vector_rdp), allocatable :: u, v, w
+                class(abstract_vector_rdp), allocatable :: wrk1, wrk2
+
+                !> Generate random vectors.
+                allocate(u, v, w, wrk1, wrk2, source=x)
+                call u%rand()
+                call v%rand()
+                call w%rand()
+
+                !> Check distributivity.
+                wrk1 = v
+                wrk2 = v
+                call wrk1%add(w)    ! v + w
+                call wrk2%add(u)    ! u + v
+
+                call u%add(wrk1)    ! u + (v + w)
+                call w%add(wrk2)    ! (u + v) + w
+
+                call u%sub(w)
+                print *, u%norm(), tol
+                success = merge(.true., .false., u%norm() <= tol)
+                if (.not. success) exit verification
+            end block addition_distributivity
+
+            addition_commutativity: block
+                class(abstract_vector_rdp), allocatable :: u, v, w
+
+                !> Generate random vectors.
+                allocate(u, v, source=x)
+                call u%rand()
+                call v%rand()
+                w = v
+
+                !> Check commutativity.
+                call v%add(u)
+                call u%add(w)
+
+                call u%sub(v)
+                success = merge(.true., .false., u%norm() <= tol)
+                if (.not. success) exit verification
+            end block addition_commutativity
+
+            addition_zero: block
+                class(abstract_vector_rdp), allocatable :: u, v, z
+
+                !> Generate random vector.
+                allocate(u, v, z, source=x)
+                v = u
+                call z%zero()
+
+                !> Check zero element.
+                call u%add(z)
+                call u%sub(v)
+                success = merge(.true., .false., u%norm() <= tol)
+                if (.not. success) exit verification
+            end block addition_zero
+
+            additive_inverse: block
+                class(abstract_vector_rdp), allocatable :: u, v
+                allocate(u, source=x)
+                call u%rand()
+                v = u
+                call u%sub(v)
+                success = merge(.true., .false., u%norm() <= tol)
+                if (.not. success) exit verification
+            end block additive_inverse
+
+            !-----------------------------------------
+            !-----     SCALAR MULTIPLICATION     -----
+            !-----------------------------------------
+            scaling_identity: block
+                class(abstract_vector_rdp), allocatable :: u, v
+                real(dp), parameter :: one = 1.0_dp
+
+                !> Generate random vector.
+                allocate(u, v, source=x)
+                call u%rand()
+                v = u
+                !> Check identity.
+                call v%scal(one)
+                call u%sub(v)
+                success = merge(.true., .false., u%norm() <= tol)
+                if (.not. success) exit verification
+            end block scaling_identity
+
+            scaling_compatibility: block
+                class(abstract_vector_rdp), allocatable :: u, v
+                real(dp) :: a, b
+                call random_number(a)
+                call random_number(b)
+
+                !> Generate random vectors.
+                allocate(u, v, source=x)
+                call u%rand(ifnorm=.true.)
+                v = u
+
+                !> Check associativity.
+                call v%scal(b)
+                call v%scal(a)
+                call u%scal(a*b)
+                call u%sub(v)
+                success = merge(.true., .false., u%norm() <= tol)
+                if (.not. success) exit verification
+            end block scaling_compatibility
+
+            scaling_distributivity: block
+                class(abstract_vector_rdp), allocatable :: u, v, w
+                real(dp) :: a
+                call random_number(a)
+
+                !> Generate random vectors.
+                allocate(u, v, w, source=x)
+                call u%rand()
+                call v%rand()
+                w = u
+
+                !> Check distributivity.
+                call w%add(v)
+                call w%scal(a)
+
+                call u%scal(a)
+                call v%scal(a)
+                call v%add(u)
+
+                call v%sub(w)
+                success = merge(.true., .false., v%norm() <= tol)
+                if (.not. success) exit verification
+            end block scaling_distributivity
+
+            scaling_distributivity_bis: block
+                class(abstract_vector_rdp), allocatable :: u, v
+                real(dp) :: a, b
+                call random_number(a)
+                call random_number(b)
+
+                !> Generate random vector.
+                allocate(u, source=x)
+                call u%rand()
+                v = u
+
+                !> Check distributivity.
+                call v%axpby(a, u, b)
+                call u%scal(a+b)
+
+                call v%sub(u)
+                success = merge(.true., .false., v%norm() <= tol)
+                if (.not. success) exit verification
+            end block scaling_distributivity_bis
+        enddo verification
+    end function verify_vector_axioms_rdp
 
     subroutine linear_combination_vector_csp(y, X, v)
         !! Given `X` and `v`, this function return \( \mathbf{y} = \mathbf{Xv} \) where
@@ -1750,6 +2111,190 @@ contains
         call X%rand(ifnorm=ifnorm)
     end subroutine rand_basis_csp
 
+
+    logical function verify_vector_axioms_csp(x, ntrials, tolerance) result(success)
+        implicit none(type, external)
+        class(abstract_vector_csp), intent(in) :: x
+        !! Derived-type whose implementation needs to be tested.
+        integer, optional, intent(in) :: ntrials
+        !! Number of random samples generated for the tests.
+        real(sp), optional, intent(in) :: tolerance
+
+        integer :: ntrials_, i
+        real(sp) :: tol
+
+        !> Deals with optional argument.
+        ntrials_ = optval(ntrials, 100)
+        tol = optval(tolerance, 10.0_sp**(-(precision(1.0_sp)-1)))
+
+        !> Run all tests to verify axioms.
+        success = .false.
+        verification: do i = 1, ntrials_
+
+            !-----------------------------------
+            !-----     VECTOR ADDITION     -----
+            !-----------------------------------
+
+            addition_distributivity: block
+                class(abstract_vector_csp), allocatable :: u, v, w
+                class(abstract_vector_csp), allocatable :: wrk1, wrk2
+
+                !> Generate random vectors.
+                allocate(u, v, w, wrk1, wrk2, source=x)
+                call u%rand()
+                call v%rand()
+                call w%rand()
+
+                !> Check distributivity.
+                wrk1 = v
+                wrk2 = v
+                call wrk1%add(w)    ! v + w
+                call wrk2%add(u)    ! u + v
+
+                call u%add(wrk1)    ! u + (v + w)
+                call w%add(wrk2)    ! (u + v) + w
+
+                call u%sub(w)
+                print *, u%norm(), tol
+                success = merge(.true., .false., u%norm() <= tol)
+                if (.not. success) exit verification
+            end block addition_distributivity
+
+            addition_commutativity: block
+                class(abstract_vector_csp), allocatable :: u, v, w
+
+                !> Generate random vectors.
+                allocate(u, v, source=x)
+                call u%rand()
+                call v%rand()
+                w = v
+
+                !> Check commutativity.
+                call v%add(u)
+                call u%add(w)
+
+                call u%sub(v)
+                success = merge(.true., .false., u%norm() <= tol)
+                if (.not. success) exit verification
+            end block addition_commutativity
+
+            addition_zero: block
+                class(abstract_vector_csp), allocatable :: u, v, z
+
+                !> Generate random vector.
+                allocate(u, v, z, source=x)
+                v = u
+                call z%zero()
+
+                !> Check zero element.
+                call u%add(z)
+                call u%sub(v)
+                success = merge(.true., .false., u%norm() <= tol)
+                if (.not. success) exit verification
+            end block addition_zero
+
+            additive_inverse: block
+                class(abstract_vector_csp), allocatable :: u, v
+                allocate(u, source=x)
+                call u%rand()
+                v = u
+                call u%sub(v)
+                success = merge(.true., .false., u%norm() <= tol)
+                if (.not. success) exit verification
+            end block additive_inverse
+
+            !-----------------------------------------
+            !-----     SCALAR MULTIPLICATION     -----
+            !-----------------------------------------
+            scaling_identity: block
+                class(abstract_vector_csp), allocatable :: u, v
+                complex(sp), parameter :: one = 1.0_sp
+
+                !> Generate random vector.
+                allocate(u, v, source=x)
+                call u%rand()
+                v = u
+                !> Check identity.
+                call v%scal(one)
+                call u%sub(v)
+                success = merge(.true., .false., u%norm() <= tol)
+                if (.not. success) exit verification
+            end block scaling_identity
+
+            scaling_compatibility: block
+                class(abstract_vector_csp), allocatable :: u, v
+                complex(sp) :: a, b
+                real(sp) :: c(2)
+                call random_number(c)
+                a = cmplx(c(1), c(2), kind=sp)
+                call random_number(c)
+                b = cmplx(c(1), c(2), kind=sp)
+
+                !> Generate random vectors.
+                allocate(u, v, source=x)
+                call u%rand(ifnorm=.true.)
+                v = u
+
+                !> Check associativity.
+                call v%scal(b)
+                call v%scal(a)
+                call u%scal(a*b)
+                call u%sub(v)
+                success = merge(.true., .false., u%norm() <= tol)
+                if (.not. success) exit verification
+            end block scaling_compatibility
+
+            scaling_distributivity: block
+                class(abstract_vector_csp), allocatable :: u, v, w
+                complex(sp) :: a
+                real(sp) :: b(2)
+                call random_number(b)
+                a = cmplx(b(1), b(2), kind=sp)
+
+                !> Generate random vectors.
+                allocate(u, v, w, source=x)
+                call u%rand()
+                call v%rand()
+                w = u
+
+                !> Check distributivity.
+                call w%add(v)
+                call w%scal(a)
+
+                call u%scal(a)
+                call v%scal(a)
+                call v%add(u)
+
+                call v%sub(w)
+                success = merge(.true., .false., v%norm() <= tol)
+                if (.not. success) exit verification
+            end block scaling_distributivity
+
+            scaling_distributivity_bis: block
+                class(abstract_vector_csp), allocatable :: u, v
+                complex(sp) :: a, b
+                real(sp) :: c(2)
+                call random_number(c)
+                a = cmplx(c(1), c(2), kind=sp)
+                call random_number(c)
+                b = cmplx(c(1), c(2), kind=sp)
+
+                !> Generate random vector.
+                allocate(u, source=x)
+                call u%rand()
+                v = u
+
+                !> Check distributivity.
+                call v%axpby(a, u, b)
+                call u%scal(a+b)
+
+                call v%sub(u)
+                success = merge(.true., .false., v%norm() <= tol)
+                if (.not. success) exit verification
+            end block scaling_distributivity_bis
+        enddo verification
+    end function verify_vector_axioms_csp
+
     subroutine linear_combination_vector_cdp(y, X, v)
         !! Given `X` and `v`, this function return \( \mathbf{y} = \mathbf{Xv} \) where
         !! `y` is an `abstract_vector`, `X` an array of `abstract_vector` and `v` a
@@ -1910,5 +2455,189 @@ contains
         logical, optional, intent(in) :: ifnorm
         call X%rand(ifnorm=ifnorm)
     end subroutine rand_basis_cdp
+
+
+    logical function verify_vector_axioms_cdp(x, ntrials, tolerance) result(success)
+        implicit none(type, external)
+        class(abstract_vector_cdp), intent(in) :: x
+        !! Derived-type whose implementation needs to be tested.
+        integer, optional, intent(in) :: ntrials
+        !! Number of random samples generated for the tests.
+        real(dp), optional, intent(in) :: tolerance
+
+        integer :: ntrials_, i
+        real(dp) :: tol
+
+        !> Deals with optional argument.
+        ntrials_ = optval(ntrials, 100)
+        tol = optval(tolerance, 10.0_dp**(-(precision(1.0_dp)-1)))
+
+        !> Run all tests to verify axioms.
+        success = .false.
+        verification: do i = 1, ntrials_
+
+            !-----------------------------------
+            !-----     VECTOR ADDITION     -----
+            !-----------------------------------
+
+            addition_distributivity: block
+                class(abstract_vector_cdp), allocatable :: u, v, w
+                class(abstract_vector_cdp), allocatable :: wrk1, wrk2
+
+                !> Generate random vectors.
+                allocate(u, v, w, wrk1, wrk2, source=x)
+                call u%rand()
+                call v%rand()
+                call w%rand()
+
+                !> Check distributivity.
+                wrk1 = v
+                wrk2 = v
+                call wrk1%add(w)    ! v + w
+                call wrk2%add(u)    ! u + v
+
+                call u%add(wrk1)    ! u + (v + w)
+                call w%add(wrk2)    ! (u + v) + w
+
+                call u%sub(w)
+                print *, u%norm(), tol
+                success = merge(.true., .false., u%norm() <= tol)
+                if (.not. success) exit verification
+            end block addition_distributivity
+
+            addition_commutativity: block
+                class(abstract_vector_cdp), allocatable :: u, v, w
+
+                !> Generate random vectors.
+                allocate(u, v, source=x)
+                call u%rand()
+                call v%rand()
+                w = v
+
+                !> Check commutativity.
+                call v%add(u)
+                call u%add(w)
+
+                call u%sub(v)
+                success = merge(.true., .false., u%norm() <= tol)
+                if (.not. success) exit verification
+            end block addition_commutativity
+
+            addition_zero: block
+                class(abstract_vector_cdp), allocatable :: u, v, z
+
+                !> Generate random vector.
+                allocate(u, v, z, source=x)
+                v = u
+                call z%zero()
+
+                !> Check zero element.
+                call u%add(z)
+                call u%sub(v)
+                success = merge(.true., .false., u%norm() <= tol)
+                if (.not. success) exit verification
+            end block addition_zero
+
+            additive_inverse: block
+                class(abstract_vector_cdp), allocatable :: u, v
+                allocate(u, source=x)
+                call u%rand()
+                v = u
+                call u%sub(v)
+                success = merge(.true., .false., u%norm() <= tol)
+                if (.not. success) exit verification
+            end block additive_inverse
+
+            !-----------------------------------------
+            !-----     SCALAR MULTIPLICATION     -----
+            !-----------------------------------------
+            scaling_identity: block
+                class(abstract_vector_cdp), allocatable :: u, v
+                complex(dp), parameter :: one = 1.0_dp
+
+                !> Generate random vector.
+                allocate(u, v, source=x)
+                call u%rand()
+                v = u
+                !> Check identity.
+                call v%scal(one)
+                call u%sub(v)
+                success = merge(.true., .false., u%norm() <= tol)
+                if (.not. success) exit verification
+            end block scaling_identity
+
+            scaling_compatibility: block
+                class(abstract_vector_cdp), allocatable :: u, v
+                complex(dp) :: a, b
+                real(dp) :: c(2)
+                call random_number(c)
+                a = cmplx(c(1), c(2), kind=dp)
+                call random_number(c)
+                b = cmplx(c(1), c(2), kind=dp)
+
+                !> Generate random vectors.
+                allocate(u, v, source=x)
+                call u%rand(ifnorm=.true.)
+                v = u
+
+                !> Check associativity.
+                call v%scal(b)
+                call v%scal(a)
+                call u%scal(a*b)
+                call u%sub(v)
+                success = merge(.true., .false., u%norm() <= tol)
+                if (.not. success) exit verification
+            end block scaling_compatibility
+
+            scaling_distributivity: block
+                class(abstract_vector_cdp), allocatable :: u, v, w
+                complex(dp) :: a
+                real(dp) :: b(2)
+                call random_number(b)
+                a = cmplx(b(1), b(2), kind=dp)
+
+                !> Generate random vectors.
+                allocate(u, v, w, source=x)
+                call u%rand()
+                call v%rand()
+                w = u
+
+                !> Check distributivity.
+                call w%add(v)
+                call w%scal(a)
+
+                call u%scal(a)
+                call v%scal(a)
+                call v%add(u)
+
+                call v%sub(w)
+                success = merge(.true., .false., v%norm() <= tol)
+                if (.not. success) exit verification
+            end block scaling_distributivity
+
+            scaling_distributivity_bis: block
+                class(abstract_vector_cdp), allocatable :: u, v
+                complex(dp) :: a, b
+                real(dp) :: c(2)
+                call random_number(c)
+                a = cmplx(c(1), c(2), kind=dp)
+                call random_number(c)
+                b = cmplx(c(1), c(2), kind=dp)
+
+                !> Generate random vector.
+                allocate(u, source=x)
+                call u%rand()
+                v = u
+
+                !> Check distributivity.
+                call v%axpby(a, u, b)
+                call u%scal(a+b)
+
+                call v%sub(u)
+                success = merge(.true., .false., v%norm() <= tol)
+                if (.not. success) exit verification
+            end block scaling_distributivity_bis
+        enddo verification
+    end function verify_vector_axioms_cdp
 
 end module LightKrylov_AbstractVectors

--- a/src/AbstractTypes/AbstractVectors.fypp
+++ b/src/AbstractTypes/AbstractVectors.fypp
@@ -20,7 +20,7 @@ module LightKrylov_AbstractVectors
     !! - `dot(self, vec)`               :   A function computing the inner product \( \alpha = \langle \mathbf{x} \vert \mathbf{y} \rangle \).
     !! - `get_size(self)`               :   A function returning the dimension \( n \) of the vector \( \mathbf{x} \).
     !!
-    !! Once these type-bound procedures have been implemented by the user, they will automatically 
+    !! Once these type-bound procedures have been implemented by the user, they will automatically
     !! be used to define:
     !!
     !! - vector addition    :   `add(self, vec) = axpby(1, vec, 1, self)`
@@ -64,7 +64,7 @@ module LightKrylov_AbstractVectors
         !!  ### Description
         !!
         !!  This interface provides methods for computing the inner products between a basis
-        !!  of `real` or `complex` vectors \( \mathbf{X} \) and a single vector 
+        !!  of `real` or `complex` vectors \( \mathbf{X} \) and a single vector
         !!  \( \mathbf{y} \) or another basis \( \mathbf{Y} \). Depending on the case, it
         !!  returns a one-dimensional array \( \mathbf{v} \) or a two-dimensional array
         !!  \( \mathbf{M} \) with the same type as \( \mathbf{X} \).
@@ -110,7 +110,7 @@ module LightKrylov_AbstractVectors
         !!
         !!  ### Description
         !!
-        !!  This interface provides methods for computing the Gram matrix associated to a basis of 
+        !!  This interface provides methods for computing the Gram matrix associated to a basis of
         !!  `abstract_vector` \( \mathbf{X} \).
         !!
         !!  ### Example
@@ -175,7 +175,7 @@ module LightKrylov_AbstractVectors
 
     interface axpby_basis
         !!  In-place addition of two arrays of extended `abstract_vector`.
-        !!  
+        !!
         !!  ### Description
         !!
         !!  This interface provides methods to add in-place two arrays of
@@ -456,7 +456,7 @@ contains
     !--------------------------------------------------------------------------------
     !-----     TYPE-BOUND PROCEDURES FOR THE CONVENIENCE DENSE VECTOR TYPES     -----
     !--------------------------------------------------------------------------------
-    
+
     #:for kind, type in RC_KINDS_TYPES
     function initialize_dense_vector_from_array_${type[0]}$${kind}$(x) result(vec)
         implicit none(type, external)
@@ -554,7 +554,7 @@ contains
     end function dense_get_size_${type[0]}$${kind}$
 
     #:endfor
-    
+
     !--------------------------------------
     !-----      UTILITY FUNCTIONS     -----
     !--------------------------------------
@@ -608,7 +608,7 @@ contains
         ! Internal variables.
         integer :: i, j, iostat
         character(len=100) :: errmsg
-    
+
         ! Check sizes.
         if (size(X) /= size(B, 1)) then
             call stop_error("Krylov basis X and combination matrix B have incompatible sizes.", &

--- a/src/AbstractTypes/AbstractVectors.fypp
+++ b/src/AbstractTypes/AbstractVectors.fypp
@@ -773,7 +773,6 @@ contains
                 call w%add(wrk2)    ! (u + v) + w
 
                 call u%sub(w)
-                print *, u%norm(), tol
                 success = merge(.true., .false., u%norm() <= tol)
                 if (.not. success) exit verification
             end block addition_distributivity

--- a/src/AbstractTypes/AbstractVectors.fypp
+++ b/src/AbstractTypes/AbstractVectors.fypp
@@ -56,6 +56,7 @@ module LightKrylov_AbstractVectors
     public :: zero_basis
     public :: copy
     public :: rand_basis
+    public :: verify_vector_axioms
 
     interface innerprod
         !!  Compute the inner product vector \( \mathbf{v} = \mathbf{X}^H \mathbf{y} \) or matrix
@@ -269,6 +270,13 @@ module LightKrylov_AbstractVectors
         module procedure rand_basis_${type[0]}$${kind}$
         #:endfor
     end interface
+
+    interface verify_vector_axioms
+        #:for kind, type in RC_KINDS_TYPES
+        module procedure verify_vector_axioms_${type[0]}$${kind}$
+        #:endfor
+    end interface
+
 
     type, abstract, public :: abstract_vector
         !!  Base abstract type from which all other types of vectors used in `LightKrylov`
@@ -720,6 +728,204 @@ contains
         logical, optional, intent(in) :: ifnorm
         call X%rand(ifnorm=ifnorm)
     end subroutine rand_basis_${type[0]}$${kind}$
+
+
+    logical function verify_vector_axioms_${type[0]}$${kind}$(x, ntrials, tolerance) result(success)
+        implicit none(type, external)
+        class(abstract_vector_${type[0]}$${kind}$), intent(in) :: x
+        !! Derived-type whose implementation needs to be tested.
+        integer, optional, intent(in) :: ntrials
+        !! Number of random samples generated for the tests.
+        real(${kind}$), optional, intent(in) :: tolerance
+
+        integer :: ntrials_, i
+        real(${kind}$) :: tol
+
+        !> Deals with optional argument.
+        ntrials_ = optval(ntrials, 100)
+        tol = optval(tolerance, 10.0_${kind}$**(-(precision(1.0_${kind}$)-1)))
+
+        !> Run all tests to verify axioms.
+        success = .false.
+        verification: do i = 1, ntrials_
+
+            !-----------------------------------
+            !-----     VECTOR ADDITION     -----
+            !-----------------------------------
+
+            addition_distributivity: block
+                class(abstract_vector_${type[0]}$${kind}$), allocatable :: u, v, w
+                class(abstract_vector_${type[0]}$${kind}$), allocatable :: wrk1, wrk2
+
+                !> Generate random vectors.
+                allocate(u, v, w, wrk1, wrk2, source=x)
+                call u%rand()
+                call v%rand()
+                call w%rand()
+
+                !> Check distributivity.
+                wrk1 = v
+                wrk2 = v
+                call wrk1%add(w)    ! v + w
+                call wrk2%add(u)    ! u + v
+
+                call u%add(wrk1)    ! u + (v + w)
+                call w%add(wrk2)    ! (u + v) + w
+
+                call u%sub(w)
+                print *, u%norm(), tol
+                success = merge(.true., .false., u%norm() <= tol)
+                if (.not. success) exit verification
+            end block addition_distributivity
+
+            addition_commutativity: block
+                class(abstract_vector_${type[0]}$${kind}$), allocatable :: u, v, w
+
+                !> Generate random vectors.
+                allocate(u, v, source=x)
+                call u%rand()
+                call v%rand()
+                w = v
+
+                !> Check commutativity.
+                call v%add(u)
+                call u%add(w)
+
+                call u%sub(v)
+                success = merge(.true., .false., u%norm() <= tol)
+                if (.not. success) exit verification
+            end block addition_commutativity
+
+            addition_zero: block
+                class(abstract_vector_${type[0]}$${kind}$), allocatable :: u, v, z
+
+                !> Generate random vector.
+                allocate(u, v, z, source=x)
+                v = u
+                call z%zero()
+
+                !> Check zero element.
+                call u%add(z)
+                call u%sub(v)
+                success = merge(.true., .false., u%norm() <= tol)
+                if (.not. success) exit verification
+            end block addition_zero
+
+            additive_inverse: block
+                class(abstract_vector_${type[0]}$${kind}$), allocatable :: u, v
+                allocate(u, source=x)
+                call u%rand()
+                v = u
+                call u%sub(v)
+                success = merge(.true., .false., u%norm() <= tol)
+                if (.not. success) exit verification
+            end block additive_inverse
+
+            !-----------------------------------------
+            !-----     SCALAR MULTIPLICATION     -----
+            !-----------------------------------------
+            scaling_identity: block
+                class(abstract_vector_${type[0]}$${kind}$), allocatable :: u, v
+                ${type}$, parameter :: one = 1.0_${kind}$
+
+                !> Generate random vector.
+                allocate(u, v, source=x)
+                call u%rand()
+                v = u
+                !> Check identity.
+                call v%scal(one)
+                call u%sub(v)
+                success = merge(.true., .false., u%norm() <= tol)
+                if (.not. success) exit verification
+            end block scaling_identity
+
+            scaling_compatibility: block
+                class(abstract_vector_${type[0]}$${kind}$), allocatable :: u, v
+                ${type}$ :: a, b
+                #:if type.startswith('complex')
+                real(${kind}$) :: c(2)
+                call random_number(c)
+                a = cmplx(c(1), c(2), kind=${kind}$)
+                call random_number(c)
+                b = cmplx(c(1), c(2), kind=${kind}$)
+                #:else
+                call random_number(a)
+                call random_number(b)
+                #:endif
+
+                !> Generate random vectors.
+                allocate(u, v, source=x)
+                call u%rand(ifnorm=.true.)
+                v = u
+
+                !> Check associativity.
+                call v%scal(b)
+                call v%scal(a)
+                call u%scal(a*b)
+                call u%sub(v)
+                success = merge(.true., .false., u%norm() <= tol)
+                if (.not. success) exit verification
+            end block scaling_compatibility
+
+            scaling_distributivity: block
+                class(abstract_vector_${type[0]}$${kind}$), allocatable :: u, v, w
+                ${type}$ :: a
+                #:if type.startswith('complex')
+                real(${kind}$) :: b(2)
+                call random_number(b)
+                a = cmplx(b(1), b(2), kind=${kind}$)
+                #:else
+                call random_number(a)
+                #:endif
+
+                !> Generate random vectors.
+                allocate(u, v, w, source=x)
+                call u%rand()
+                call v%rand()
+                w = u
+
+                !> Check distributivity.
+                call w%add(v)
+                call w%scal(a)
+
+                call u%scal(a)
+                call v%scal(a)
+                call v%add(u)
+
+                call v%sub(w)
+                success = merge(.true., .false., v%norm() <= tol)
+                if (.not. success) exit verification
+            end block scaling_distributivity
+
+            scaling_distributivity_bis: block
+                class(abstract_vector_${type[0]}$${kind}$), allocatable :: u, v
+                ${type}$ :: a, b
+                #:if type.startswith('complex')
+                real(${kind}$) :: c(2)
+                call random_number(c)
+                a = cmplx(c(1), c(2), kind=${kind}$)
+                call random_number(c)
+                b = cmplx(c(1), c(2), kind=${kind}$)
+                #:else
+                call random_number(a)
+                call random_number(b)
+                #:endif
+
+                !> Generate random vector.
+                allocate(u, source=x)
+                call u%rand()
+                v = u
+
+                !> Check distributivity.
+                call v%axpby(a, u, b)
+                call u%scal(a+b)
+
+                call v%sub(u)
+                success = merge(.true., .false., v%norm() <= tol)
+                if (.not. success) exit verification
+            end block scaling_distributivity_bis
+        enddo verification
+    end function verify_vector_axioms_${type[0]}$${kind}$
 
     #:endfor
 end module LightKrylov_AbstractVectors

--- a/src/LightKrylov.f90
+++ b/src/LightKrylov.f90
@@ -66,7 +66,8 @@ module LightKrylov
     public :: zero_basis
     public :: copy
     public :: rand_basis
-    
+    public :: verify_vector_axioms
+
     ! AbstractLinops exports.
     public :: abstract_linop
     public :: abstract_linop_rsp

--- a/src/LightKrylov.fypp
+++ b/src/LightKrylov.fypp
@@ -60,7 +60,8 @@ module LightKrylov
     public :: zero_basis
     public :: copy
     public :: rand_basis
-    
+    public :: verify_vector_axioms
+
     ! AbstractLinops exports.
     public :: abstract_linop
     #:for kind, type in RC_KINDS_TYPES

--- a/test/TestVectors.f90
+++ b/test/TestVectors.f90
@@ -39,10 +39,23 @@ contains
                     new_unittest("Vector scale", test_vector_rsp_scal)     , &
                     new_unittest("Vector addition", test_vector_rsp_add)   , &
                     new_unittest("Vector subtraction", test_vector_rsp_sub), &
-                    new_unittest("Vector dot product", test_vector_rsp_dot)  &
+                    new_unittest("Vector dot product", test_vector_rsp_dot), &
+                    new_unittest("Vector space axioms", test_vector_axioms_rsp) &
                     ]
         return
     end subroutine collect_vector_rsp_testsuite
+
+    subroutine test_vector_axioms_rsp(error)
+        type(error_type), allocatable, intent(out) :: error
+        type(dense_vector_rsp) :: x
+        real(sp) :: x_(n)
+        logical :: success
+        ! Initialize vector.
+        x_ = 0.0_sp ; x = dense_vector(x_)
+        success = verify_vector_axioms(x)
+        call check(error, success .eqv. .true.)
+        call check_test(error, 'test_vector_axioms_rsp', eq='Vector space axioms')
+    end subroutine test_vector_axioms_rsp
 
     subroutine test_vector_rsp_norm(error)
         ! Error type to be returned.
@@ -166,10 +179,23 @@ contains
                     new_unittest("Vector scale", test_vector_rdp_scal)     , &
                     new_unittest("Vector addition", test_vector_rdp_add)   , &
                     new_unittest("Vector subtraction", test_vector_rdp_sub), &
-                    new_unittest("Vector dot product", test_vector_rdp_dot)  &
+                    new_unittest("Vector dot product", test_vector_rdp_dot), &
+                    new_unittest("Vector space axioms", test_vector_axioms_rdp) &
                     ]
         return
     end subroutine collect_vector_rdp_testsuite
+
+    subroutine test_vector_axioms_rdp(error)
+        type(error_type), allocatable, intent(out) :: error
+        type(dense_vector_rdp) :: x
+        real(dp) :: x_(n)
+        logical :: success
+        ! Initialize vector.
+        x_ = 0.0_dp ; x = dense_vector(x_)
+        success = verify_vector_axioms(x)
+        call check(error, success .eqv. .true.)
+        call check_test(error, 'test_vector_axioms_rdp', eq='Vector space axioms')
+    end subroutine test_vector_axioms_rdp
 
     subroutine test_vector_rdp_norm(error)
         ! Error type to be returned.
@@ -293,10 +319,23 @@ contains
                     new_unittest("Vector scale", test_vector_csp_scal)     , &
                     new_unittest("Vector addition", test_vector_csp_add)   , &
                     new_unittest("Vector subtraction", test_vector_csp_sub), &
-                    new_unittest("Vector dot product", test_vector_csp_dot)  &
+                    new_unittest("Vector dot product", test_vector_csp_dot), &
+                    new_unittest("Vector space axioms", test_vector_axioms_csp) &
                     ]
         return
     end subroutine collect_vector_csp_testsuite
+
+    subroutine test_vector_axioms_csp(error)
+        type(error_type), allocatable, intent(out) :: error
+        type(dense_vector_csp) :: x
+        complex(sp) :: x_(n)
+        logical :: success
+        ! Initialize vector.
+        x_ = 0.0_sp ; x = dense_vector(x_)
+        success = verify_vector_axioms(x)
+        call check(error, success .eqv. .true.)
+        call check_test(error, 'test_vector_axioms_csp', eq='Vector space axioms')
+    end subroutine test_vector_axioms_csp
 
     subroutine test_vector_csp_norm(error)
         ! Error type to be returned.
@@ -421,10 +460,23 @@ contains
                     new_unittest("Vector scale", test_vector_cdp_scal)     , &
                     new_unittest("Vector addition", test_vector_cdp_add)   , &
                     new_unittest("Vector subtraction", test_vector_cdp_sub), &
-                    new_unittest("Vector dot product", test_vector_cdp_dot)  &
+                    new_unittest("Vector dot product", test_vector_cdp_dot), &
+                    new_unittest("Vector space axioms", test_vector_axioms_cdp) &
                     ]
         return
     end subroutine collect_vector_cdp_testsuite
+
+    subroutine test_vector_axioms_cdp(error)
+        type(error_type), allocatable, intent(out) :: error
+        type(dense_vector_cdp) :: x
+        complex(dp) :: x_(n)
+        logical :: success
+        ! Initialize vector.
+        x_ = 0.0_dp ; x = dense_vector(x_)
+        success = verify_vector_axioms(x)
+        call check(error, success .eqv. .true.)
+        call check_test(error, 'test_vector_axioms_cdp', eq='Vector space axioms')
+    end subroutine test_vector_axioms_cdp
 
     subroutine test_vector_cdp_norm(error)
         ! Error type to be returned.

--- a/test/TestVectors.fypp
+++ b/test/TestVectors.fypp
@@ -41,10 +41,23 @@ contains
                     new_unittest("Vector scale", test_vector_${type[0]}$${kind}$_scal)     , &
                     new_unittest("Vector addition", test_vector_${type[0]}$${kind}$_add)   , &
                     new_unittest("Vector subtraction", test_vector_${type[0]}$${kind}$_sub), &
-                    new_unittest("Vector dot product", test_vector_${type[0]}$${kind}$_dot)  &
+                    new_unittest("Vector dot product", test_vector_${type[0]}$${kind}$_dot), &
+                    new_unittest("Vector space axioms", test_vector_axioms_${type[0]}$${kind}$) &
                     ]
         return
     end subroutine collect_vector_${type[0]}$${kind}$_testsuite
+
+    subroutine test_vector_axioms_${type[0]}$${kind}$(error)
+        type(error_type), allocatable, intent(out) :: error
+        type(dense_vector_${type[0]}$${kind}$) :: x
+        ${type}$ :: x_(n)
+        logical :: success
+        ! Initialize vector.
+        x_ = 0.0_${kind}$ ; x = dense_vector(x_)
+        success = verify_vector_axioms(x)
+        call check(error, success .eqv. .true.)
+        call check_test(error, 'test_vector_axioms_${type[0]}$${kind}$', eq='Vector space axioms')
+    end subroutine test_vector_axioms_${type[0]}$${kind}$
 
     subroutine test_vector_${type[0]}$${kind}$_norm(error)
         ! Error type to be returned.


### PR DESCRIPTION
This PR introduces the utility function `verify_vector_axioms`, a quality-of-life addition to facilitate the verification of user's extension of `abstract_vector`. The signature is as follows

```fortran
success = verify_vector_axioms(x, ntrials, tolerance)
```

where `x` is the vector type defined by the user, `ntrials` is the number of random vectors generated for each internal tests, and `tolerance` is the user-specified tolerance to define whether the tests pass or not.