### PR TITLE
Improvement of the vector + linop axiom tests

### DIFF
--- a/src/AbstractTypes/AbstractLinops.f90
+++ b/src/AbstractTypes/AbstractLinops.f90
@@ -1683,7 +1683,7 @@ contains
     !-----      UTILITY FUNCTIONS     -----
     !--------------------------------------
 
-    logical function verify_linop_axioms_rsp(A, x, ntrials, tolerance, test_adjoint) result(success)
+    logical function verify_linop_axioms_rsp(A, x, ntrials, tolerance, test_zero_map, test_adjoint) result(success)
         implicit none(type, external)
         class(abstract_linop_rsp), intent(inout) :: A
         !! Linear operator whose implementation needs to be tested.
@@ -1693,11 +1693,13 @@ contains
         !! Number of random samples generated for the tests.
         real(sp), optional, intent(in) :: tolerance
         !! Tolerance used for the axiom checks.
+        logical, optional, intent(in) :: test_zero_map
+        !! Verify explicitly that the operator maps x = 0 to 0? (Default: .true.)
         logical, optional, intent(in) :: test_adjoint
         !! Verify also the adjoint consistency `<A u, v> = <u, A^H v>`? (Default: .true.)
 
         integer :: ntrials_, i
-        logical :: test_adjoint_
+        logical :: test_zero_map_, test_adjoint_
         real(sp) :: tol, error_norm, scale
         character(len=128) :: failed_test
         character(len=256) :: msg
@@ -1707,6 +1709,7 @@ contains
         !> Deals with optional arguments.
         ntrials_ = optval(ntrials, 10)
         tol = optval(tolerance, 10.0_sp**(-(precision(1.0_sp)-1)))
+        test_zero_map_ = optval(test_zero_map, .true.)
         test_adjoint_ = optval(test_adjoint, .true.)
 
         !> Run all tests to verify axioms.
@@ -1751,6 +1754,7 @@ contains
 
                 !> Generate random vectors.
                 allocate(u, Au, Aau, source=x)
+                call u%rand()
                 call random_number(alpha)
 
                 !> Check homogeneity.
@@ -1774,22 +1778,24 @@ contains
             !-------------------------------------------
             !-----     ZERO MAPS TO ZERO           -----
             !-------------------------------------------
-            zero_to_zero: block
-                class(abstract_vector_rsp), allocatable :: u, Au
+            if (test_zero_map_) then
+                zero_to_zero: block
+                    class(abstract_vector_rsp), allocatable :: u, Au
 
-                !> Check that the zero vector is mapped to the zero vector.
-                allocate(u, Au, source=x)
-                call u%zero()
-                call A%apply_matvec(u, Au)
-                error_norm = Au%norm()
-                success = merge(.true., .false., error_norm <= tol)
+                    !> Check that the zero vector is mapped to the zero vector.
+                    allocate(u, Au, source=x)
+                    call u%zero()
+                    call A%apply_matvec(u, Au)
+                    error_norm = Au%norm()
+                    success = merge(.true., .false., error_norm <= tol)
 
-                !> Exit if the test fails.
-                if (.not. success) then
-                    failed_test = 'zero_to_zero'
-                    exit verification
-                end if
-            end block zero_to_zero
+                    !> Exit if the test fails.
+                    if (.not. success) then
+                        failed_test = 'zero_to_zero'
+                        exit verification
+                    end if
+                end block zero_to_zero
+            end if
 
             !-------------------------------------------
             !-----     ADJOINT CONSISTENCY         -----
@@ -1835,7 +1841,7 @@ contains
 
     end function verify_linop_axioms_rsp
 
-    logical function verify_linop_axioms_rdp(A, x, ntrials, tolerance, test_adjoint) result(success)
+    logical function verify_linop_axioms_rdp(A, x, ntrials, tolerance, test_zero_map, test_adjoint) result(success)
         implicit none(type, external)
         class(abstract_linop_rdp), intent(inout) :: A
         !! Linear operator whose implementation needs to be tested.
@@ -1845,11 +1851,13 @@ contains
         !! Number of random samples generated for the tests.
         real(dp), optional, intent(in) :: tolerance
         !! Tolerance used for the axiom checks.
+        logical, optional, intent(in) :: test_zero_map
+        !! Verify explicitly that the operator maps x = 0 to 0? (Default: .true.)
         logical, optional, intent(in) :: test_adjoint
         !! Verify also the adjoint consistency `<A u, v> = <u, A^H v>`? (Default: .true.)
 
         integer :: ntrials_, i
-        logical :: test_adjoint_
+        logical :: test_zero_map_, test_adjoint_
         real(dp) :: tol, error_norm, scale
         character(len=128) :: failed_test
         character(len=256) :: msg
@@ -1859,6 +1867,7 @@ contains
         !> Deals with optional arguments.
         ntrials_ = optval(ntrials, 10)
         tol = optval(tolerance, 10.0_dp**(-(precision(1.0_dp)-1)))
+        test_zero_map_ = optval(test_zero_map, .true.)
         test_adjoint_ = optval(test_adjoint, .true.)
 
         !> Run all tests to verify axioms.
@@ -1903,6 +1912,7 @@ contains
 
                 !> Generate random vectors.
                 allocate(u, Au, Aau, source=x)
+                call u%rand()
                 call random_number(alpha)
 
                 !> Check homogeneity.
@@ -1926,22 +1936,24 @@ contains
             !-------------------------------------------
             !-----     ZERO MAPS TO ZERO           -----
             !-------------------------------------------
-            zero_to_zero: block
-                class(abstract_vector_rdp), allocatable :: u, Au
+            if (test_zero_map_) then
+                zero_to_zero: block
+                    class(abstract_vector_rdp), allocatable :: u, Au
 
-                !> Check that the zero vector is mapped to the zero vector.
-                allocate(u, Au, source=x)
-                call u%zero()
-                call A%apply_matvec(u, Au)
-                error_norm = Au%norm()
-                success = merge(.true., .false., error_norm <= tol)
+                    !> Check that the zero vector is mapped to the zero vector.
+                    allocate(u, Au, source=x)
+                    call u%zero()
+                    call A%apply_matvec(u, Au)
+                    error_norm = Au%norm()
+                    success = merge(.true., .false., error_norm <= tol)
 
-                !> Exit if the test fails.
-                if (.not. success) then
-                    failed_test = 'zero_to_zero'
-                    exit verification
-                end if
-            end block zero_to_zero
+                    !> Exit if the test fails.
+                    if (.not. success) then
+                        failed_test = 'zero_to_zero'
+                        exit verification
+                    end if
+                end block zero_to_zero
+            end if
 
             !-------------------------------------------
             !-----     ADJOINT CONSISTENCY         -----
@@ -1987,7 +1999,7 @@ contains
 
     end function verify_linop_axioms_rdp
 
-    logical function verify_linop_axioms_csp(A, x, ntrials, tolerance, test_adjoint) result(success)
+    logical function verify_linop_axioms_csp(A, x, ntrials, tolerance, test_zero_map, test_adjoint) result(success)
         implicit none(type, external)
         class(abstract_linop_csp), intent(inout) :: A
         !! Linear operator whose implementation needs to be tested.
@@ -1997,11 +2009,13 @@ contains
         !! Number of random samples generated for the tests.
         real(sp), optional, intent(in) :: tolerance
         !! Tolerance used for the axiom checks.
+        logical, optional, intent(in) :: test_zero_map
+        !! Verify explicitly that the operator maps x = 0 to 0? (Default: .true.)
         logical, optional, intent(in) :: test_adjoint
         !! Verify also the adjoint consistency `<A u, v> = <u, A^H v>`? (Default: .true.)
 
         integer :: ntrials_, i
-        logical :: test_adjoint_
+        logical :: test_zero_map_, test_adjoint_
         real(sp) :: tol, error_norm, scale
         character(len=128) :: failed_test
         character(len=256) :: msg
@@ -2011,6 +2025,7 @@ contains
         !> Deals with optional arguments.
         ntrials_ = optval(ntrials, 10)
         tol = optval(tolerance, 10.0_sp**(-(precision(1.0_sp)-1)))
+        test_zero_map_ = optval(test_zero_map, .true.)
         test_adjoint_ = optval(test_adjoint, .true.)
 
         !> Run all tests to verify axioms.
@@ -2055,6 +2070,7 @@ contains
 
                 !> Generate random vectors.
                 allocate(u, Au, Aau, source=x)
+                call u%rand()
                 alpha = cmplx(0.0_sp, 0.0_sp, kind=sp)
                 call random_number(alpha%re) ; call random_number(alpha%im)
 
@@ -2079,22 +2095,24 @@ contains
             !-------------------------------------------
             !-----     ZERO MAPS TO ZERO           -----
             !-------------------------------------------
-            zero_to_zero: block
-                class(abstract_vector_csp), allocatable :: u, Au
+            if (test_zero_map_) then
+                zero_to_zero: block
+                    class(abstract_vector_csp), allocatable :: u, Au
 
-                !> Check that the zero vector is mapped to the zero vector.
-                allocate(u, Au, source=x)
-                call u%zero()
-                call A%apply_matvec(u, Au)
-                error_norm = Au%norm()
-                success = merge(.true., .false., error_norm <= tol)
+                    !> Check that the zero vector is mapped to the zero vector.
+                    allocate(u, Au, source=x)
+                    call u%zero()
+                    call A%apply_matvec(u, Au)
+                    error_norm = Au%norm()
+                    success = merge(.true., .false., error_norm <= tol)
 
-                !> Exit if the test fails.
-                if (.not. success) then
-                    failed_test = 'zero_to_zero'
-                    exit verification
-                end if
-            end block zero_to_zero
+                    !> Exit if the test fails.
+                    if (.not. success) then
+                        failed_test = 'zero_to_zero'
+                        exit verification
+                    end if
+                end block zero_to_zero
+            end if
 
             !-------------------------------------------
             !-----     ADJOINT CONSISTENCY         -----
@@ -2140,7 +2158,7 @@ contains
 
     end function verify_linop_axioms_csp
 
-    logical function verify_linop_axioms_cdp(A, x, ntrials, tolerance, test_adjoint) result(success)
+    logical function verify_linop_axioms_cdp(A, x, ntrials, tolerance, test_zero_map, test_adjoint) result(success)
         implicit none(type, external)
         class(abstract_linop_cdp), intent(inout) :: A
         !! Linear operator whose implementation needs to be tested.
@@ -2150,11 +2168,13 @@ contains
         !! Number of random samples generated for the tests.
         real(dp), optional, intent(in) :: tolerance
         !! Tolerance used for the axiom checks.
+        logical, optional, intent(in) :: test_zero_map
+        !! Verify explicitly that the operator maps x = 0 to 0? (Default: .true.)
         logical, optional, intent(in) :: test_adjoint
         !! Verify also the adjoint consistency `<A u, v> = <u, A^H v>`? (Default: .true.)
 
         integer :: ntrials_, i
-        logical :: test_adjoint_
+        logical :: test_zero_map_, test_adjoint_
         real(dp) :: tol, error_norm, scale
         character(len=128) :: failed_test
         character(len=256) :: msg
@@ -2164,6 +2184,7 @@ contains
         !> Deals with optional arguments.
         ntrials_ = optval(ntrials, 10)
         tol = optval(tolerance, 10.0_dp**(-(precision(1.0_dp)-1)))
+        test_zero_map_ = optval(test_zero_map, .true.)
         test_adjoint_ = optval(test_adjoint, .true.)
 
         !> Run all tests to verify axioms.
@@ -2208,6 +2229,7 @@ contains
 
                 !> Generate random vectors.
                 allocate(u, Au, Aau, source=x)
+                call u%rand()
                 alpha = cmplx(0.0_dp, 0.0_dp, kind=dp)
                 call random_number(alpha%re) ; call random_number(alpha%im)
 
@@ -2232,22 +2254,24 @@ contains
             !-------------------------------------------
             !-----     ZERO MAPS TO ZERO           -----
             !-------------------------------------------
-            zero_to_zero: block
-                class(abstract_vector_cdp), allocatable :: u, Au
+            if (test_zero_map_) then
+                zero_to_zero: block
+                    class(abstract_vector_cdp), allocatable :: u, Au
 
-                !> Check that the zero vector is mapped to the zero vector.
-                allocate(u, Au, source=x)
-                call u%zero()
-                call A%apply_matvec(u, Au)
-                error_norm = Au%norm()
-                success = merge(.true., .false., error_norm <= tol)
+                    !> Check that the zero vector is mapped to the zero vector.
+                    allocate(u, Au, source=x)
+                    call u%zero()
+                    call A%apply_matvec(u, Au)
+                    error_norm = Au%norm()
+                    success = merge(.true., .false., error_norm <= tol)
 
-                !> Exit if the test fails.
-                if (.not. success) then
-                    failed_test = 'zero_to_zero'
-                    exit verification
-                end if
-            end block zero_to_zero
+                    !> Exit if the test fails.
+                    if (.not. success) then
+                        failed_test = 'zero_to_zero'
+                        exit verification
+                    end if
+                end block zero_to_zero
+            end if
 
             !-------------------------------------------
             !-----     ADJOINT CONSISTENCY         -----

--- a/src/AbstractTypes/AbstractLinops.f90
+++ b/src/AbstractTypes/AbstractLinops.f90
@@ -1755,7 +1755,8 @@ contains
                 !> Generate random vectors.
                 allocate(u, Au, Aau, source=x)
                 call u%rand()
-                call random_number(alpha)
+                !> generate the identical non-trivial alpha on all ranks
+                alpha = (-1.0_sp)**i * (1.0_sp + real(i,sp))
 
                 !> Check homogeneity.
                 call A%apply_matvec(u, Au) ; call Au%scal(alpha)
@@ -1913,7 +1914,8 @@ contains
                 !> Generate random vectors.
                 allocate(u, Au, Aau, source=x)
                 call u%rand()
-                call random_number(alpha)
+                !> generate the identical non-trivial alpha on all ranks
+                alpha = (-1.0_dp)**i * (1.0_dp + real(i,dp))
 
                 !> Check homogeneity.
                 call A%apply_matvec(u, Au) ; call Au%scal(alpha)
@@ -2071,8 +2073,8 @@ contains
                 !> Generate random vectors.
                 allocate(u, Au, Aau, source=x)
                 call u%rand()
-                alpha = cmplx(0.0_sp, 0.0_sp, kind=sp)
-                call random_number(alpha%re) ; call random_number(alpha%im)
+                !> generate the identical non-trivial alpha on all ranks
+                alpha = cmplx(1.0_sp + real(i,sp), -0.5_sp*real(i,sp), sp)
 
                 !> Check homogeneity.
                 call A%apply_matvec(u, Au) ; call Au%scal(alpha)
@@ -2230,8 +2232,8 @@ contains
                 !> Generate random vectors.
                 allocate(u, Au, Aau, source=x)
                 call u%rand()
-                alpha = cmplx(0.0_dp, 0.0_dp, kind=dp)
-                call random_number(alpha%re) ; call random_number(alpha%im)
+                !> generate the identical non-trivial alpha on all ranks
+                alpha = cmplx(1.0_dp + real(i,dp), -0.5_dp*real(i,dp), dp)
 
                 !> Check homogeneity.
                 call A%apply_matvec(u, Au) ; call Au%scal(alpha)

--- a/src/AbstractTypes/AbstractLinops.f90
+++ b/src/AbstractTypes/AbstractLinops.f90
@@ -22,6 +22,8 @@ module LightKrylov_AbstractLinops
     character(len=*), parameter :: this_module      = 'LK_Linops'
     character(len=*), parameter :: this_module_long = 'Lightkrylov_AbstractLinops'
 
+    public :: verify_linop_axioms
+
     type, abstract, public :: abstract_linop
         !!  Base type to define an abstract linear operator. All other operator types defined
         !!  in `LightKrylov` derive from this fundamental one.
@@ -638,6 +640,13 @@ module LightKrylov_AbstractLinops
         module procedure initialize_dense_linop_from_array_cdp
     end interface
     public :: dense_linop
+
+    interface verify_linop_axioms
+        module procedure verify_linop_axioms_rsp
+        module procedure verify_linop_axioms_rdp
+        module procedure verify_linop_axioms_csp
+        module procedure verify_linop_axioms_cdp
+    end interface
 
 contains
 
@@ -1669,5 +1678,619 @@ contains
         type(dense_linop_cdp) :: linop
         linop%data = A
     end function initialize_dense_linop_from_array_cdp
+    
+    !--------------------------------------
+    !-----      UTILITY FUNCTIONS     -----
+    !--------------------------------------
+
+    logical function verify_linop_axioms_rsp(A, x, ntrials, tolerance, test_adjoint) result(success)
+        implicit none(type, external)
+        class(abstract_linop_rsp), intent(inout) :: A
+        !! Linear operator whose implementation needs to be tested.
+        class(abstract_vector_rsp), intent(in) :: x
+        !! Mold vector from the operator's domain (used to generate random inputs).
+        integer, optional, intent(in) :: ntrials
+        !! Number of random samples generated for the tests.
+        real(sp), optional, intent(in) :: tolerance
+        !! Tolerance used for the axiom checks.
+        logical, optional, intent(in) :: test_adjoint
+        !! Verify also the adjoint consistency `<A u, v> = <u, A^H v>`? (Default: .true.)
+
+        integer :: ntrials_, i
+        logical :: test_adjoint_
+        real(sp) :: tol, error_norm, scale
+        character(len=128) :: failed_test
+        character(len=256) :: msg
+
+        character(len=*), parameter :: this_procedure = 'verify_linop_axioms_rsp'
+
+        !> Deals with optional arguments.
+        ntrials_ = optval(ntrials, 10)
+        tol = optval(tolerance, 10.0_sp**(-(precision(1.0_sp)-1)))
+        test_adjoint_ = optval(test_adjoint, .true.)
+
+        !> Run all tests to verify axioms.
+        success = .false.
+        verification: do i = 1, ntrials_
+
+            !-------------------------------------------
+            !-----     LINEARITY : ADDITIVITY      -----
+            !-------------------------------------------
+            additivity: block
+                class(abstract_vector_rsp), allocatable :: u, v, Au, Av, Auv
+                allocate(u, v, Au, Av, Auv, source=x)
+
+                !> Generate random vectors.
+                call u%rand()
+                call v%rand()
+
+                !> Check additivity.
+                call A%apply_matvec(u, Au)
+                call A%apply_matvec(v, Av)
+                scale = Au%norm() + Av%norm()
+                call Au%add(Av)                 ! Au <- A(u) + A(v)
+
+                call u%add(v)
+                call A%apply_matvec(u, Auv)     ! Auv <- A(u + v)
+
+                call Auv%sub(Au)
+                error_norm = Auv%norm()
+                success = merge(.true., .false., error_norm <= tol * max(scale, one_rsp))
+                if (.not. success) then
+                    failed_test = 'additivity'
+                    exit verification
+                end if
+            end block additivity
+
+            !-------------------------------------------
+            !-----     LINEARITY : HOMOGENEITY     -----
+            !-------------------------------------------
+            homogeneity: block
+                class(abstract_vector_rsp), allocatable :: u, Au, Aau
+                real(sp) :: alpha
+
+                !> Generate random vectors.
+                allocate(u, Au, Aau, source=x)
+                call random_number(alpha)
+
+                !> Check homogeneity.
+                call A%apply_matvec(u, Au) ; call Au%scal(alpha)
+                scale = Au%norm()
+
+                call u%scal(alpha)
+                call A%apply_matvec(u, Aau)
+
+                call Aau%sub(Au)
+                error_norm = Aau%norm()
+                success = merge(.true., .false., error_norm <= tol * max(scale, one_rsp))
+
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'homogeneity'
+                    exit verification
+                end if
+            end block homogeneity
+
+            !-------------------------------------------
+            !-----     ZERO MAPS TO ZERO           -----
+            !-------------------------------------------
+            zero_to_zero: block
+                class(abstract_vector_rsp), allocatable :: u, Au
+
+                !> Check that the zero vector is mapped to the zero vector.
+                allocate(u, Au, source=x)
+                call u%zero()
+                call A%apply_matvec(u, Au)
+                error_norm = Au%norm()
+                success = merge(.true., .false., error_norm <= tol)
+
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'zero_to_zero'
+                    exit verification
+                end if
+            end block zero_to_zero
+
+            !-------------------------------------------
+            !-----     ADJOINT CONSISTENCY         -----
+            !-----     <A u, v> = <u, A^H v>        -----
+            !-------------------------------------------
+            if (test_adjoint_) then
+                adjoint_consistency: block
+                    class(abstract_vector_rsp), allocatable :: u, v, Au, Av
+                    real(sp) :: lhs, rhs
+
+                    !> Generate random vectors.
+                    allocate(u, v, Au, Av, source=x)
+                    call u%rand()
+                    call v%rand()
+    
+                    !> Check adjoint consistency.
+                    call A%apply_matvec(u, Au)      ! A u
+                    call A%apply_rmatvec(v, Av)     ! A^H v
+                    scale = Au%norm()*v%norm()
+                    lhs = Au%dot(v)                 ! <A u, v>
+                    rhs = u%dot(Av)                 ! <u, A^H v>
+                    error_norm = abs(lhs - rhs)
+                    success = merge(.true., .false., error_norm <= tol * max(scale, one_rsp))
+    
+                    if (.not. success) then
+                        failed_test = 'adjoint_consistency'
+                        exit verification
+                    end if
+                end block adjoint_consistency
+                end if
+
+        enddo verification
+
+        if (success) then
+            write(msg, '(A,I0,A)') 'All linop axioms verified (', ntrials_, ' trials).'
+            call log_information(msg, this_module, this_procedure)
+        else
+            write(msg, '(A,I0,A)') 'Linop axiom check FAILED at trial ', i, ', test: '//trim(failed_test)
+            call log_message(msg, this_module, this_procedure)
+            write(msg, '(A,E12.5,A,E12.5)') 'error_norm = ', error_norm, ' > tol = ', tol
+            call log_message(msg, this_module, this_procedure)
+        end if
+
+    end function verify_linop_axioms_rsp
+
+    logical function verify_linop_axioms_rdp(A, x, ntrials, tolerance, test_adjoint) result(success)
+        implicit none(type, external)
+        class(abstract_linop_rdp), intent(inout) :: A
+        !! Linear operator whose implementation needs to be tested.
+        class(abstract_vector_rdp), intent(in) :: x
+        !! Mold vector from the operator's domain (used to generate random inputs).
+        integer, optional, intent(in) :: ntrials
+        !! Number of random samples generated for the tests.
+        real(dp), optional, intent(in) :: tolerance
+        !! Tolerance used for the axiom checks.
+        logical, optional, intent(in) :: test_adjoint
+        !! Verify also the adjoint consistency `<A u, v> = <u, A^H v>`? (Default: .true.)
+
+        integer :: ntrials_, i
+        logical :: test_adjoint_
+        real(dp) :: tol, error_norm, scale
+        character(len=128) :: failed_test
+        character(len=256) :: msg
+
+        character(len=*), parameter :: this_procedure = 'verify_linop_axioms_rdp'
+
+        !> Deals with optional arguments.
+        ntrials_ = optval(ntrials, 10)
+        tol = optval(tolerance, 10.0_dp**(-(precision(1.0_dp)-1)))
+        test_adjoint_ = optval(test_adjoint, .true.)
+
+        !> Run all tests to verify axioms.
+        success = .false.
+        verification: do i = 1, ntrials_
+
+            !-------------------------------------------
+            !-----     LINEARITY : ADDITIVITY      -----
+            !-------------------------------------------
+            additivity: block
+                class(abstract_vector_rdp), allocatable :: u, v, Au, Av, Auv
+                allocate(u, v, Au, Av, Auv, source=x)
+
+                !> Generate random vectors.
+                call u%rand()
+                call v%rand()
+
+                !> Check additivity.
+                call A%apply_matvec(u, Au)
+                call A%apply_matvec(v, Av)
+                scale = Au%norm() + Av%norm()
+                call Au%add(Av)                 ! Au <- A(u) + A(v)
+
+                call u%add(v)
+                call A%apply_matvec(u, Auv)     ! Auv <- A(u + v)
+
+                call Auv%sub(Au)
+                error_norm = Auv%norm()
+                success = merge(.true., .false., error_norm <= tol * max(scale, one_rdp))
+                if (.not. success) then
+                    failed_test = 'additivity'
+                    exit verification
+                end if
+            end block additivity
+
+            !-------------------------------------------
+            !-----     LINEARITY : HOMOGENEITY     -----
+            !-------------------------------------------
+            homogeneity: block
+                class(abstract_vector_rdp), allocatable :: u, Au, Aau
+                real(dp) :: alpha
+
+                !> Generate random vectors.
+                allocate(u, Au, Aau, source=x)
+                call random_number(alpha)
+
+                !> Check homogeneity.
+                call A%apply_matvec(u, Au) ; call Au%scal(alpha)
+                scale = Au%norm()
+
+                call u%scal(alpha)
+                call A%apply_matvec(u, Aau)
+
+                call Aau%sub(Au)
+                error_norm = Aau%norm()
+                success = merge(.true., .false., error_norm <= tol * max(scale, one_rdp))
+
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'homogeneity'
+                    exit verification
+                end if
+            end block homogeneity
+
+            !-------------------------------------------
+            !-----     ZERO MAPS TO ZERO           -----
+            !-------------------------------------------
+            zero_to_zero: block
+                class(abstract_vector_rdp), allocatable :: u, Au
+
+                !> Check that the zero vector is mapped to the zero vector.
+                allocate(u, Au, source=x)
+                call u%zero()
+                call A%apply_matvec(u, Au)
+                error_norm = Au%norm()
+                success = merge(.true., .false., error_norm <= tol)
+
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'zero_to_zero'
+                    exit verification
+                end if
+            end block zero_to_zero
+
+            !-------------------------------------------
+            !-----     ADJOINT CONSISTENCY         -----
+            !-----     <A u, v> = <u, A^H v>        -----
+            !-------------------------------------------
+            if (test_adjoint_) then
+                adjoint_consistency: block
+                    class(abstract_vector_rdp), allocatable :: u, v, Au, Av
+                    real(dp) :: lhs, rhs
+
+                    !> Generate random vectors.
+                    allocate(u, v, Au, Av, source=x)
+                    call u%rand()
+                    call v%rand()
+    
+                    !> Check adjoint consistency.
+                    call A%apply_matvec(u, Au)      ! A u
+                    call A%apply_rmatvec(v, Av)     ! A^H v
+                    scale = Au%norm()*v%norm()
+                    lhs = Au%dot(v)                 ! <A u, v>
+                    rhs = u%dot(Av)                 ! <u, A^H v>
+                    error_norm = abs(lhs - rhs)
+                    success = merge(.true., .false., error_norm <= tol * max(scale, one_rdp))
+    
+                    if (.not. success) then
+                        failed_test = 'adjoint_consistency'
+                        exit verification
+                    end if
+                end block adjoint_consistency
+                end if
+
+        enddo verification
+
+        if (success) then
+            write(msg, '(A,I0,A)') 'All linop axioms verified (', ntrials_, ' trials).'
+            call log_information(msg, this_module, this_procedure)
+        else
+            write(msg, '(A,I0,A)') 'Linop axiom check FAILED at trial ', i, ', test: '//trim(failed_test)
+            call log_message(msg, this_module, this_procedure)
+            write(msg, '(A,E12.5,A,E12.5)') 'error_norm = ', error_norm, ' > tol = ', tol
+            call log_message(msg, this_module, this_procedure)
+        end if
+
+    end function verify_linop_axioms_rdp
+
+    logical function verify_linop_axioms_csp(A, x, ntrials, tolerance, test_adjoint) result(success)
+        implicit none(type, external)
+        class(abstract_linop_csp), intent(inout) :: A
+        !! Linear operator whose implementation needs to be tested.
+        class(abstract_vector_csp), intent(in) :: x
+        !! Mold vector from the operator's domain (used to generate random inputs).
+        integer, optional, intent(in) :: ntrials
+        !! Number of random samples generated for the tests.
+        real(sp), optional, intent(in) :: tolerance
+        !! Tolerance used for the axiom checks.
+        logical, optional, intent(in) :: test_adjoint
+        !! Verify also the adjoint consistency `<A u, v> = <u, A^H v>`? (Default: .true.)
+
+        integer :: ntrials_, i
+        logical :: test_adjoint_
+        real(sp) :: tol, error_norm, scale
+        character(len=128) :: failed_test
+        character(len=256) :: msg
+
+        character(len=*), parameter :: this_procedure = 'verify_linop_axioms_csp'
+
+        !> Deals with optional arguments.
+        ntrials_ = optval(ntrials, 10)
+        tol = optval(tolerance, 10.0_sp**(-(precision(1.0_sp)-1)))
+        test_adjoint_ = optval(test_adjoint, .true.)
+
+        !> Run all tests to verify axioms.
+        success = .false.
+        verification: do i = 1, ntrials_
+
+            !-------------------------------------------
+            !-----     LINEARITY : ADDITIVITY      -----
+            !-------------------------------------------
+            additivity: block
+                class(abstract_vector_csp), allocatable :: u, v, Au, Av, Auv
+                allocate(u, v, Au, Av, Auv, source=x)
+
+                !> Generate random vectors.
+                call u%rand()
+                call v%rand()
+
+                !> Check additivity.
+                call A%apply_matvec(u, Au)
+                call A%apply_matvec(v, Av)
+                scale = Au%norm() + Av%norm()
+                call Au%add(Av)                 ! Au <- A(u) + A(v)
+
+                call u%add(v)
+                call A%apply_matvec(u, Auv)     ! Auv <- A(u + v)
+
+                call Auv%sub(Au)
+                error_norm = Auv%norm()
+                success = merge(.true., .false., error_norm <= tol * max(scale, one_rsp))
+                if (.not. success) then
+                    failed_test = 'additivity'
+                    exit verification
+                end if
+            end block additivity
+
+            !-------------------------------------------
+            !-----     LINEARITY : HOMOGENEITY     -----
+            !-------------------------------------------
+            homogeneity: block
+                class(abstract_vector_csp), allocatable :: u, Au, Aau
+                complex(sp) :: alpha
+
+                !> Generate random vectors.
+                allocate(u, Au, Aau, source=x)
+                alpha = cmplx(0.0_sp, 0.0_sp, kind=sp)
+                call random_number(alpha%re) ; call random_number(alpha%im)
+
+                !> Check homogeneity.
+                call A%apply_matvec(u, Au) ; call Au%scal(alpha)
+                scale = Au%norm()
+
+                call u%scal(alpha)
+                call A%apply_matvec(u, Aau)
+
+                call Aau%sub(Au)
+                error_norm = Aau%norm()
+                success = merge(.true., .false., error_norm <= tol * max(scale, one_rsp))
+
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'homogeneity'
+                    exit verification
+                end if
+            end block homogeneity
+
+            !-------------------------------------------
+            !-----     ZERO MAPS TO ZERO           -----
+            !-------------------------------------------
+            zero_to_zero: block
+                class(abstract_vector_csp), allocatable :: u, Au
+
+                !> Check that the zero vector is mapped to the zero vector.
+                allocate(u, Au, source=x)
+                call u%zero()
+                call A%apply_matvec(u, Au)
+                error_norm = Au%norm()
+                success = merge(.true., .false., error_norm <= tol)
+
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'zero_to_zero'
+                    exit verification
+                end if
+            end block zero_to_zero
+
+            !-------------------------------------------
+            !-----     ADJOINT CONSISTENCY         -----
+            !-----     <A u, v> = <u, A^H v>        -----
+            !-------------------------------------------
+            if (test_adjoint_) then
+                adjoint_consistency: block
+                    class(abstract_vector_csp), allocatable :: u, v, Au, Av
+                    complex(sp) :: lhs, rhs
+
+                    !> Generate random vectors.
+                    allocate(u, v, Au, Av, source=x)
+                    call u%rand()
+                    call v%rand()
+    
+                    !> Check adjoint consistency.
+                    call A%apply_matvec(u, Au)      ! A u
+                    call A%apply_rmatvec(v, Av)     ! A^H v
+                    scale = Au%norm()*v%norm()
+                    lhs = Au%dot(v)                 ! <A u, v>
+                    rhs = u%dot(Av)                 ! <u, A^H v>
+                    error_norm = abs(lhs - rhs)
+                    success = merge(.true., .false., error_norm <= tol * max(scale, one_rsp))
+    
+                    if (.not. success) then
+                        failed_test = 'adjoint_consistency'
+                        exit verification
+                    end if
+                end block adjoint_consistency
+                end if
+
+        enddo verification
+
+        if (success) then
+            write(msg, '(A,I0,A)') 'All linop axioms verified (', ntrials_, ' trials).'
+            call log_information(msg, this_module, this_procedure)
+        else
+            write(msg, '(A,I0,A)') 'Linop axiom check FAILED at trial ', i, ', test: '//trim(failed_test)
+            call log_message(msg, this_module, this_procedure)
+            write(msg, '(A,E12.5,A,E12.5)') 'error_norm = ', error_norm, ' > tol = ', tol
+            call log_message(msg, this_module, this_procedure)
+        end if
+
+    end function verify_linop_axioms_csp
+
+    logical function verify_linop_axioms_cdp(A, x, ntrials, tolerance, test_adjoint) result(success)
+        implicit none(type, external)
+        class(abstract_linop_cdp), intent(inout) :: A
+        !! Linear operator whose implementation needs to be tested.
+        class(abstract_vector_cdp), intent(in) :: x
+        !! Mold vector from the operator's domain (used to generate random inputs).
+        integer, optional, intent(in) :: ntrials
+        !! Number of random samples generated for the tests.
+        real(dp), optional, intent(in) :: tolerance
+        !! Tolerance used for the axiom checks.
+        logical, optional, intent(in) :: test_adjoint
+        !! Verify also the adjoint consistency `<A u, v> = <u, A^H v>`? (Default: .true.)
+
+        integer :: ntrials_, i
+        logical :: test_adjoint_
+        real(dp) :: tol, error_norm, scale
+        character(len=128) :: failed_test
+        character(len=256) :: msg
+
+        character(len=*), parameter :: this_procedure = 'verify_linop_axioms_cdp'
+
+        !> Deals with optional arguments.
+        ntrials_ = optval(ntrials, 10)
+        tol = optval(tolerance, 10.0_dp**(-(precision(1.0_dp)-1)))
+        test_adjoint_ = optval(test_adjoint, .true.)
+
+        !> Run all tests to verify axioms.
+        success = .false.
+        verification: do i = 1, ntrials_
+
+            !-------------------------------------------
+            !-----     LINEARITY : ADDITIVITY      -----
+            !-------------------------------------------
+            additivity: block
+                class(abstract_vector_cdp), allocatable :: u, v, Au, Av, Auv
+                allocate(u, v, Au, Av, Auv, source=x)
+
+                !> Generate random vectors.
+                call u%rand()
+                call v%rand()
+
+                !> Check additivity.
+                call A%apply_matvec(u, Au)
+                call A%apply_matvec(v, Av)
+                scale = Au%norm() + Av%norm()
+                call Au%add(Av)                 ! Au <- A(u) + A(v)
+
+                call u%add(v)
+                call A%apply_matvec(u, Auv)     ! Auv <- A(u + v)
+
+                call Auv%sub(Au)
+                error_norm = Auv%norm()
+                success = merge(.true., .false., error_norm <= tol * max(scale, one_rdp))
+                if (.not. success) then
+                    failed_test = 'additivity'
+                    exit verification
+                end if
+            end block additivity
+
+            !-------------------------------------------
+            !-----     LINEARITY : HOMOGENEITY     -----
+            !-------------------------------------------
+            homogeneity: block
+                class(abstract_vector_cdp), allocatable :: u, Au, Aau
+                complex(dp) :: alpha
+
+                !> Generate random vectors.
+                allocate(u, Au, Aau, source=x)
+                alpha = cmplx(0.0_dp, 0.0_dp, kind=dp)
+                call random_number(alpha%re) ; call random_number(alpha%im)
+
+                !> Check homogeneity.
+                call A%apply_matvec(u, Au) ; call Au%scal(alpha)
+                scale = Au%norm()
+
+                call u%scal(alpha)
+                call A%apply_matvec(u, Aau)
+
+                call Aau%sub(Au)
+                error_norm = Aau%norm()
+                success = merge(.true., .false., error_norm <= tol * max(scale, one_rdp))
+
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'homogeneity'
+                    exit verification
+                end if
+            end block homogeneity
+
+            !-------------------------------------------
+            !-----     ZERO MAPS TO ZERO           -----
+            !-------------------------------------------
+            zero_to_zero: block
+                class(abstract_vector_cdp), allocatable :: u, Au
+
+                !> Check that the zero vector is mapped to the zero vector.
+                allocate(u, Au, source=x)
+                call u%zero()
+                call A%apply_matvec(u, Au)
+                error_norm = Au%norm()
+                success = merge(.true., .false., error_norm <= tol)
+
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'zero_to_zero'
+                    exit verification
+                end if
+            end block zero_to_zero
+
+            !-------------------------------------------
+            !-----     ADJOINT CONSISTENCY         -----
+            !-----     <A u, v> = <u, A^H v>        -----
+            !-------------------------------------------
+            if (test_adjoint_) then
+                adjoint_consistency: block
+                    class(abstract_vector_cdp), allocatable :: u, v, Au, Av
+                    complex(dp) :: lhs, rhs
+
+                    !> Generate random vectors.
+                    allocate(u, v, Au, Av, source=x)
+                    call u%rand()
+                    call v%rand()
+    
+                    !> Check adjoint consistency.
+                    call A%apply_matvec(u, Au)      ! A u
+                    call A%apply_rmatvec(v, Av)     ! A^H v
+                    scale = Au%norm()*v%norm()
+                    lhs = Au%dot(v)                 ! <A u, v>
+                    rhs = u%dot(Av)                 ! <u, A^H v>
+                    error_norm = abs(lhs - rhs)
+                    success = merge(.true., .false., error_norm <= tol * max(scale, one_rdp))
+    
+                    if (.not. success) then
+                        failed_test = 'adjoint_consistency'
+                        exit verification
+                    end if
+                end block adjoint_consistency
+                end if
+
+        enddo verification
+
+        if (success) then
+            write(msg, '(A,I0,A)') 'All linop axioms verified (', ntrials_, ' trials).'
+            call log_information(msg, this_module, this_procedure)
+        else
+            write(msg, '(A,I0,A)') 'Linop axiom check FAILED at trial ', i, ', test: '//trim(failed_test)
+            call log_message(msg, this_module, this_procedure)
+            write(msg, '(A,E12.5,A,E12.5)') 'error_norm = ', error_norm, ' > tol = ', tol
+            call log_message(msg, this_module, this_procedure)
+        end if
+
+    end function verify_linop_axioms_cdp
 
 end module LightKrylov_AbstractLinops

--- a/src/AbstractTypes/AbstractLinops.fypp
+++ b/src/AbstractTypes/AbstractLinops.fypp
@@ -683,7 +683,7 @@ contains
     !--------------------------------------
 
     #:for kind, type in RC_KINDS_TYPES
-    logical function verify_linop_axioms_${type[0]}$${kind}$(A, x, ntrials, tolerance, test_adjoint) result(success)
+    logical function verify_linop_axioms_${type[0]}$${kind}$(A, x, ntrials, tolerance, test_zero_map, test_adjoint) result(success)
         implicit none(type, external)
         class(abstract_linop_${type[0]}$${kind}$), intent(inout) :: A
         !! Linear operator whose implementation needs to be tested.
@@ -693,11 +693,13 @@ contains
         !! Number of random samples generated for the tests.
         real(${kind}$), optional, intent(in) :: tolerance
         !! Tolerance used for the axiom checks.
+        logical, optional, intent(in) :: test_zero_map
+        !! Verify explicitly that the operator maps x = 0 to 0? (Default: .true.)
         logical, optional, intent(in) :: test_adjoint
         !! Verify also the adjoint consistency `<A u, v> = <u, A^H v>`? (Default: .true.)
 
         integer :: ntrials_, i
-        logical :: test_adjoint_
+        logical :: test_zero_map_, test_adjoint_
         real(${kind}$) :: tol, error_norm, scale
         character(len=128) :: failed_test
         character(len=256) :: msg
@@ -707,6 +709,7 @@ contains
         !> Deals with optional arguments.
         ntrials_ = optval(ntrials, 10)
         tol = optval(tolerance, 10.0_${kind}$**(-(precision(1.0_${kind}$)-1)))
+        test_zero_map_ = optval(test_zero_map, .true.)
         test_adjoint_ = optval(test_adjoint, .true.)
 
         !> Run all tests to verify axioms.
@@ -751,6 +754,7 @@ contains
 
                 !> Generate random vectors.
                 allocate(u, Au, Aau, source=x)
+                call u%rand()
                 #:if type[0] == "c"
                 alpha = cmplx(0.0_${kind}$, 0.0_${kind}$, kind=${kind}$)
                 call random_number(alpha%re) ; call random_number(alpha%im)
@@ -779,22 +783,24 @@ contains
             !-------------------------------------------
             !-----     ZERO MAPS TO ZERO           -----
             !-------------------------------------------
-            zero_to_zero: block
-                class(abstract_vector_${type[0]}$${kind}$), allocatable :: u, Au
+            if (test_zero_map_) then
+                zero_to_zero: block
+                    class(abstract_vector_${type[0]}$${kind}$), allocatable :: u, Au
 
-                !> Check that the zero vector is mapped to the zero vector.
-                allocate(u, Au, source=x)
-                call u%zero()
-                call A%apply_matvec(u, Au)
-                error_norm = Au%norm()
-                success = merge(.true., .false., error_norm <= tol)
+                    !> Check that the zero vector is mapped to the zero vector.
+                    allocate(u, Au, source=x)
+                    call u%zero()
+                    call A%apply_matvec(u, Au)
+                    error_norm = Au%norm()
+                    success = merge(.true., .false., error_norm <= tol)
 
-                !> Exit if the test fails.
-                if (.not. success) then
-                    failed_test = 'zero_to_zero'
-                    exit verification
-                end if
-            end block zero_to_zero
+                    !> Exit if the test fails.
+                    if (.not. success) then
+                        failed_test = 'zero_to_zero'
+                        exit verification
+                    end if
+                end block zero_to_zero
+            end if
 
             !-------------------------------------------
             !-----     ADJOINT CONSISTENCY         -----

--- a/src/AbstractTypes/AbstractLinops.fypp
+++ b/src/AbstractTypes/AbstractLinops.fypp
@@ -24,6 +24,8 @@ module LightKrylov_AbstractLinops
     character(len=*), parameter :: this_module      = 'LK_Linops'
     character(len=*), parameter :: this_module_long = 'Lightkrylov_AbstractLinops'
 
+    public :: verify_linop_axioms
+
     type, abstract, public :: abstract_linop
         !!  Base type to define an abstract linear operator. All other operator types defined
         !!  in `LightKrylov` derive from this fundamental one.
@@ -276,6 +278,12 @@ module LightKrylov_AbstractLinops
         #:endfor
     end interface
     public :: dense_linop
+
+    interface verify_linop_axioms
+        #:for kind, type in RC_KINDS_TYPES
+        module procedure verify_linop_axioms_${type[0]}$${kind}$
+        #:endfor
+    end interface
 
 contains
 
@@ -669,5 +677,168 @@ contains
         linop%data = A
     end function initialize_dense_linop_from_array_${type[0]}$${kind}$
     #:endfor
+    
+    !--------------------------------------
+    !-----      UTILITY FUNCTIONS     -----
+    !--------------------------------------
 
+    #:for kind, type in RC_KINDS_TYPES
+    logical function verify_linop_axioms_${type[0]}$${kind}$(A, x, ntrials, tolerance, test_adjoint) result(success)
+        implicit none(type, external)
+        class(abstract_linop_${type[0]}$${kind}$), intent(inout) :: A
+        !! Linear operator whose implementation needs to be tested.
+        class(abstract_vector_${type[0]}$${kind}$), intent(in) :: x
+        !! Mold vector from the operator's domain (used to generate random inputs).
+        integer, optional, intent(in) :: ntrials
+        !! Number of random samples generated for the tests.
+        real(${kind}$), optional, intent(in) :: tolerance
+        !! Tolerance used for the axiom checks.
+        logical, optional, intent(in) :: test_adjoint
+        !! Verify also the adjoint consistency `<A u, v> = <u, A^H v>`? (Default: .true.)
+
+        integer :: ntrials_, i
+        logical :: test_adjoint_
+        real(${kind}$) :: tol, error_norm, scale
+        character(len=128) :: failed_test
+        character(len=256) :: msg
+
+        character(len=*), parameter :: this_procedure = 'verify_linop_axioms_${type[0]}$${kind}$'
+
+        !> Deals with optional arguments.
+        ntrials_ = optval(ntrials, 10)
+        tol = optval(tolerance, 10.0_${kind}$**(-(precision(1.0_${kind}$)-1)))
+        test_adjoint_ = optval(test_adjoint, .true.)
+
+        !> Run all tests to verify axioms.
+        success = .false.
+        verification: do i = 1, ntrials_
+
+            !-------------------------------------------
+            !-----     LINEARITY : ADDITIVITY      -----
+            !-------------------------------------------
+            additivity: block
+                class(abstract_vector_${type[0]}$${kind}$), allocatable :: u, v, Au, Av, Auv
+                allocate(u, v, Au, Av, Auv, source=x)
+
+                !> Generate random vectors.
+                call u%rand()
+                call v%rand()
+
+                !> Check additivity.
+                call A%apply_matvec(u, Au)
+                call A%apply_matvec(v, Av)
+                scale = Au%norm() + Av%norm()
+                call Au%add(Av)                 ! Au <- A(u) + A(v)
+
+                call u%add(v)
+                call A%apply_matvec(u, Auv)     ! Auv <- A(u + v)
+
+                call Auv%sub(Au)
+                error_norm = Auv%norm()
+                success = merge(.true., .false., error_norm <= tol * max(scale, one_r${kind}$))
+                if (.not. success) then
+                    failed_test = 'additivity'
+                    exit verification
+                end if
+            end block additivity
+
+            !-------------------------------------------
+            !-----     LINEARITY : HOMOGENEITY     -----
+            !-------------------------------------------
+            homogeneity: block
+                class(abstract_vector_${type[0]}$${kind}$), allocatable :: u, Au, Aau
+                ${type}$ :: alpha
+
+                !> Generate random vectors.
+                allocate(u, Au, Aau, source=x)
+                #:if type[0] == "c"
+                alpha = cmplx(0.0_${kind}$, 0.0_${kind}$, kind=${kind}$)
+                call random_number(alpha%re) ; call random_number(alpha%im)
+                #:else
+                call random_number(alpha)
+                #:endif
+
+                !> Check homogeneity.
+                call A%apply_matvec(u, Au) ; call Au%scal(alpha)
+                scale = Au%norm()
+
+                call u%scal(alpha)
+                call A%apply_matvec(u, Aau)
+
+                call Aau%sub(Au)
+                error_norm = Aau%norm()
+                success = merge(.true., .false., error_norm <= tol * max(scale, one_r${kind}$))
+
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'homogeneity'
+                    exit verification
+                end if
+            end block homogeneity
+
+            !-------------------------------------------
+            !-----     ZERO MAPS TO ZERO           -----
+            !-------------------------------------------
+            zero_to_zero: block
+                class(abstract_vector_${type[0]}$${kind}$), allocatable :: u, Au
+
+                !> Check that the zero vector is mapped to the zero vector.
+                allocate(u, Au, source=x)
+                call u%zero()
+                call A%apply_matvec(u, Au)
+                error_norm = Au%norm()
+                success = merge(.true., .false., error_norm <= tol)
+
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'zero_to_zero'
+                    exit verification
+                end if
+            end block zero_to_zero
+
+            !-------------------------------------------
+            !-----     ADJOINT CONSISTENCY         -----
+            !-----     <A u, v> = <u, A^H v>        -----
+            !-------------------------------------------
+            if (test_adjoint_) then
+                adjoint_consistency: block
+                    class(abstract_vector_${type[0]}$${kind}$), allocatable :: u, v, Au, Av
+                    ${type}$ :: lhs, rhs
+
+                    !> Generate random vectors.
+                    allocate(u, v, Au, Av, source=x)
+                    call u%rand()
+                    call v%rand()
+    
+                    !> Check adjoint consistency.
+                    call A%apply_matvec(u, Au)      ! A u
+                    call A%apply_rmatvec(v, Av)     ! A^H v
+                    scale = Au%norm()*v%norm()
+                    lhs = Au%dot(v)                 ! <A u, v>
+                    rhs = u%dot(Av)                 ! <u, A^H v>
+                    error_norm = abs(lhs - rhs)
+                    success = merge(.true., .false., error_norm <= tol * max(scale, one_r${kind}$))
+    
+                    if (.not. success) then
+                        failed_test = 'adjoint_consistency'
+                        exit verification
+                    end if
+                end block adjoint_consistency
+                end if
+
+        enddo verification
+
+        if (success) then
+            write(msg, '(A,I0,A)') 'All linop axioms verified (', ntrials_, ' trials).'
+            call log_information(msg, this_module, this_procedure)
+        else
+            write(msg, '(A,I0,A)') 'Linop axiom check FAILED at trial ', i, ', test: '//trim(failed_test)
+            call log_message(msg, this_module, this_procedure)
+            write(msg, '(A,E12.5,A,E12.5)') 'error_norm = ', error_norm, ' > tol = ', tol
+            call log_message(msg, this_module, this_procedure)
+        end if
+
+    end function verify_linop_axioms_${type[0]}$${kind}$
+
+    #:endfor
 end module LightKrylov_AbstractLinops

--- a/src/AbstractTypes/AbstractLinops.fypp
+++ b/src/AbstractTypes/AbstractLinops.fypp
@@ -755,11 +755,11 @@ contains
                 !> Generate random vectors.
                 allocate(u, Au, Aau, source=x)
                 call u%rand()
+                !> generate the identical non-trivial alpha on all ranks
                 #:if type[0] == "c"
-                alpha = cmplx(0.0_${kind}$, 0.0_${kind}$, kind=${kind}$)
-                call random_number(alpha%re) ; call random_number(alpha%im)
+                alpha = cmplx(1.0_${kind}$ + real(i,${kind}$), -0.5_${kind}$*real(i,${kind}$), ${kind}$)
                 #:else
-                call random_number(alpha)
+                alpha = (-1.0_${kind}$)**i * (1.0_${kind}$ + real(i,${kind}$))
                 #:endif
 
                 !> Check homogeneity.

--- a/src/AbstractTypes/AbstractVectors.f90
+++ b/src/AbstractTypes/AbstractVectors.f90
@@ -1667,7 +1667,7 @@ contains
 
         if (success) then
             write(msg, '(A,I0,A)') 'All vector axioms verified (', ntrials_, ' trials).'
-            call log_message(msg, this_module, this_procedure)
+            call log_information(msg, this_module, this_procedure)
         else
             write(msg, '(A,I0,A)') 'Vector axiom check FAILED at trial ', i, ', test: '//trim(failed_test)
             call log_message(msg, this_module, this_procedure)
@@ -2069,7 +2069,7 @@ contains
 
         if (success) then
             write(msg, '(A,I0,A)') 'All vector axioms verified (', ntrials_, ' trials).'
-            call log_message(msg, this_module, this_procedure)
+            call log_information(msg, this_module, this_procedure)
         else
             write(msg, '(A,I0,A)') 'Vector axiom check FAILED at trial ', i, ', test: '//trim(failed_test)
             call log_message(msg, this_module, this_procedure)
@@ -2479,7 +2479,7 @@ contains
 
         if (success) then
             write(msg, '(A,I0,A)') 'All vector axioms verified (', ntrials_, ' trials).'
-            call log_message(msg, this_module, this_procedure)
+            call log_information(msg, this_module, this_procedure)
         else
             write(msg, '(A,I0,A)') 'Vector axiom check FAILED at trial ', i, ', test: '//trim(failed_test)
             call log_message(msg, this_module, this_procedure)
@@ -2889,7 +2889,7 @@ contains
 
         if (success) then
             write(msg, '(A,I0,A)') 'All vector axioms verified (', ntrials_, ' trials).'
-            call log_message(msg, this_module, this_procedure)
+            call log_information(msg, this_module, this_procedure)
         else
             write(msg, '(A,I0,A)') 'Vector axiom check FAILED at trial ', i, ', test: '//trim(failed_test)
             call log_message(msg, this_module, this_procedure)

--- a/src/AbstractTypes/AbstractVectors.f90
+++ b/src/AbstractTypes/AbstractVectors.f90
@@ -1447,7 +1447,11 @@ contains
         real(sp), optional, intent(in) :: tolerance
 
         integer :: ntrials_, i
-        real(sp) :: tol
+        character(len=128) :: failed_test
+        character(len=256) :: msg
+        real(sp) :: tol, error_norm
+
+        character(len=*), parameter :: this_procedure = "verify_vector_axioms_rsp"
 
         !> Deals with optional argument.
         ntrials_ = optval(ntrials, 100)
@@ -1481,8 +1485,13 @@ contains
                 call w%add(wrk2)    ! (u + v) + w
 
                 call u%sub(w)
-                success = merge(.true., .false., u%norm() <= tol)
-                if (.not. success) exit verification
+                error_norm = u%norm()
+                success = merge(.true., .false., error_norm <= tol)
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'addition_distributivity'
+                    exit verification
+                end if
             end block addition_distributivity
 
             addition_commutativity: block
@@ -1499,8 +1508,13 @@ contains
                 call u%add(w)
 
                 call u%sub(v)
-                success = merge(.true., .false., u%norm() <= tol)
-                if (.not. success) exit verification
+                error_norm = u%norm()
+                success = merge(.true., .false., error_norm <= tol)
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'addition_commutativity'
+                    exit verification
+                end if
             end block addition_commutativity
 
             addition_zero: block
@@ -1514,8 +1528,13 @@ contains
                 !> Check zero element.
                 call u%add(z)
                 call u%sub(v)
-                success = merge(.true., .false., u%norm() <= tol)
-                if (.not. success) exit verification
+                error_norm = u%norm()
+                success = merge(.true., .false., error_norm <= tol)
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'additive_zero'
+                    exit verification
+                end if
             end block addition_zero
 
             additive_inverse: block
@@ -1524,8 +1543,12 @@ contains
                 call u%rand()
                 v = u
                 call u%sub(v)
-                success = merge(.true., .false., u%norm() <= tol)
-                if (.not. success) exit verification
+                success = merge(.true., .false., error_norm <= tol)
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'additive_inverse'
+                    exit verification
+                end if
             end block additive_inverse
 
             !-----------------------------------------
@@ -1542,8 +1565,13 @@ contains
                 !> Check identity.
                 call v%scal(one)
                 call u%sub(v)
-                success = merge(.true., .false., u%norm() <= tol)
-                if (.not. success) exit verification
+                error_norm = u%norm()
+                success = merge(.true., .false., error_norm <= tol)
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'scaling_identity'
+                    exit verification
+                end if
             end block scaling_identity
 
             scaling_compatibility: block
@@ -1562,8 +1590,12 @@ contains
                 call v%scal(a)
                 call u%scal(a*b)
                 call u%sub(v)
-                success = merge(.true., .false., u%norm() <= tol)
-                if (.not. success) exit verification
+                error_norm = u%norm()
+                success = merge(.true., .false., error_norm <= tol)
+                if (.not. success) then
+                    failed_test = 'scaling_compatibility'
+                    exit verification
+                end if
             end block scaling_compatibility
 
             scaling_distributivity: block
@@ -1586,8 +1618,13 @@ contains
                 call v%add(u)
 
                 call v%sub(w)
-                success = merge(.true., .false., v%norm() <= tol)
-                if (.not. success) exit verification
+                error_norm = v%norm()
+                success = merge(.true., .false., error_norm <= tol)
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'scaling_distributivity'
+                    exit verification
+                end if
             end block scaling_distributivity
 
             scaling_distributivity_bis: block
@@ -1606,10 +1643,24 @@ contains
                 call u%scal(a+b)
 
                 call v%sub(u)
-                success = merge(.true., .false., v%norm() <= tol)
-                if (.not. success) exit verification
+                error_norm = v%norm()
+                success = merge(.true., .false., error_norm <= tol)
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'scaling_distributivity_bis'
+                    exit verification
+                end if
             end block scaling_distributivity_bis
         enddo verification
+        if (success) then
+            write(msg, '(A,I0,A)') 'All vector axioms verified (', ntrials_, ' trials).'
+            call log_message(msg, this_module, this_procedure)
+        else
+            write(msg, '(A,I0,A)') 'Vector axiom check FAILED at trial ', i, ', test: '//trim(failed_test)
+            call log_message(msg, this_module, this_procedure)
+            write(msg, '(A,E12.5,A,E12.5)') 'error_norm = ', error_norm, ' > tol = ', tol
+            call log_message(msg, this_module, this_procedure)
+        end if
     end function verify_vector_axioms_rsp
 
     subroutine linear_combination_vector_rdp(y, X, v)
@@ -1783,7 +1834,11 @@ contains
         real(dp), optional, intent(in) :: tolerance
 
         integer :: ntrials_, i
-        real(dp) :: tol
+        character(len=128) :: failed_test
+        character(len=256) :: msg
+        real(dp) :: tol, error_norm
+
+        character(len=*), parameter :: this_procedure = "verify_vector_axioms_rdp"
 
         !> Deals with optional argument.
         ntrials_ = optval(ntrials, 100)
@@ -1817,8 +1872,13 @@ contains
                 call w%add(wrk2)    ! (u + v) + w
 
                 call u%sub(w)
-                success = merge(.true., .false., u%norm() <= tol)
-                if (.not. success) exit verification
+                error_norm = u%norm()
+                success = merge(.true., .false., error_norm <= tol)
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'addition_distributivity'
+                    exit verification
+                end if
             end block addition_distributivity
 
             addition_commutativity: block
@@ -1835,8 +1895,13 @@ contains
                 call u%add(w)
 
                 call u%sub(v)
-                success = merge(.true., .false., u%norm() <= tol)
-                if (.not. success) exit verification
+                error_norm = u%norm()
+                success = merge(.true., .false., error_norm <= tol)
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'addition_commutativity'
+                    exit verification
+                end if
             end block addition_commutativity
 
             addition_zero: block
@@ -1850,8 +1915,13 @@ contains
                 !> Check zero element.
                 call u%add(z)
                 call u%sub(v)
-                success = merge(.true., .false., u%norm() <= tol)
-                if (.not. success) exit verification
+                error_norm = u%norm()
+                success = merge(.true., .false., error_norm <= tol)
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'additive_zero'
+                    exit verification
+                end if
             end block addition_zero
 
             additive_inverse: block
@@ -1860,8 +1930,12 @@ contains
                 call u%rand()
                 v = u
                 call u%sub(v)
-                success = merge(.true., .false., u%norm() <= tol)
-                if (.not. success) exit verification
+                success = merge(.true., .false., error_norm <= tol)
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'additive_inverse'
+                    exit verification
+                end if
             end block additive_inverse
 
             !-----------------------------------------
@@ -1878,8 +1952,13 @@ contains
                 !> Check identity.
                 call v%scal(one)
                 call u%sub(v)
-                success = merge(.true., .false., u%norm() <= tol)
-                if (.not. success) exit verification
+                error_norm = u%norm()
+                success = merge(.true., .false., error_norm <= tol)
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'scaling_identity'
+                    exit verification
+                end if
             end block scaling_identity
 
             scaling_compatibility: block
@@ -1898,8 +1977,12 @@ contains
                 call v%scal(a)
                 call u%scal(a*b)
                 call u%sub(v)
-                success = merge(.true., .false., u%norm() <= tol)
-                if (.not. success) exit verification
+                error_norm = u%norm()
+                success = merge(.true., .false., error_norm <= tol)
+                if (.not. success) then
+                    failed_test = 'scaling_compatibility'
+                    exit verification
+                end if
             end block scaling_compatibility
 
             scaling_distributivity: block
@@ -1922,8 +2005,13 @@ contains
                 call v%add(u)
 
                 call v%sub(w)
-                success = merge(.true., .false., v%norm() <= tol)
-                if (.not. success) exit verification
+                error_norm = v%norm()
+                success = merge(.true., .false., error_norm <= tol)
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'scaling_distributivity'
+                    exit verification
+                end if
             end block scaling_distributivity
 
             scaling_distributivity_bis: block
@@ -1942,10 +2030,24 @@ contains
                 call u%scal(a+b)
 
                 call v%sub(u)
-                success = merge(.true., .false., v%norm() <= tol)
-                if (.not. success) exit verification
+                error_norm = v%norm()
+                success = merge(.true., .false., error_norm <= tol)
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'scaling_distributivity_bis'
+                    exit verification
+                end if
             end block scaling_distributivity_bis
         enddo verification
+        if (success) then
+            write(msg, '(A,I0,A)') 'All vector axioms verified (', ntrials_, ' trials).'
+            call log_message(msg, this_module, this_procedure)
+        else
+            write(msg, '(A,I0,A)') 'Vector axiom check FAILED at trial ', i, ', test: '//trim(failed_test)
+            call log_message(msg, this_module, this_procedure)
+            write(msg, '(A,E12.5,A,E12.5)') 'error_norm = ', error_norm, ' > tol = ', tol
+            call log_message(msg, this_module, this_procedure)
+        end if
     end function verify_vector_axioms_rdp
 
     subroutine linear_combination_vector_csp(y, X, v)
@@ -2119,7 +2221,11 @@ contains
         real(sp), optional, intent(in) :: tolerance
 
         integer :: ntrials_, i
-        real(sp) :: tol
+        character(len=128) :: failed_test
+        character(len=256) :: msg
+        real(sp) :: tol, error_norm
+
+        character(len=*), parameter :: this_procedure = "verify_vector_axioms_csp"
 
         !> Deals with optional argument.
         ntrials_ = optval(ntrials, 100)
@@ -2153,8 +2259,13 @@ contains
                 call w%add(wrk2)    ! (u + v) + w
 
                 call u%sub(w)
-                success = merge(.true., .false., u%norm() <= tol)
-                if (.not. success) exit verification
+                error_norm = u%norm()
+                success = merge(.true., .false., error_norm <= tol)
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'addition_distributivity'
+                    exit verification
+                end if
             end block addition_distributivity
 
             addition_commutativity: block
@@ -2171,8 +2282,13 @@ contains
                 call u%add(w)
 
                 call u%sub(v)
-                success = merge(.true., .false., u%norm() <= tol)
-                if (.not. success) exit verification
+                error_norm = u%norm()
+                success = merge(.true., .false., error_norm <= tol)
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'addition_commutativity'
+                    exit verification
+                end if
             end block addition_commutativity
 
             addition_zero: block
@@ -2186,8 +2302,13 @@ contains
                 !> Check zero element.
                 call u%add(z)
                 call u%sub(v)
-                success = merge(.true., .false., u%norm() <= tol)
-                if (.not. success) exit verification
+                error_norm = u%norm()
+                success = merge(.true., .false., error_norm <= tol)
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'additive_zero'
+                    exit verification
+                end if
             end block addition_zero
 
             additive_inverse: block
@@ -2196,8 +2317,12 @@ contains
                 call u%rand()
                 v = u
                 call u%sub(v)
-                success = merge(.true., .false., u%norm() <= tol)
-                if (.not. success) exit verification
+                success = merge(.true., .false., error_norm <= tol)
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'additive_inverse'
+                    exit verification
+                end if
             end block additive_inverse
 
             !-----------------------------------------
@@ -2214,8 +2339,13 @@ contains
                 !> Check identity.
                 call v%scal(one)
                 call u%sub(v)
-                success = merge(.true., .false., u%norm() <= tol)
-                if (.not. success) exit verification
+                error_norm = u%norm()
+                success = merge(.true., .false., error_norm <= tol)
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'scaling_identity'
+                    exit verification
+                end if
             end block scaling_identity
 
             scaling_compatibility: block
@@ -2237,8 +2367,12 @@ contains
                 call v%scal(a)
                 call u%scal(a*b)
                 call u%sub(v)
-                success = merge(.true., .false., u%norm() <= tol)
-                if (.not. success) exit verification
+                error_norm = u%norm()
+                success = merge(.true., .false., error_norm <= tol)
+                if (.not. success) then
+                    failed_test = 'scaling_compatibility'
+                    exit verification
+                end if
             end block scaling_compatibility
 
             scaling_distributivity: block
@@ -2263,8 +2397,13 @@ contains
                 call v%add(u)
 
                 call v%sub(w)
-                success = merge(.true., .false., v%norm() <= tol)
-                if (.not. success) exit verification
+                error_norm = v%norm()
+                success = merge(.true., .false., error_norm <= tol)
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'scaling_distributivity'
+                    exit verification
+                end if
             end block scaling_distributivity
 
             scaling_distributivity_bis: block
@@ -2286,10 +2425,24 @@ contains
                 call u%scal(a+b)
 
                 call v%sub(u)
-                success = merge(.true., .false., v%norm() <= tol)
-                if (.not. success) exit verification
+                error_norm = v%norm()
+                success = merge(.true., .false., error_norm <= tol)
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'scaling_distributivity_bis'
+                    exit verification
+                end if
             end block scaling_distributivity_bis
         enddo verification
+        if (success) then
+            write(msg, '(A,I0,A)') 'All vector axioms verified (', ntrials_, ' trials).'
+            call log_message(msg, this_module, this_procedure)
+        else
+            write(msg, '(A,I0,A)') 'Vector axiom check FAILED at trial ', i, ', test: '//trim(failed_test)
+            call log_message(msg, this_module, this_procedure)
+            write(msg, '(A,E12.5,A,E12.5)') 'error_norm = ', error_norm, ' > tol = ', tol
+            call log_message(msg, this_module, this_procedure)
+        end if
     end function verify_vector_axioms_csp
 
     subroutine linear_combination_vector_cdp(y, X, v)
@@ -2463,7 +2616,11 @@ contains
         real(dp), optional, intent(in) :: tolerance
 
         integer :: ntrials_, i
-        real(dp) :: tol
+        character(len=128) :: failed_test
+        character(len=256) :: msg
+        real(dp) :: tol, error_norm
+
+        character(len=*), parameter :: this_procedure = "verify_vector_axioms_cdp"
 
         !> Deals with optional argument.
         ntrials_ = optval(ntrials, 100)
@@ -2497,8 +2654,13 @@ contains
                 call w%add(wrk2)    ! (u + v) + w
 
                 call u%sub(w)
-                success = merge(.true., .false., u%norm() <= tol)
-                if (.not. success) exit verification
+                error_norm = u%norm()
+                success = merge(.true., .false., error_norm <= tol)
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'addition_distributivity'
+                    exit verification
+                end if
             end block addition_distributivity
 
             addition_commutativity: block
@@ -2515,8 +2677,13 @@ contains
                 call u%add(w)
 
                 call u%sub(v)
-                success = merge(.true., .false., u%norm() <= tol)
-                if (.not. success) exit verification
+                error_norm = u%norm()
+                success = merge(.true., .false., error_norm <= tol)
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'addition_commutativity'
+                    exit verification
+                end if
             end block addition_commutativity
 
             addition_zero: block
@@ -2530,8 +2697,13 @@ contains
                 !> Check zero element.
                 call u%add(z)
                 call u%sub(v)
-                success = merge(.true., .false., u%norm() <= tol)
-                if (.not. success) exit verification
+                error_norm = u%norm()
+                success = merge(.true., .false., error_norm <= tol)
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'additive_zero'
+                    exit verification
+                end if
             end block addition_zero
 
             additive_inverse: block
@@ -2540,8 +2712,12 @@ contains
                 call u%rand()
                 v = u
                 call u%sub(v)
-                success = merge(.true., .false., u%norm() <= tol)
-                if (.not. success) exit verification
+                success = merge(.true., .false., error_norm <= tol)
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'additive_inverse'
+                    exit verification
+                end if
             end block additive_inverse
 
             !-----------------------------------------
@@ -2558,8 +2734,13 @@ contains
                 !> Check identity.
                 call v%scal(one)
                 call u%sub(v)
-                success = merge(.true., .false., u%norm() <= tol)
-                if (.not. success) exit verification
+                error_norm = u%norm()
+                success = merge(.true., .false., error_norm <= tol)
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'scaling_identity'
+                    exit verification
+                end if
             end block scaling_identity
 
             scaling_compatibility: block
@@ -2581,8 +2762,12 @@ contains
                 call v%scal(a)
                 call u%scal(a*b)
                 call u%sub(v)
-                success = merge(.true., .false., u%norm() <= tol)
-                if (.not. success) exit verification
+                error_norm = u%norm()
+                success = merge(.true., .false., error_norm <= tol)
+                if (.not. success) then
+                    failed_test = 'scaling_compatibility'
+                    exit verification
+                end if
             end block scaling_compatibility
 
             scaling_distributivity: block
@@ -2607,8 +2792,13 @@ contains
                 call v%add(u)
 
                 call v%sub(w)
-                success = merge(.true., .false., v%norm() <= tol)
-                if (.not. success) exit verification
+                error_norm = v%norm()
+                success = merge(.true., .false., error_norm <= tol)
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'scaling_distributivity'
+                    exit verification
+                end if
             end block scaling_distributivity
 
             scaling_distributivity_bis: block
@@ -2630,10 +2820,24 @@ contains
                 call u%scal(a+b)
 
                 call v%sub(u)
-                success = merge(.true., .false., v%norm() <= tol)
-                if (.not. success) exit verification
+                error_norm = v%norm()
+                success = merge(.true., .false., error_norm <= tol)
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'scaling_distributivity_bis'
+                    exit verification
+                end if
             end block scaling_distributivity_bis
         enddo verification
+        if (success) then
+            write(msg, '(A,I0,A)') 'All vector axioms verified (', ntrials_, ' trials).'
+            call log_message(msg, this_module, this_procedure)
+        else
+            write(msg, '(A,I0,A)') 'Vector axiom check FAILED at trial ', i, ', test: '//trim(failed_test)
+            call log_message(msg, this_module, this_procedure)
+            write(msg, '(A,E12.5,A,E12.5)') 'error_norm = ', error_norm, ' > tol = ', tol
+            call log_message(msg, this_module, this_procedure)
+        end if
     end function verify_vector_axioms_cdp
 
 end module LightKrylov_AbstractVectors

--- a/src/AbstractTypes/AbstractVectors.f90
+++ b/src/AbstractTypes/AbstractVectors.f90
@@ -292,7 +292,6 @@ module LightKrylov_AbstractVectors
         module procedure verify_vector_axioms_cdp
     end interface
 
-
     type, abstract, public :: abstract_vector
         !!  Base abstract type from which all other types of vectors used in `LightKrylov`
         !!  are being derived from.
@@ -1437,7 +1436,6 @@ contains
         call X%rand(ifnorm=ifnorm)
     end subroutine rand_basis_rsp
 
-
     logical function verify_vector_axioms_rsp(x, ntrials, tolerance) result(success)
         implicit none(type, external)
         class(abstract_vector_rsp), intent(in) :: x
@@ -1447,9 +1445,9 @@ contains
         real(sp), optional, intent(in) :: tolerance
 
         integer :: ntrials_, i
+        real(sp) :: tol, error_norm
         character(len=128) :: failed_test
         character(len=256) :: msg
-        real(sp) :: tol, error_norm
 
         character(len=*), parameter :: this_procedure = "verify_vector_axioms_rsp"
 
@@ -1464,7 +1462,6 @@ contains
             !-----------------------------------
             !-----     VECTOR ADDITION     -----
             !-----------------------------------
-
             addition_distributivity: block
                 class(abstract_vector_rsp), allocatable :: u, v, w
                 class(abstract_vector_rsp), allocatable :: wrk1, wrk2
@@ -1487,6 +1484,7 @@ contains
                 call u%sub(w)
                 error_norm = u%norm()
                 success = merge(.true., .false., error_norm <= tol)
+
                 !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'addition_distributivity'
@@ -1510,6 +1508,7 @@ contains
                 call u%sub(v)
                 error_norm = u%norm()
                 success = merge(.true., .false., error_norm <= tol)
+
                 !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'addition_commutativity'
@@ -1530,6 +1529,7 @@ contains
                 call u%sub(v)
                 error_norm = u%norm()
                 success = merge(.true., .false., error_norm <= tol)
+
                 !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'additive_zero'
@@ -1539,11 +1539,17 @@ contains
 
             additive_inverse: block
                 class(abstract_vector_rsp), allocatable :: u, v
+
+                !> Generate random vector.
                 allocate(u, source=x)
                 call u%rand()
                 v = u
+
+                !> Check additive inverse.
                 call u%sub(v)
+                error_norm = u%norm()
                 success = merge(.true., .false., error_norm <= tol)
+
                 !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'additive_inverse'
@@ -1567,6 +1573,7 @@ contains
                 call u%sub(v)
                 error_norm = u%norm()
                 success = merge(.true., .false., error_norm <= tol)
+
                 !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'scaling_identity'
@@ -1592,6 +1599,8 @@ contains
                 call u%sub(v)
                 error_norm = u%norm()
                 success = merge(.true., .false., error_norm <= tol)
+
+                !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'scaling_compatibility'
                     exit verification
@@ -1620,6 +1629,7 @@ contains
                 call v%sub(w)
                 error_norm = v%norm()
                 success = merge(.true., .false., error_norm <= tol)
+
                 !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'scaling_distributivity'
@@ -1645,13 +1655,16 @@ contains
                 call v%sub(u)
                 error_norm = v%norm()
                 success = merge(.true., .false., error_norm <= tol)
+                
                 !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'scaling_distributivity_bis'
                     exit verification
                 end if
             end block scaling_distributivity_bis
+
         enddo verification
+
         if (success) then
             write(msg, '(A,I0,A)') 'All vector axioms verified (', ntrials_, ' trials).'
             call log_message(msg, this_module, this_procedure)
@@ -1661,6 +1674,7 @@ contains
             write(msg, '(A,E12.5,A,E12.5)') 'error_norm = ', error_norm, ' > tol = ', tol
             call log_message(msg, this_module, this_procedure)
         end if
+
     end function verify_vector_axioms_rsp
 
     subroutine linear_combination_vector_rdp(y, X, v)
@@ -1824,7 +1838,6 @@ contains
         call X%rand(ifnorm=ifnorm)
     end subroutine rand_basis_rdp
 
-
     logical function verify_vector_axioms_rdp(x, ntrials, tolerance) result(success)
         implicit none(type, external)
         class(abstract_vector_rdp), intent(in) :: x
@@ -1834,9 +1847,9 @@ contains
         real(dp), optional, intent(in) :: tolerance
 
         integer :: ntrials_, i
+        real(dp) :: tol, error_norm
         character(len=128) :: failed_test
         character(len=256) :: msg
-        real(dp) :: tol, error_norm
 
         character(len=*), parameter :: this_procedure = "verify_vector_axioms_rdp"
 
@@ -1851,7 +1864,6 @@ contains
             !-----------------------------------
             !-----     VECTOR ADDITION     -----
             !-----------------------------------
-
             addition_distributivity: block
                 class(abstract_vector_rdp), allocatable :: u, v, w
                 class(abstract_vector_rdp), allocatable :: wrk1, wrk2
@@ -1874,6 +1886,7 @@ contains
                 call u%sub(w)
                 error_norm = u%norm()
                 success = merge(.true., .false., error_norm <= tol)
+
                 !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'addition_distributivity'
@@ -1897,6 +1910,7 @@ contains
                 call u%sub(v)
                 error_norm = u%norm()
                 success = merge(.true., .false., error_norm <= tol)
+
                 !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'addition_commutativity'
@@ -1917,6 +1931,7 @@ contains
                 call u%sub(v)
                 error_norm = u%norm()
                 success = merge(.true., .false., error_norm <= tol)
+
                 !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'additive_zero'
@@ -1926,11 +1941,17 @@ contains
 
             additive_inverse: block
                 class(abstract_vector_rdp), allocatable :: u, v
+
+                !> Generate random vector.
                 allocate(u, source=x)
                 call u%rand()
                 v = u
+
+                !> Check additive inverse.
                 call u%sub(v)
+                error_norm = u%norm()
                 success = merge(.true., .false., error_norm <= tol)
+
                 !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'additive_inverse'
@@ -1954,6 +1975,7 @@ contains
                 call u%sub(v)
                 error_norm = u%norm()
                 success = merge(.true., .false., error_norm <= tol)
+
                 !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'scaling_identity'
@@ -1979,6 +2001,8 @@ contains
                 call u%sub(v)
                 error_norm = u%norm()
                 success = merge(.true., .false., error_norm <= tol)
+
+                !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'scaling_compatibility'
                     exit verification
@@ -2007,6 +2031,7 @@ contains
                 call v%sub(w)
                 error_norm = v%norm()
                 success = merge(.true., .false., error_norm <= tol)
+
                 !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'scaling_distributivity'
@@ -2032,13 +2057,16 @@ contains
                 call v%sub(u)
                 error_norm = v%norm()
                 success = merge(.true., .false., error_norm <= tol)
+                
                 !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'scaling_distributivity_bis'
                     exit verification
                 end if
             end block scaling_distributivity_bis
+
         enddo verification
+
         if (success) then
             write(msg, '(A,I0,A)') 'All vector axioms verified (', ntrials_, ' trials).'
             call log_message(msg, this_module, this_procedure)
@@ -2048,6 +2076,7 @@ contains
             write(msg, '(A,E12.5,A,E12.5)') 'error_norm = ', error_norm, ' > tol = ', tol
             call log_message(msg, this_module, this_procedure)
         end if
+
     end function verify_vector_axioms_rdp
 
     subroutine linear_combination_vector_csp(y, X, v)
@@ -2211,7 +2240,6 @@ contains
         call X%rand(ifnorm=ifnorm)
     end subroutine rand_basis_csp
 
-
     logical function verify_vector_axioms_csp(x, ntrials, tolerance) result(success)
         implicit none(type, external)
         class(abstract_vector_csp), intent(in) :: x
@@ -2221,9 +2249,9 @@ contains
         real(sp), optional, intent(in) :: tolerance
 
         integer :: ntrials_, i
+        real(sp) :: tol, error_norm
         character(len=128) :: failed_test
         character(len=256) :: msg
-        real(sp) :: tol, error_norm
 
         character(len=*), parameter :: this_procedure = "verify_vector_axioms_csp"
 
@@ -2238,7 +2266,6 @@ contains
             !-----------------------------------
             !-----     VECTOR ADDITION     -----
             !-----------------------------------
-
             addition_distributivity: block
                 class(abstract_vector_csp), allocatable :: u, v, w
                 class(abstract_vector_csp), allocatable :: wrk1, wrk2
@@ -2261,6 +2288,7 @@ contains
                 call u%sub(w)
                 error_norm = u%norm()
                 success = merge(.true., .false., error_norm <= tol)
+
                 !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'addition_distributivity'
@@ -2284,6 +2312,7 @@ contains
                 call u%sub(v)
                 error_norm = u%norm()
                 success = merge(.true., .false., error_norm <= tol)
+
                 !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'addition_commutativity'
@@ -2304,6 +2333,7 @@ contains
                 call u%sub(v)
                 error_norm = u%norm()
                 success = merge(.true., .false., error_norm <= tol)
+
                 !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'additive_zero'
@@ -2313,11 +2343,17 @@ contains
 
             additive_inverse: block
                 class(abstract_vector_csp), allocatable :: u, v
+
+                !> Generate random vector.
                 allocate(u, source=x)
                 call u%rand()
                 v = u
+
+                !> Check additive inverse.
                 call u%sub(v)
+                error_norm = u%norm()
                 success = merge(.true., .false., error_norm <= tol)
+
                 !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'additive_inverse'
@@ -2341,6 +2377,7 @@ contains
                 call u%sub(v)
                 error_norm = u%norm()
                 success = merge(.true., .false., error_norm <= tol)
+
                 !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'scaling_identity'
@@ -2369,6 +2406,8 @@ contains
                 call u%sub(v)
                 error_norm = u%norm()
                 success = merge(.true., .false., error_norm <= tol)
+
+                !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'scaling_compatibility'
                     exit verification
@@ -2399,6 +2438,7 @@ contains
                 call v%sub(w)
                 error_norm = v%norm()
                 success = merge(.true., .false., error_norm <= tol)
+
                 !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'scaling_distributivity'
@@ -2427,13 +2467,16 @@ contains
                 call v%sub(u)
                 error_norm = v%norm()
                 success = merge(.true., .false., error_norm <= tol)
+                
                 !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'scaling_distributivity_bis'
                     exit verification
                 end if
             end block scaling_distributivity_bis
+
         enddo verification
+
         if (success) then
             write(msg, '(A,I0,A)') 'All vector axioms verified (', ntrials_, ' trials).'
             call log_message(msg, this_module, this_procedure)
@@ -2443,6 +2486,7 @@ contains
             write(msg, '(A,E12.5,A,E12.5)') 'error_norm = ', error_norm, ' > tol = ', tol
             call log_message(msg, this_module, this_procedure)
         end if
+
     end function verify_vector_axioms_csp
 
     subroutine linear_combination_vector_cdp(y, X, v)
@@ -2606,7 +2650,6 @@ contains
         call X%rand(ifnorm=ifnorm)
     end subroutine rand_basis_cdp
 
-
     logical function verify_vector_axioms_cdp(x, ntrials, tolerance) result(success)
         implicit none(type, external)
         class(abstract_vector_cdp), intent(in) :: x
@@ -2616,9 +2659,9 @@ contains
         real(dp), optional, intent(in) :: tolerance
 
         integer :: ntrials_, i
+        real(dp) :: tol, error_norm
         character(len=128) :: failed_test
         character(len=256) :: msg
-        real(dp) :: tol, error_norm
 
         character(len=*), parameter :: this_procedure = "verify_vector_axioms_cdp"
 
@@ -2633,7 +2676,6 @@ contains
             !-----------------------------------
             !-----     VECTOR ADDITION     -----
             !-----------------------------------
-
             addition_distributivity: block
                 class(abstract_vector_cdp), allocatable :: u, v, w
                 class(abstract_vector_cdp), allocatable :: wrk1, wrk2
@@ -2656,6 +2698,7 @@ contains
                 call u%sub(w)
                 error_norm = u%norm()
                 success = merge(.true., .false., error_norm <= tol)
+
                 !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'addition_distributivity'
@@ -2679,6 +2722,7 @@ contains
                 call u%sub(v)
                 error_norm = u%norm()
                 success = merge(.true., .false., error_norm <= tol)
+
                 !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'addition_commutativity'
@@ -2699,6 +2743,7 @@ contains
                 call u%sub(v)
                 error_norm = u%norm()
                 success = merge(.true., .false., error_norm <= tol)
+
                 !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'additive_zero'
@@ -2708,11 +2753,17 @@ contains
 
             additive_inverse: block
                 class(abstract_vector_cdp), allocatable :: u, v
+
+                !> Generate random vector.
                 allocate(u, source=x)
                 call u%rand()
                 v = u
+
+                !> Check additive inverse.
                 call u%sub(v)
+                error_norm = u%norm()
                 success = merge(.true., .false., error_norm <= tol)
+
                 !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'additive_inverse'
@@ -2736,6 +2787,7 @@ contains
                 call u%sub(v)
                 error_norm = u%norm()
                 success = merge(.true., .false., error_norm <= tol)
+
                 !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'scaling_identity'
@@ -2764,6 +2816,8 @@ contains
                 call u%sub(v)
                 error_norm = u%norm()
                 success = merge(.true., .false., error_norm <= tol)
+
+                !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'scaling_compatibility'
                     exit verification
@@ -2794,6 +2848,7 @@ contains
                 call v%sub(w)
                 error_norm = v%norm()
                 success = merge(.true., .false., error_norm <= tol)
+
                 !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'scaling_distributivity'
@@ -2822,13 +2877,16 @@ contains
                 call v%sub(u)
                 error_norm = v%norm()
                 success = merge(.true., .false., error_norm <= tol)
+                
                 !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'scaling_distributivity_bis'
                     exit verification
                 end if
             end block scaling_distributivity_bis
+
         enddo verification
+
         if (success) then
             write(msg, '(A,I0,A)') 'All vector axioms verified (', ntrials_, ' trials).'
             call log_message(msg, this_module, this_procedure)
@@ -2838,6 +2896,7 @@ contains
             write(msg, '(A,E12.5,A,E12.5)') 'error_norm = ', error_norm, ' > tol = ', tol
             call log_message(msg, this_module, this_procedure)
         end if
+
     end function verify_vector_axioms_cdp
 
 end module LightKrylov_AbstractVectors

--- a/src/AbstractTypes/AbstractVectors.fypp
+++ b/src/AbstractTypes/AbstractVectors.fypp
@@ -729,7 +729,6 @@ contains
         call X%rand(ifnorm=ifnorm)
     end subroutine rand_basis_${type[0]}$${kind}$
 
-
     logical function verify_vector_axioms_${type[0]}$${kind}$(x, ntrials, tolerance) result(success)
         implicit none(type, external)
         class(abstract_vector_${type[0]}$${kind}$), intent(in) :: x
@@ -739,7 +738,11 @@ contains
         real(${kind}$), optional, intent(in) :: tolerance
 
         integer :: ntrials_, i
-        real(${kind}$) :: tol
+        character(len=128) :: failed_test
+        character(len=256) :: msg
+        real(${kind}$) :: tol, error_norm
+
+        character(len=*), parameter :: this_procedure = "verify_vector_axioms_${type[0]}$${kind}$"
 
         !> Deals with optional argument.
         ntrials_ = optval(ntrials, 100)
@@ -773,8 +776,13 @@ contains
                 call w%add(wrk2)    ! (u + v) + w
 
                 call u%sub(w)
-                success = merge(.true., .false., u%norm() <= tol)
-                if (.not. success) exit verification
+                error_norm = u%norm()
+                success = merge(.true., .false., error_norm <= tol)
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'addition_distributivity'
+                    exit verification
+                end if
             end block addition_distributivity
 
             addition_commutativity: block
@@ -791,8 +799,13 @@ contains
                 call u%add(w)
 
                 call u%sub(v)
-                success = merge(.true., .false., u%norm() <= tol)
-                if (.not. success) exit verification
+                error_norm = u%norm()
+                success = merge(.true., .false., error_norm <= tol)
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'addition_commutativity'
+                    exit verification
+                end if
             end block addition_commutativity
 
             addition_zero: block
@@ -806,8 +819,13 @@ contains
                 !> Check zero element.
                 call u%add(z)
                 call u%sub(v)
-                success = merge(.true., .false., u%norm() <= tol)
-                if (.not. success) exit verification
+                error_norm = u%norm()
+                success = merge(.true., .false., error_norm <= tol)
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'additive_zero'
+                    exit verification
+                end if
             end block addition_zero
 
             additive_inverse: block
@@ -816,8 +834,12 @@ contains
                 call u%rand()
                 v = u
                 call u%sub(v)
-                success = merge(.true., .false., u%norm() <= tol)
-                if (.not. success) exit verification
+                success = merge(.true., .false., error_norm <= tol)
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'additive_inverse'
+                    exit verification
+                end if
             end block additive_inverse
 
             !-----------------------------------------
@@ -834,8 +856,13 @@ contains
                 !> Check identity.
                 call v%scal(one)
                 call u%sub(v)
-                success = merge(.true., .false., u%norm() <= tol)
-                if (.not. success) exit verification
+                error_norm = u%norm()
+                success = merge(.true., .false., error_norm <= tol)
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'scaling_identity'
+                    exit verification
+                end if
             end block scaling_identity
 
             scaling_compatibility: block
@@ -862,8 +889,12 @@ contains
                 call v%scal(a)
                 call u%scal(a*b)
                 call u%sub(v)
-                success = merge(.true., .false., u%norm() <= tol)
-                if (.not. success) exit verification
+                error_norm = u%norm()
+                success = merge(.true., .false., error_norm <= tol)
+                if (.not. success) then
+                    failed_test = 'scaling_compatibility'
+                    exit verification
+                end if
             end block scaling_compatibility
 
             scaling_distributivity: block
@@ -892,8 +923,13 @@ contains
                 call v%add(u)
 
                 call v%sub(w)
-                success = merge(.true., .false., v%norm() <= tol)
-                if (.not. success) exit verification
+                error_norm = v%norm()
+                success = merge(.true., .false., error_norm <= tol)
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'scaling_distributivity'
+                    exit verification
+                end if
             end block scaling_distributivity
 
             scaling_distributivity_bis: block
@@ -920,10 +956,24 @@ contains
                 call u%scal(a+b)
 
                 call v%sub(u)
-                success = merge(.true., .false., v%norm() <= tol)
-                if (.not. success) exit verification
+                error_norm = v%norm()
+                success = merge(.true., .false., error_norm <= tol)
+                !> Exit if the test fails.
+                if (.not. success) then
+                    failed_test = 'scaling_distributivity_bis'
+                    exit verification
+                end if
             end block scaling_distributivity_bis
         enddo verification
+        if (success) then
+            write(msg, '(A,I0,A)') 'All vector axioms verified (', ntrials_, ' trials).'
+            call log_message(msg, this_module, this_procedure)
+        else
+            write(msg, '(A,I0,A)') 'Vector axiom check FAILED at trial ', i, ', test: '//trim(failed_test)
+            call log_message(msg, this_module, this_procedure)
+            write(msg, '(A,E12.5,A,E12.5)') 'error_norm = ', error_norm, ' > tol = ', tol
+            call log_message(msg, this_module, this_procedure)
+        end if
     end function verify_vector_axioms_${type[0]}$${kind}$
 
     #:endfor

--- a/src/AbstractTypes/AbstractVectors.fypp
+++ b/src/AbstractTypes/AbstractVectors.fypp
@@ -277,7 +277,6 @@ module LightKrylov_AbstractVectors
         #:endfor
     end interface
 
-
     type, abstract, public :: abstract_vector
         !!  Base abstract type from which all other types of vectors used in `LightKrylov`
         !!  are being derived from.
@@ -738,9 +737,9 @@ contains
         real(${kind}$), optional, intent(in) :: tolerance
 
         integer :: ntrials_, i
+        real(${kind}$) :: tol, error_norm
         character(len=128) :: failed_test
         character(len=256) :: msg
-        real(${kind}$) :: tol, error_norm
 
         character(len=*), parameter :: this_procedure = "verify_vector_axioms_${type[0]}$${kind}$"
 
@@ -755,7 +754,6 @@ contains
             !-----------------------------------
             !-----     VECTOR ADDITION     -----
             !-----------------------------------
-
             addition_distributivity: block
                 class(abstract_vector_${type[0]}$${kind}$), allocatable :: u, v, w
                 class(abstract_vector_${type[0]}$${kind}$), allocatable :: wrk1, wrk2
@@ -778,6 +776,7 @@ contains
                 call u%sub(w)
                 error_norm = u%norm()
                 success = merge(.true., .false., error_norm <= tol)
+
                 !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'addition_distributivity'
@@ -801,6 +800,7 @@ contains
                 call u%sub(v)
                 error_norm = u%norm()
                 success = merge(.true., .false., error_norm <= tol)
+
                 !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'addition_commutativity'
@@ -821,6 +821,7 @@ contains
                 call u%sub(v)
                 error_norm = u%norm()
                 success = merge(.true., .false., error_norm <= tol)
+
                 !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'additive_zero'
@@ -830,11 +831,17 @@ contains
 
             additive_inverse: block
                 class(abstract_vector_${type[0]}$${kind}$), allocatable :: u, v
+
+                !> Generate random vector.
                 allocate(u, source=x)
                 call u%rand()
                 v = u
+
+                !> Check additive inverse.
                 call u%sub(v)
+                error_norm = u%norm()
                 success = merge(.true., .false., error_norm <= tol)
+
                 !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'additive_inverse'
@@ -858,6 +865,7 @@ contains
                 call u%sub(v)
                 error_norm = u%norm()
                 success = merge(.true., .false., error_norm <= tol)
+
                 !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'scaling_identity'
@@ -891,6 +899,8 @@ contains
                 call u%sub(v)
                 error_norm = u%norm()
                 success = merge(.true., .false., error_norm <= tol)
+
+                !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'scaling_compatibility'
                     exit verification
@@ -925,6 +935,7 @@ contains
                 call v%sub(w)
                 error_norm = v%norm()
                 success = merge(.true., .false., error_norm <= tol)
+
                 !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'scaling_distributivity'
@@ -958,13 +969,16 @@ contains
                 call v%sub(u)
                 error_norm = v%norm()
                 success = merge(.true., .false., error_norm <= tol)
+                
                 !> Exit if the test fails.
                 if (.not. success) then
                     failed_test = 'scaling_distributivity_bis'
                     exit verification
                 end if
             end block scaling_distributivity_bis
+
         enddo verification
+
         if (success) then
             write(msg, '(A,I0,A)') 'All vector axioms verified (', ntrials_, ' trials).'
             call log_message(msg, this_module, this_procedure)
@@ -974,6 +988,7 @@ contains
             write(msg, '(A,E12.5,A,E12.5)') 'error_norm = ', error_norm, ' > tol = ', tol
             call log_message(msg, this_module, this_procedure)
         end if
+
     end function verify_vector_axioms_${type[0]}$${kind}$
 
     #:endfor

--- a/src/AbstractTypes/AbstractVectors.fypp
+++ b/src/AbstractTypes/AbstractVectors.fypp
@@ -981,7 +981,7 @@ contains
 
         if (success) then
             write(msg, '(A,I0,A)') 'All vector axioms verified (', ntrials_, ' trials).'
-            call log_message(msg, this_module, this_procedure)
+            call log_information(msg, this_module, this_procedure)
         else
             write(msg, '(A,I0,A)') 'Vector axiom check FAILED at trial ', i, ', test: '//trim(failed_test)
             call log_message(msg, this_module, this_procedure)

--- a/src/LightKrylov.f90
+++ b/src/LightKrylov.f90
@@ -103,6 +103,7 @@ module LightKrylov
     public :: dense_linop_cdp
     public :: abstract_hermitian_linop_cdp
     public :: adjoint
+    public :: verify_linop_axioms
 
     ! AbstractSystems exports.
     public :: abstract_system_rsp

--- a/src/LightKrylov.fypp
+++ b/src/LightKrylov.fypp
@@ -79,6 +79,7 @@ module LightKrylov
     #:endif
     #:endfor
     public :: adjoint
+    public :: verify_linop_axioms
 
     ! AbstractSystems exports.
     #:for kind, type in RC_KINDS_TYPES

--- a/test/TestLinops.f90
+++ b/test/TestLinops.f90
@@ -36,9 +36,10 @@ contains
 
         testsuite = [ &
                     new_unittest("Matrix-vector product", test_matvec_rsp), &
-                    new_unittest("Tranpose Matrix-vector product", test_rmatvec_rsp),  &
-                    new_unittest("Adjoint Matrix-vector product", test_adjoint_matvec_rsp),  &
-                    new_unittest("Tranpose Adjoint Matrix-vector product", test_adjoint_rmatvec_rsp) &
+                    new_unittest("Tranpose Matrix-vector product", test_rmatvec_rsp), &
+                    new_unittest("Adjoint Matrix-vector product", test_adjoint_matvec_rsp), &
+                    new_unittest("Tranpose Adjoint Matrix-vector product", test_adjoint_rmatvec_rsp), &
+                    new_unittest("Linear operator axioms", test_linop_axioms_rsp) &
                     ]
         return
     end subroutine collect_linop_rsp_testsuite
@@ -153,14 +154,31 @@ contains
        return
     end subroutine test_adjoint_rmatvec_rsp
 
+    subroutine test_linop_axioms_rsp(error)
+        type(error_type), allocatable, intent(out) :: error
+        type(dense_linop_rsp) :: A
+        type(dense_vector_rsp) :: x
+        real(sp) :: x_(n)
+        logical :: success
+        ! Initialize matrix.
+        A = dense_linop_rsp() ; allocate(A%data(n, n))
+        call random_number(A%data)
+        ! Initialize mold vector.
+        x_ = 0.0_sp ; x = dense_vector(x_)
+        success = verify_linop_axioms(A, x)
+        call check(error, success .eqv. .true.)
+        call check_test(error, 'test_linop_axioms_rsp', eq='Linear operator axioms')
+    end subroutine test_linop_axioms_rsp
+
     subroutine collect_linop_rdp_testsuite(testsuite)
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
                     new_unittest("Matrix-vector product", test_matvec_rdp), &
-                    new_unittest("Tranpose Matrix-vector product", test_rmatvec_rdp),  &
-                    new_unittest("Adjoint Matrix-vector product", test_adjoint_matvec_rdp),  &
-                    new_unittest("Tranpose Adjoint Matrix-vector product", test_adjoint_rmatvec_rdp) &
+                    new_unittest("Tranpose Matrix-vector product", test_rmatvec_rdp), &
+                    new_unittest("Adjoint Matrix-vector product", test_adjoint_matvec_rdp), &
+                    new_unittest("Tranpose Adjoint Matrix-vector product", test_adjoint_rmatvec_rdp), &
+                    new_unittest("Linear operator axioms", test_linop_axioms_rdp) &
                     ]
         return
     end subroutine collect_linop_rdp_testsuite
@@ -275,14 +293,31 @@ contains
        return
     end subroutine test_adjoint_rmatvec_rdp
 
+    subroutine test_linop_axioms_rdp(error)
+        type(error_type), allocatable, intent(out) :: error
+        type(dense_linop_rdp) :: A
+        type(dense_vector_rdp) :: x
+        real(dp) :: x_(n)
+        logical :: success
+        ! Initialize matrix.
+        A = dense_linop_rdp() ; allocate(A%data(n, n))
+        call random_number(A%data)
+        ! Initialize mold vector.
+        x_ = 0.0_dp ; x = dense_vector(x_)
+        success = verify_linop_axioms(A, x)
+        call check(error, success .eqv. .true.)
+        call check_test(error, 'test_linop_axioms_rdp', eq='Linear operator axioms')
+    end subroutine test_linop_axioms_rdp
+
     subroutine collect_linop_csp_testsuite(testsuite)
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
                     new_unittest("Matrix-vector product", test_matvec_csp), &
-                    new_unittest("Tranpose Matrix-vector product", test_rmatvec_csp),  &
-                    new_unittest("Adjoint Matrix-vector product", test_adjoint_matvec_csp),  &
-                    new_unittest("Tranpose Adjoint Matrix-vector product", test_adjoint_rmatvec_csp) &
+                    new_unittest("Tranpose Matrix-vector product", test_rmatvec_csp), &
+                    new_unittest("Adjoint Matrix-vector product", test_adjoint_matvec_csp), &
+                    new_unittest("Tranpose Adjoint Matrix-vector product", test_adjoint_rmatvec_csp), &
+                    new_unittest("Linear operator axioms", test_linop_axioms_csp) &
                     ]
         return
     end subroutine collect_linop_csp_testsuite
@@ -401,14 +436,32 @@ contains
        return
     end subroutine test_adjoint_rmatvec_csp
 
+    subroutine test_linop_axioms_csp(error)
+        type(error_type), allocatable, intent(out) :: error
+        type(dense_linop_csp) :: A
+        type(dense_vector_csp) :: x
+        complex(sp) :: x_(n)
+        real(sp) :: Adata(n, n, 2)
+        logical :: success
+        ! Initialize matrix.
+        A = dense_linop_csp() ; allocate(A%data(n, n))
+        call random_number(Adata) ; A%data%re = Adata(:, :, 1) ; A%data%im = Adata(:, :, 2)
+        ! Initialize mold vector.
+        x_ = 0.0_sp ; x = dense_vector(x_)
+        success = verify_linop_axioms(A, x)
+        call check(error, success .eqv. .true.)
+        call check_test(error, 'test_linop_axioms_csp', eq='Linear operator axioms')
+    end subroutine test_linop_axioms_csp
+
     subroutine collect_linop_cdp_testsuite(testsuite)
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
         testsuite = [ &
                     new_unittest("Matrix-vector product", test_matvec_cdp), &
-                    new_unittest("Tranpose Matrix-vector product", test_rmatvec_cdp),  &
-                    new_unittest("Adjoint Matrix-vector product", test_adjoint_matvec_cdp),  &
-                    new_unittest("Tranpose Adjoint Matrix-vector product", test_adjoint_rmatvec_cdp) &
+                    new_unittest("Tranpose Matrix-vector product", test_rmatvec_cdp), &
+                    new_unittest("Adjoint Matrix-vector product", test_adjoint_matvec_cdp), &
+                    new_unittest("Tranpose Adjoint Matrix-vector product", test_adjoint_rmatvec_cdp), &
+                    new_unittest("Linear operator axioms", test_linop_axioms_cdp) &
                     ]
         return
     end subroutine collect_linop_cdp_testsuite
@@ -526,6 +579,23 @@ contains
 
        return
     end subroutine test_adjoint_rmatvec_cdp
+
+    subroutine test_linop_axioms_cdp(error)
+        type(error_type), allocatable, intent(out) :: error
+        type(dense_linop_cdp) :: A
+        type(dense_vector_cdp) :: x
+        complex(dp) :: x_(n)
+        real(dp) :: Adata(n, n, 2)
+        logical :: success
+        ! Initialize matrix.
+        A = dense_linop_cdp() ; allocate(A%data(n, n))
+        call random_number(Adata) ; A%data%re = Adata(:, :, 1) ; A%data%im = Adata(:, :, 2)
+        ! Initialize mold vector.
+        x_ = 0.0_dp ; x = dense_vector(x_)
+        success = verify_linop_axioms(A, x)
+        call check(error, success .eqv. .true.)
+        call check_test(error, 'test_linop_axioms_cdp', eq='Linear operator axioms')
+    end subroutine test_linop_axioms_cdp
 
 end module TestLinops
 

--- a/test/TestLinops.fypp
+++ b/test/TestLinops.fypp
@@ -38,9 +38,10 @@ contains
 
         testsuite = [ &
                     new_unittest("Matrix-vector product", test_matvec_${type[0]}$${kind}$), &
-                    new_unittest("Tranpose Matrix-vector product", test_rmatvec_${type[0]}$${kind}$),  &
-                    new_unittest("Adjoint Matrix-vector product", test_adjoint_matvec_${type[0]}$${kind}$),  &
-                    new_unittest("Tranpose Adjoint Matrix-vector product", test_adjoint_rmatvec_${type[0]}$${kind}$) &
+                    new_unittest("Tranpose Matrix-vector product", test_rmatvec_${type[0]}$${kind}$), &
+                    new_unittest("Adjoint Matrix-vector product", test_adjoint_matvec_${type[0]}$${kind}$), &
+                    new_unittest("Tranpose Adjoint Matrix-vector product", test_adjoint_rmatvec_${type[0]}$${kind}$), &
+                    new_unittest("Linear operator axioms", test_linop_axioms_${type[0]}$${kind}$) &
                     ]
         return
     end subroutine collect_linop_${type[0]}$${kind}$_testsuite
@@ -182,6 +183,29 @@ contains
 
        return
     end subroutine test_adjoint_rmatvec_${type[0]}$${kind}$
+
+    subroutine test_linop_axioms_${type[0]}$${kind}$(error)
+        type(error_type), allocatable, intent(out) :: error
+        type(dense_linop_${type[0]}$${kind}$) :: A
+        type(dense_vector_${type[0]}$${kind}$) :: x
+        ${type}$ :: x_(n)
+        #:if type[0] == "c"
+        real(${kind}$) :: Adata(n, n, 2)
+        #:endif
+        logical :: success
+        ! Initialize matrix.
+        A = dense_linop_${type[0]}$${kind}$() ; allocate(A%data(n, n))
+        #:if type[0] == "c"
+        call random_number(Adata) ; A%data%re = Adata(:, :, 1) ; A%data%im = Adata(:, :, 2)
+        #:else
+        call random_number(A%data)
+        #:endif
+        ! Initialize mold vector.
+        x_ = 0.0_${kind}$ ; x = dense_vector(x_)
+        success = verify_linop_axioms(A, x)
+        call check(error, success .eqv. .true.)
+        call check_test(error, 'test_linop_axioms_${type[0]}$${kind}$', eq='Linear operator axioms')
+    end subroutine test_linop_axioms_${type[0]}$${kind}$
 
     #:endfor
 end module TestLinops

--- a/test/TestVectors.f90
+++ b/test/TestVectors.f90
@@ -45,18 +45,6 @@ contains
         return
     end subroutine collect_vector_rsp_testsuite
 
-    subroutine test_vector_axioms_rsp(error)
-        type(error_type), allocatable, intent(out) :: error
-        type(dense_vector_rsp) :: x
-        real(sp) :: x_(n)
-        logical :: success
-        ! Initialize vector.
-        x_ = 0.0_sp ; x = dense_vector(x_)
-        success = verify_vector_axioms(x)
-        call check(error, success .eqv. .true.)
-        call check_test(error, 'test_vector_axioms_rsp', eq='Vector space axioms')
-    end subroutine test_vector_axioms_rsp
-
     subroutine test_vector_rsp_norm(error)
         ! Error type to be returned.
         type(error_type), allocatable, intent(out) :: error
@@ -171,6 +159,18 @@ contains
         return
     end subroutine test_vector_rsp_scal
 
+    subroutine test_vector_axioms_rsp(error)
+        type(error_type), allocatable, intent(out) :: error
+        type(dense_vector_rsp) :: x
+        real(sp) :: x_(n)
+        logical :: success
+        ! Initialize vector.
+        x_ = 0.0_sp ; x = dense_vector(x_)
+        success = verify_vector_axioms(x)
+        call check(error, success .eqv. .true.)
+        call check_test(error, 'test_vector_axioms_rsp', eq='Vector space axioms')
+    end subroutine test_vector_axioms_rsp
+
     subroutine collect_vector_rdp_testsuite(testsuite)
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
@@ -184,18 +184,6 @@ contains
                     ]
         return
     end subroutine collect_vector_rdp_testsuite
-
-    subroutine test_vector_axioms_rdp(error)
-        type(error_type), allocatable, intent(out) :: error
-        type(dense_vector_rdp) :: x
-        real(dp) :: x_(n)
-        logical :: success
-        ! Initialize vector.
-        x_ = 0.0_dp ; x = dense_vector(x_)
-        success = verify_vector_axioms(x)
-        call check(error, success .eqv. .true.)
-        call check_test(error, 'test_vector_axioms_rdp', eq='Vector space axioms')
-    end subroutine test_vector_axioms_rdp
 
     subroutine test_vector_rdp_norm(error)
         ! Error type to be returned.
@@ -311,6 +299,18 @@ contains
         return
     end subroutine test_vector_rdp_scal
 
+    subroutine test_vector_axioms_rdp(error)
+        type(error_type), allocatable, intent(out) :: error
+        type(dense_vector_rdp) :: x
+        real(dp) :: x_(n)
+        logical :: success
+        ! Initialize vector.
+        x_ = 0.0_dp ; x = dense_vector(x_)
+        success = verify_vector_axioms(x)
+        call check(error, success .eqv. .true.)
+        call check_test(error, 'test_vector_axioms_rdp', eq='Vector space axioms')
+    end subroutine test_vector_axioms_rdp
+
     subroutine collect_vector_csp_testsuite(testsuite)
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
@@ -324,18 +324,6 @@ contains
                     ]
         return
     end subroutine collect_vector_csp_testsuite
-
-    subroutine test_vector_axioms_csp(error)
-        type(error_type), allocatable, intent(out) :: error
-        type(dense_vector_csp) :: x
-        complex(sp) :: x_(n)
-        logical :: success
-        ! Initialize vector.
-        x_ = 0.0_sp ; x = dense_vector(x_)
-        success = verify_vector_axioms(x)
-        call check(error, success .eqv. .true.)
-        call check_test(error, 'test_vector_axioms_csp', eq='Vector space axioms')
-    end subroutine test_vector_axioms_csp
 
     subroutine test_vector_csp_norm(error)
         ! Error type to be returned.
@@ -452,6 +440,18 @@ contains
         return
     end subroutine test_vector_csp_scal
 
+    subroutine test_vector_axioms_csp(error)
+        type(error_type), allocatable, intent(out) :: error
+        type(dense_vector_csp) :: x
+        complex(sp) :: x_(n)
+        logical :: success
+        ! Initialize vector.
+        x_ = 0.0_sp ; x = dense_vector(x_)
+        success = verify_vector_axioms(x)
+        call check(error, success .eqv. .true.)
+        call check_test(error, 'test_vector_axioms_csp', eq='Vector space axioms')
+    end subroutine test_vector_axioms_csp
+
     subroutine collect_vector_cdp_testsuite(testsuite)
         type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
@@ -465,18 +465,6 @@ contains
                     ]
         return
     end subroutine collect_vector_cdp_testsuite
-
-    subroutine test_vector_axioms_cdp(error)
-        type(error_type), allocatable, intent(out) :: error
-        type(dense_vector_cdp) :: x
-        complex(dp) :: x_(n)
-        logical :: success
-        ! Initialize vector.
-        x_ = 0.0_dp ; x = dense_vector(x_)
-        success = verify_vector_axioms(x)
-        call check(error, success .eqv. .true.)
-        call check_test(error, 'test_vector_axioms_cdp', eq='Vector space axioms')
-    end subroutine test_vector_axioms_cdp
 
     subroutine test_vector_cdp_norm(error)
         ! Error type to be returned.
@@ -592,6 +580,18 @@ contains
 
         return
     end subroutine test_vector_cdp_scal
+
+    subroutine test_vector_axioms_cdp(error)
+        type(error_type), allocatable, intent(out) :: error
+        type(dense_vector_cdp) :: x
+        complex(dp) :: x_(n)
+        logical :: success
+        ! Initialize vector.
+        x_ = 0.0_dp ; x = dense_vector(x_)
+        success = verify_vector_axioms(x)
+        call check(error, success .eqv. .true.)
+        call check_test(error, 'test_vector_axioms_cdp', eq='Vector space axioms')
+    end subroutine test_vector_axioms_cdp
 
 
 end module TestVectors

--- a/test/TestVectors.fypp
+++ b/test/TestVectors.fypp
@@ -47,18 +47,6 @@ contains
         return
     end subroutine collect_vector_${type[0]}$${kind}$_testsuite
 
-    subroutine test_vector_axioms_${type[0]}$${kind}$(error)
-        type(error_type), allocatable, intent(out) :: error
-        type(dense_vector_${type[0]}$${kind}$) :: x
-        ${type}$ :: x_(n)
-        logical :: success
-        ! Initialize vector.
-        x_ = 0.0_${kind}$ ; x = dense_vector(x_)
-        success = verify_vector_axioms(x)
-        call check(error, success .eqv. .true.)
-        call check_test(error, 'test_vector_axioms_${type[0]}$${kind}$', eq='Vector space axioms')
-    end subroutine test_vector_axioms_${type[0]}$${kind}$
-
     subroutine test_vector_${type[0]}$${kind}$_norm(error)
         ! Error type to be returned.
         type(error_type), allocatable, intent(out) :: error
@@ -177,6 +165,18 @@ contains
 
         return
     end subroutine test_vector_${type[0]}$${kind}$_scal
+
+    subroutine test_vector_axioms_${type[0]}$${kind}$(error)
+        type(error_type), allocatable, intent(out) :: error
+        type(dense_vector_${type[0]}$${kind}$) :: x
+        ${type}$ :: x_(n)
+        logical :: success
+        ! Initialize vector.
+        x_ = 0.0_${kind}$ ; x = dense_vector(x_)
+        success = verify_vector_axioms(x)
+        call check(error, success .eqv. .true.)
+        call check_test(error, 'test_vector_axioms_${type[0]}$${kind}$', eq='Vector space axioms')
+    end subroutine test_vector_axioms_${type[0]}$${kind}$
 
     #:endfor
 


### PR DESCRIPTION
Some improvements of the axiomatic tests.

- [x] Added book-keeping such that, if one of the axiom tests fails, the tester outputs the trial as well as the axiom that failed, together with the error_norm to facilitate debugging.
- [x] Added a similar axiomatic test framework for the linops testing additivitiy, homogeneity, origin preservation and, optionally, adjoint consistency. These wrappers can then also be applied by users to their own implementations for sanity checks. For the operator homogeneity that will be tested in parallel with a global operator, I choose to use a deterministic non-trivial scaling factor for the test to avoid awkward communication while retaining global consistency for operator test in a parallel environment.